### PR TITLE
fix: 修复提子场景下同步误判导致的棋盘重同步

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/ReadBoard.java
+++ b/src/main/java/featurecat/lizzie/analysis/ReadBoard.java
@@ -6,8 +6,10 @@ import featurecat.lizzie.gui.FloatBoard;
 import featurecat.lizzie.gui.LizzieFrame;
 import featurecat.lizzie.gui.SMessage;
 import featurecat.lizzie.rules.Board;
+import featurecat.lizzie.rules.BoardData;
 import featurecat.lizzie.rules.BoardHistoryNode;
 import featurecat.lizzie.rules.Stone;
+import featurecat.lizzie.rules.Zobrist;
 import featurecat.lizzie.util.Utils;
 import java.io.BufferedOutputStream;
 import java.io.File;
@@ -750,11 +752,11 @@ public class ReadBoard {
       return false;
     }
     SyncSnapshotClassifier.SingleMove move = recoveredMove.get();
-    Lizzie.board.moveToAnyPosition(syncStartNode);
-    Lizzie.board.placeForSync(move.x, move.y, move.color, false);
-    if (hasSnapshotDiff(Lizzie.board.getHistory().getMainEnd().getData().stones, snapshotCodes)) {
+    if (!canApplySingleMoveRecovery(syncStartNode, move, snapshotCodes)) {
       return false;
     }
+    Lizzie.board.moveToAnyPosition(syncStartNode);
+    Lizzie.board.placeForSync(move.x, move.y, move.color, false);
     if (Lizzie.config.alwaysSyncBoardStat || showInBoard) {
       Lizzie.frame.lastMove();
     }
@@ -762,6 +764,45 @@ public class ReadBoard {
     if (editMode) Lizzie.board.moveToAnyPosition(currentNode);
     Lizzie.frame.renderVarTree(0, 0, false, false);
     return true;
+  }
+
+  private boolean canApplySingleMoveRecovery(
+      BoardHistoryNode syncStartNode, SyncSnapshotClassifier.SingleMove move, int[] snapshotCodes) {
+    BoardData syncStartData = syncStartNode.getData();
+    Stone[] stones = syncStartData.stones.clone();
+    int moveIndex = Board.getIndex(move.x, move.y);
+    if (!stones[moveIndex].isEmpty()) {
+      return false;
+    }
+    Zobrist zobrist = syncStartData.zobrist.clone();
+    stones[moveIndex] = move.color;
+    zobrist.toggleStone(move.x, move.y, move.color);
+    int isSuicidal = 0;
+    if (!Lizzie.config.noCapture) {
+      Board.removeDeadChain(move.x + 1, move.y, move.color.opposite(), stones, zobrist);
+      Board.removeDeadChain(move.x, move.y + 1, move.color.opposite(), stones, zobrist);
+      Board.removeDeadChain(move.x - 1, move.y, move.color.opposite(), stones, zobrist);
+      Board.removeDeadChain(move.x, move.y - 1, move.color.opposite(), stones, zobrist);
+      isSuicidal = Board.removeDeadChain(move.x, move.y, move.color, stones, zobrist);
+    }
+    if (violatesRecoveryKo(syncStartNode, zobrist) || violatesRecoverySuicide(isSuicidal)) {
+      return false;
+    }
+    return !hasSnapshotDiff(stones, snapshotCodes);
+  }
+
+  private boolean violatesRecoveryKo(BoardHistoryNode syncStartNode, Zobrist zobrist) {
+    return syncStartNode
+        .previous()
+        .map(previousNode -> previousNode != null && zobrist.equals(previousNode.getData().zobrist))
+        .orElse(false);
+  }
+
+  private boolean violatesRecoverySuicide(int isSuicidal) {
+    if (Lizzie.leelaz.canSuicidal) {
+      return isSuicidal == 1;
+    }
+    return isSuicidal > 0;
   }
 
   private boolean hasSnapshotDiff(Stone[] stones, int[] snapshotCodes) {

--- a/src/main/java/featurecat/lizzie/analysis/ReadBoard.java
+++ b/src/main/java/featurecat/lizzie/analysis/ReadBoard.java
@@ -654,10 +654,8 @@ public class ReadBoard {
       }
     }
     if (!needReSync) {
-      restoreViewedNodeAfterSync(played, node, node2);
+      applySyncViewState(played, node, node2);
     }
-    if (editMode) Lizzie.board.moveToAnyPosition(node);
-    if (played) Lizzie.frame.renderVarTree(0, 0, false, false);
     if (needReSync && !isSecondTime) {
       int[] snapshotCodes = getSnapshotCodes();
       if (tryApplySingleMoveRecovery(node, node2, syncStartStones, snapshotCodes)) {
@@ -760,10 +758,15 @@ public class ReadBoard {
     if (Lizzie.config.alwaysSyncBoardStat || showInBoard) {
       Lizzie.frame.lastMove();
     }
-    restoreViewedNodeAfterSync(true, currentNode, syncStartNode);
-    if (editMode) Lizzie.board.moveToAnyPosition(currentNode);
-    Lizzie.frame.renderVarTree(0, 0, false, false);
+    applySyncViewState(true, currentNode, syncStartNode);
     return true;
+  }
+
+  private void applySyncViewState(
+      boolean played, BoardHistoryNode currentNode, BoardHistoryNode syncEndNode) {
+    restoreViewedNodeAfterSync(played, currentNode, syncEndNode);
+    if (editMode) Lizzie.board.moveToAnyPosition(currentNode);
+    if (played) Lizzie.frame.renderVarTree(0, 0, false, false);
   }
 
   private boolean canApplySingleMoveRecovery(

--- a/src/main/java/featurecat/lizzie/analysis/ReadBoard.java
+++ b/src/main/java/featurecat/lizzie/analysis/ReadBoard.java
@@ -18,6 +18,7 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -55,6 +56,7 @@ public class ReadBoard {
   private boolean hideFloadBoardBeforePlace = false;
   private boolean hideFromPlace = false;
   public boolean editMode = false;
+  private final SyncConflictTracker conflictTracker = new SyncConflictTracker();
 
   public ReadBoard(boolean usePipe, boolean isJavaReadBoard) throws Exception {
     this.usePipe = usePipe;
@@ -162,9 +164,7 @@ public class ReadBoard {
 
       if (usePipe) commands.add("0");
       else commands.add("1");
-      // if (Lizzie.config.isChinese)
       commands.add(Lizzie.resourceBundle.getString("ReadBoard.language"));
-      // else commands.add("1");
       if (usePipe) commands.add("-1");
       else commands.add(String.valueOf(port));
       ProcessBuilder processBuilder = new ProcessBuilder(commands);
@@ -173,7 +173,6 @@ public class ReadBoard {
       try {
         process = processBuilder.start();
       } catch (IOException e) {
-        // TODO Auto-generated catch block
         if (!usePipe) {
           Utils.showMsg(e.getLocalizedMessage());
           SMessage msg = new SMessage();
@@ -292,6 +291,7 @@ public class ReadBoard {
       tempcount = new ArrayList<Integer>();
     }
     if (line.startsWith("clear")) {
+      conflictTracker.clear();
       Lizzie.board.clear(false);
       Lizzie.frame.refresh();
     }
@@ -301,11 +301,14 @@ public class ReadBoard {
         int boardWidth = Integer.parseInt(params[1]);
         int boardHeight = Integer.parseInt(params[2]);
         if (boardWidth != Board.boardWidth || boardHeight != Board.boardHeight) {
+          conflictTracker.clear();
           Lizzie.board.reopen(boardWidth, boardHeight);
         } else {
+          conflictTracker.clear();
           Lizzie.board.clear(false);
         }
       } else {
+        conflictTracker.clear();
         Lizzie.board.clear(false);
       }
     }
@@ -329,6 +332,8 @@ public class ReadBoard {
     }
     if (line.startsWith("endsync")) {
       noMsg = true;
+      conflictTracker.clear();
+      tempcount = new ArrayList<Integer>();
       Lizzie.frame.syncBoard = false;
       if (Lizzie.frame.isAnaPlayingAgainstLeelaz) {
         Lizzie.frame.stopAiPlayingAndPolicy();
@@ -339,6 +344,8 @@ public class ReadBoard {
       }
     }
     if (line.startsWith("stopsync")) {
+      conflictTracker.clear();
+      tempcount = new ArrayList<Integer>();
       Lizzie.frame.syncBoard = false;
       if (Lizzie.frame.isAnaPlayingAgainstLeelaz) {
         Lizzie.frame.stopAiPlayingAndPolicy();
@@ -527,6 +534,7 @@ public class ReadBoard {
     //    }
     if (tempcount.size() > Board.boardWidth * Board.boardHeight) {
       tempcount = new ArrayList<Integer>();
+      conflictTracker.clear();
       return;
     }
     isSyncing = true;
@@ -539,6 +547,7 @@ public class ReadBoard {
     boolean isLastBlack = false;
     BoardHistoryNode node = Lizzie.board.getHistory().getCurrentHistoryNode();
     BoardHistoryNode node2 = Lizzie.board.getHistory().getMainEnd();
+    Stone[] syncStartStones = node2.getData().stones.clone();
     Stone[] stones = Lizzie.board.getHistory().getMainEnd().getData().stones;
 
     boolean needRefresh = false;
@@ -642,22 +651,33 @@ public class ReadBoard {
         }
       }
     }
-    if (!Lizzie.frame.bothSync && !needReSync) {
-      if (played
-          && !Lizzie.config.alwaysGotoLastOnLive
-          && !(showInBoard
-              && Lizzie.frame.floatBoard != null
-              && !Lizzie.frame.floatBoard.hideSuggestion)
-          && Lizzie.board.getHistory().getCurrentHistoryNode().previous().isPresent()
-          && node != node2) {
-        Lizzie.board.moveToAnyPosition(node);
-      }
+    if (!needReSync) {
+      restoreViewedNodeAfterSync(played, node, node2);
     }
     if (editMode) Lizzie.board.moveToAnyPosition(node);
     if (played) Lizzie.frame.renderVarTree(0, 0, false, false);
     if (needReSync && !isSecondTime) {
-      Lizzie.board.clear(false);
-      syncBoardStones(true);
+      int[] snapshotCodes = getSnapshotCodes();
+      if (tryApplySingleMoveRecovery(node, node2, syncStartStones, snapshotCodes)) {
+        played = true;
+        needReSync = false;
+        needRefresh = true;
+      } else {
+        if (!played && !needRefresh) {
+          SyncConflictTracker.Decision conflictDecision =
+              conflictTracker.evaluate(snapshotCodes, false);
+          if (conflictDecision == SyncConflictTracker.Decision.HOLD) {
+            isSyncing = false;
+            return;
+          }
+        }
+        conflictTracker.clear();
+        Lizzie.board.clear(false);
+        syncBoardStones(true);
+      }
+    }
+    if (!needReSync) {
+      conflictTracker.clear();
     }
     if (played || needRefresh) {
       Lizzie.frame.refresh();
@@ -694,6 +714,67 @@ public class ReadBoard {
     //	    }
   }
 
+  private int[] getSnapshotCodes() {
+    int[] codes = new int[tempcount.size()];
+    for (int index = 0; index < tempcount.size(); index++) {
+      codes[index] = tempcount.get(index);
+    }
+    return codes;
+  }
+
+  private void restoreViewedNodeAfterSync(
+      boolean played, BoardHistoryNode currentNode, BoardHistoryNode syncEndNode) {
+    if (Lizzie.frame.bothSync
+        || !played
+        || Lizzie.config.alwaysGotoLastOnLive
+        || (showInBoard
+            && Lizzie.frame.floatBoard != null
+            && !Lizzie.frame.floatBoard.hideSuggestion)
+        || !Lizzie.board.getHistory().getCurrentHistoryNode().previous().isPresent()
+        || currentNode == syncEndNode) {
+      return;
+    }
+    Lizzie.board.moveToAnyPosition(currentNode);
+  }
+
+  private boolean tryApplySingleMoveRecovery(
+      BoardHistoryNode currentNode,
+      BoardHistoryNode syncStartNode,
+      Stone[] syncStartStones,
+      int[] snapshotCodes) {
+    SyncSnapshotClassifier classifier =
+        new SyncSnapshotClassifier(Board.boardWidth, Board.boardHeight);
+    Optional<SyncSnapshotClassifier.SingleMove> recoveredMove =
+        classifier.findSingleMoveCapture(syncStartStones, snapshotCodes);
+    if (!recoveredMove.isPresent()) {
+      return false;
+    }
+    SyncSnapshotClassifier.SingleMove move = recoveredMove.get();
+    Lizzie.board.moveToAnyPosition(syncStartNode);
+    Lizzie.board.placeForSync(move.x, move.y, move.color, false);
+    if (hasSnapshotDiff(Lizzie.board.getHistory().getMainEnd().getData().stones, snapshotCodes)) {
+      return false;
+    }
+    if (Lizzie.config.alwaysSyncBoardStat || showInBoard) {
+      Lizzie.frame.lastMove();
+    }
+    restoreViewedNodeAfterSync(true, currentNode, syncStartNode);
+    if (editMode) Lizzie.board.moveToAnyPosition(currentNode);
+    Lizzie.frame.renderVarTree(0, 0, false, false);
+    return true;
+  }
+
+  private boolean hasSnapshotDiff(Stone[] stones, int[] snapshotCodes) {
+    for (int index = 0; index < snapshotCodes.length; index++) {
+      int y = index / Board.boardWidth;
+      int x = index % Board.boardWidth;
+      if (isStoneDiff(snapshotCodes[index], stones, x, y)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   private boolean isStoneDiff(int m, Stone[] stones, int x, int y) {
     // TODO Auto-generated method stub
     Stone stone = stones[Board.getIndex(x, y)];
@@ -720,6 +801,8 @@ public class ReadBoard {
 
   public void shutdown() {
     noMsg = true;
+    conflictTracker.clear();
+    tempcount = new ArrayList<Integer>();
     Lizzie.frame.syncBoard = false;
     Lizzie.frame.bothSync = false;
     this.sendCommand("quit");

--- a/src/main/java/featurecat/lizzie/analysis/ReadBoard.java
+++ b/src/main/java/featurecat/lizzie/analysis/ReadBoard.java
@@ -664,8 +664,7 @@ public class ReadBoard {
         needRefresh = true;
       } else {
         if (!played && !needRefresh) {
-          SyncConflictTracker.Decision conflictDecision =
-              conflictTracker.evaluate(snapshotCodes, false);
+          SyncConflictTracker.Decision conflictDecision = conflictTracker.evaluate(snapshotCodes);
           if (conflictDecision == SyncConflictTracker.Decision.HOLD) {
             isSyncing = false;
             return;

--- a/src/main/java/featurecat/lizzie/analysis/SyncConflictTracker.java
+++ b/src/main/java/featurecat/lizzie/analysis/SyncConflictTracker.java
@@ -1,0 +1,33 @@
+package featurecat.lizzie.analysis;
+
+import java.util.Arrays;
+
+final class SyncConflictTracker {
+  enum Decision {
+    APPLY,
+    HOLD,
+    REBUILD
+  }
+
+  private int[] pendingSnapshot = new int[0];
+  private boolean pendingConflict = false;
+
+  Decision evaluate(int[] snapshot, boolean canApplyIncrementally) {
+    if (canApplyIncrementally) {
+      clear();
+      return Decision.APPLY;
+    }
+    if (!pendingConflict || !Arrays.equals(pendingSnapshot, snapshot)) {
+      pendingSnapshot = Arrays.copyOf(snapshot, snapshot.length);
+      pendingConflict = true;
+      return Decision.HOLD;
+    }
+    clear();
+    return Decision.REBUILD;
+  }
+
+  void clear() {
+    pendingSnapshot = new int[0];
+    pendingConflict = false;
+  }
+}

--- a/src/main/java/featurecat/lizzie/analysis/SyncConflictTracker.java
+++ b/src/main/java/featurecat/lizzie/analysis/SyncConflictTracker.java
@@ -4,7 +4,6 @@ import java.util.Arrays;
 
 final class SyncConflictTracker {
   enum Decision {
-    APPLY,
     HOLD,
     REBUILD
   }
@@ -12,11 +11,7 @@ final class SyncConflictTracker {
   private int[] pendingSnapshot = new int[0];
   private boolean pendingConflict = false;
 
-  Decision evaluate(int[] snapshot, boolean canApplyIncrementally) {
-    if (canApplyIncrementally) {
-      clear();
-      return Decision.APPLY;
-    }
+  Decision evaluate(int[] snapshot) {
     if (!pendingConflict || !Arrays.equals(pendingSnapshot, snapshot)) {
       pendingSnapshot = Arrays.copyOf(snapshot, snapshot.length);
       pendingConflict = true;

--- a/src/main/java/featurecat/lizzie/analysis/SyncSnapshotClassifier.java
+++ b/src/main/java/featurecat/lizzie/analysis/SyncSnapshotClassifier.java
@@ -1,0 +1,220 @@
+package featurecat.lizzie.analysis;
+
+import featurecat.lizzie.rules.Stone;
+import java.util.Optional;
+
+final class SyncSnapshotClassifier {
+  private static final int[][] NEIGHBORS = new int[][] {{1, 0}, {0, 1}, {-1, 0}, {0, -1}};
+
+  private final int boardWidth;
+  private final int boardHeight;
+  private final int boardArea;
+
+  SyncSnapshotClassifier(int boardWidth, int boardHeight) {
+    this.boardWidth = boardWidth;
+    this.boardHeight = boardHeight;
+    this.boardArea = boardWidth * boardHeight;
+  }
+
+  Optional<SingleMove> findSingleMoveCapture(Stone[] currentStones, int[] snapshot) {
+    if (currentStones.length != boardArea || snapshot.length != boardArea) {
+      return Optional.empty();
+    }
+    Delta delta = analyzeDelta(currentStones, snapshot);
+    if (!delta.isSingleMove()) {
+      return Optional.empty();
+    }
+    SingleMove move = new SingleMove(delta.moveX, delta.moveY, delta.moveColor);
+    Stone[] simulated = simulateMove(currentStones, move);
+    if (simulated == null || !matchesSnapshot(simulated, snapshot)) {
+      return Optional.empty();
+    }
+    return Optional.of(move);
+  }
+
+  private Delta analyzeDelta(Stone[] currentStones, int[] snapshot) {
+    Delta delta = new Delta();
+    for (int snapshotIndex = 0; snapshotIndex < boardArea; snapshotIndex++) {
+      int x = snapshotIndex % boardWidth;
+      int y = snapshotIndex / boardWidth;
+      int currentValue = normalize(currentStones[stoneIndex(x, y)]);
+      int snapshotValue = normalize(snapshot[snapshotIndex]);
+      if (currentValue == snapshotValue) {
+        continue;
+      }
+      if (currentValue == 0 && snapshotValue > 0) {
+        delta.recordAddition(x, y, snapshotValue == 1 ? Stone.BLACK : Stone.WHITE);
+        continue;
+      }
+      if (snapshotValue == 0 && currentValue > 0) {
+        delta.recordRemoval(currentValue == 1 ? Stone.BLACK : Stone.WHITE);
+        continue;
+      }
+      delta.invalidate();
+      return delta;
+    }
+    return delta;
+  }
+
+  private Stone[] simulateMove(Stone[] currentStones, SingleMove move) {
+    int moveIndex = stoneIndex(move.x, move.y);
+    if (!currentStones[moveIndex].isEmpty()) {
+      return null;
+    }
+    Stone[] simulated = currentStones.clone();
+    simulated[moveIndex] = move.color;
+    for (int[] neighbor : NEIGHBORS) {
+      captureDeadNeighbor(
+          simulated, move.x + neighbor[0], move.y + neighbor[1], move.color.opposite());
+    }
+    if (!hasLiberty(simulated, move.x, move.y, move.color, new boolean[boardArea])) {
+      return null;
+    }
+    return simulated;
+  }
+
+  private void captureDeadNeighbor(Stone[] stones, int x, int y, Stone color) {
+    if (!isOnBoard(x, y) || !sameColor(stones[stoneIndex(x, y)], color)) {
+      return;
+    }
+    if (hasLiberty(stones, x, y, color, new boolean[boardArea])) {
+      return;
+    }
+    removeGroup(stones, x, y, color, new boolean[boardArea]);
+  }
+
+  private boolean hasLiberty(Stone[] stones, int x, int y, Stone color, boolean[] visited) {
+    int index = stoneIndex(x, y);
+    if (visited[index]) {
+      return false;
+    }
+    visited[index] = true;
+    for (int[] neighbor : NEIGHBORS) {
+      int nextX = x + neighbor[0];
+      int nextY = y + neighbor[1];
+      if (!isOnBoard(nextX, nextY)) {
+        continue;
+      }
+      Stone nextStone = stones[stoneIndex(nextX, nextY)];
+      if (nextStone.isEmpty()) {
+        return true;
+      }
+      if (sameColor(nextStone, color) && hasLiberty(stones, nextX, nextY, color, visited)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private void removeGroup(Stone[] stones, int x, int y, Stone color, boolean[] visited) {
+    int index = stoneIndex(x, y);
+    if (visited[index] || !sameColor(stones[index], color)) {
+      return;
+    }
+    visited[index] = true;
+    stones[index] = Stone.EMPTY;
+    for (int[] neighbor : NEIGHBORS) {
+      int nextX = x + neighbor[0];
+      int nextY = y + neighbor[1];
+      if (isOnBoard(nextX, nextY)) {
+        removeGroup(stones, nextX, nextY, color, visited);
+      }
+    }
+  }
+
+  private boolean matchesSnapshot(Stone[] stones, int[] snapshot) {
+    for (int snapshotIndex = 0; snapshotIndex < boardArea; snapshotIndex++) {
+      int x = snapshotIndex % boardWidth;
+      int y = snapshotIndex / boardWidth;
+      if (normalize(stones[stoneIndex(x, y)]) != normalize(snapshot[snapshotIndex])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private boolean sameColor(Stone left, Stone right) {
+    return normalize(left) == normalize(right);
+  }
+
+  private int stoneIndex(int x, int y) {
+    return x * boardHeight + y;
+  }
+
+  private boolean isOnBoard(int x, int y) {
+    return x >= 0 && x < boardWidth && y >= 0 && y < boardHeight;
+  }
+
+  private int normalize(Stone stone) {
+    if (stone == Stone.BLACK || stone == Stone.BLACK_RECURSED) {
+      return 1;
+    }
+    if (stone == Stone.WHITE || stone == Stone.WHITE_RECURSED) {
+      return 2;
+    }
+    return 0;
+  }
+
+  private int normalize(int value) {
+    if (value == 1 || value == 3) {
+      return 1;
+    }
+    if (value == 2 || value == 4) {
+      return 2;
+    }
+    return 0;
+  }
+
+  static final class SingleMove {
+    final int x;
+    final int y;
+    final Stone color;
+
+    SingleMove(int x, int y, Stone color) {
+      this.x = x;
+      this.y = y;
+      this.color = color;
+    }
+  }
+
+  private static final class Delta {
+    private int moveX = -1;
+    private int moveY = -1;
+    private Stone moveColor = Stone.EMPTY;
+    private int removedBlack = 0;
+    private int removedWhite = 0;
+    private boolean valid = true;
+
+    private void recordAddition(int x, int y, Stone color) {
+      if (moveColor != Stone.EMPTY) {
+        valid = false;
+        return;
+      }
+      moveX = x;
+      moveY = y;
+      moveColor = color;
+    }
+
+    private void recordRemoval(Stone color) {
+      if (color == Stone.BLACK) {
+        removedBlack++;
+      } else if (color == Stone.WHITE) {
+        removedWhite++;
+      }
+    }
+
+    private void invalidate() {
+      valid = false;
+    }
+
+    private boolean isSingleMove() {
+      if (!valid || moveColor == Stone.EMPTY) {
+        return false;
+      }
+      if (moveColor == Stone.BLACK) {
+        return removedBlack == 0;
+      }
+      return removedWhite == 0;
+    }
+  }
+}


### PR DESCRIPTION
## 摘要

修复 ReadBoard 同步流程在提子场景下偶发触发整盘刷新/重同步的问题。

本次修改将“合法单步落子 + 提子”从异常冲突中区分出来：

- 保留现有增量同步主流程不变
- 在后置差异校验命中后，优先尝试将快照解释为一次合法落子及其提子结果
- 仅当该解释失败时，才继续走现有的冲突处理与重同步流程

## 变更内容

- 在 `ReadBoard` 中保存本轮同步开始时的盘面状态
- 在 `needReSync` 分支中增加后置单步恢复逻辑，避免合法提子直接触发 `clear(false) + syncBoardStones(true)`
- 重构 `SyncSnapshotClassifier`，使其作为后置“单步落子/提子解释器”使用
- 支持识别“1 手新增落子 + 若干对方棋子被提走”的合法快照
- 保持 `SyncConflictTracker` 仅用于无法解释的后置冲突，不重新引入前置总裁判

## 影响

- 修复提子时被误判为整盘冲突而触发刷新/重同步的问题
- 不改变已有的正常增量同步路径
- 真正无法解释的异常快照仍会进入原有冲突处理流程