### PR TITLE
fix(gui): 优化界面运行时性能并补齐缓存失效与测试覆盖

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/AnalysisFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/AnalysisFrame.java
@@ -26,10 +26,9 @@ import java.awt.event.WindowEvent;
 import java.awt.event.WindowStateListener;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.ResourceBundle;
 import javax.imageio.ImageIO;
 import javax.swing.*;
@@ -37,13 +36,16 @@ import javax.swing.table.AbstractTableModel;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.JTableHeader;
 import javax.swing.table.TableCellRenderer;
-import javax.swing.table.TableModel;
 import org.json.JSONArray;
 
 public class AnalysisFrame extends JFrame {
+  private static final int STANDARD_COLUMN_COUNT = 7;
+  private static final int EXTENDED_COLUMN_COUNT = 9;
+  private static final int TABLE_REFRESH_INTERVAL_MS = 100;
+
   private final ResourceBundle resourceBundle = Lizzie.resourceBundle;
   ;
-  TableModel dataModel;
+  AnalysisTableModel dataModel;
   JScrollPane scrollpane;
   JPanel topPanel;
   JPanel bottomPanel;
@@ -95,15 +97,7 @@ public class AnalysisFrame extends JFrame {
     winrateFont = new Font(Lizzie.config.uiFontName, Font.BOLD, Math.max(Config.frameFontSize, 14));
     headFont = new Font(Lizzie.config.uiFontName, Font.PLAIN, Math.max(Config.frameFontSize, 13));
 
-    table.getTableHeader().setFont(headFont);
-    table.getTableHeader().setReorderingAllowed(false);
-    table.setFont(winrateFont);
-    table.setRowHeight(Config.menuHeight);
-    TableCellRenderer tcr = new ColorTableCellRenderer();
-    table.setDefaultRenderer(Object.class, tcr);
-
-    ((DefaultTableCellRenderer) table.getTableHeader().getDefaultRenderer())
-        .setHorizontalAlignment(JLabel.CENTER);
+    configureTableAppearance();
     scrollpane = new JScrollPane(table);
     topPanel = new JPanel(new BorderLayout());
     topPanel.add(scrollpane);
@@ -233,35 +227,19 @@ public class AnalysisFrame extends JFrame {
 
     timer =
         new Timer(
-            100,
+            TABLE_REFRESH_INTERVAL_MS,
             new ActionListener() {
               public void actionPerformed(ActionEvent evt) {
-                dataModel.getColumnCount();
-                repaint();
-                // table.validate();
-                // table.updateUI();
+                refreshAnalysisView();
               }
             });
     timer.start();
 
-    table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-    table.setFillsViewportHeight(true);
-    table.getColumnModel().getColumn(0).setPreferredWidth(35);
-    table.getColumnModel().getColumn(1).setPreferredWidth(20);
-    table.getColumnModel().getColumn(2).setPreferredWidth(40);
-    table.getColumnModel().getColumn(3).setPreferredWidth(70);
-    table.getColumnModel().getColumn(4).setPreferredWidth(35);
-    table.getColumnModel().getColumn(5).setPreferredWidth(50);
-    table.getColumnModel().getColumn(6).setPreferredWidth(35);
-    if (table.getColumnCount() == 9) {
-      table.getColumnModel().getColumn(7).setPreferredWidth(70);
-      table.getColumnModel().getColumn(8).setPreferredWidth(35);
-    }
     boolean persisted = Lizzie.config.persistedUi != null;
 
     if (persisted) {
 
-      if (table.getColumnCount() == 9) {
+      if (table.getColumnCount() == EXTENDED_COLUMN_COUNT) {
         if (Lizzie.config.persistedUi.optJSONArray("suggestions-list-position-9") != null
             && Lizzie.config.persistedUi.optJSONArray("suggestions-list-position-9").length()
                 == 13) {
@@ -480,6 +458,45 @@ public class AnalysisFrame extends JFrame {
     if (this.isAlwaysOnTop())
       setTitle(Lizzie.resourceBundle.getString("Lizzie.alwaysOnTopTitle") + oriTitle);
     else setTitle(oriTitle);
+  }
+
+  private void refreshAnalysisView() {
+    AnalysisTableModel.RefreshResult result = dataModel.refreshSnapshot();
+    if (!result.isChanged()) {
+      return;
+    }
+    if (result.isStructureChanged()) {
+      configureTableAppearance();
+    }
+    repaint();
+  }
+
+  private void configureTableAppearance() {
+    table.getTableHeader().setFont(headFont);
+    table.getTableHeader().setReorderingAllowed(false);
+    table.setFont(winrateFont);
+    table.setRowHeight(Config.menuHeight);
+    TableCellRenderer cellRenderer = new ColorTableCellRenderer();
+    table.setDefaultRenderer(Object.class, cellRenderer);
+    ((DefaultTableCellRenderer) table.getTableHeader().getDefaultRenderer())
+        .setHorizontalAlignment(JLabel.CENTER);
+    table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+    table.setFillsViewportHeight(true);
+    configureTableColumnWidths();
+  }
+
+  private void configureTableColumnWidths() {
+    table.getColumnModel().getColumn(0).setPreferredWidth(35);
+    table.getColumnModel().getColumn(1).setPreferredWidth(20);
+    table.getColumnModel().getColumn(2).setPreferredWidth(40);
+    table.getColumnModel().getColumn(3).setPreferredWidth(70);
+    table.getColumnModel().getColumn(4).setPreferredWidth(35);
+    table.getColumnModel().getColumn(5).setPreferredWidth(50);
+    table.getColumnModel().getColumn(6).setPreferredWidth(35);
+    if (table.getColumnCount() == EXTENDED_COLUMN_COUNT) {
+      table.getColumnModel().getColumn(7).setPreferredWidth(70);
+      table.getColumnModel().getColumn(8).setPreferredWidth(35);
+    }
   }
 
   private void paintBottomPanel(Graphics g0, int width, int height) {
@@ -754,314 +771,540 @@ public class AnalysisFrame extends JFrame {
     }
   }
 
-  public AbstractTableModel getTableModel() {
-    return new AbstractTableModel() {
-      ArrayList<MoveData> data2 = new ArrayList<MoveData>();
-      List<MoveData> bestMoves;
+  public AnalysisTableModel getTableModel() {
+    return new AnalysisTableModel();
+  }
 
-      public int getColumnCount() {
-        Leelaz leelaz = null;
-        if (index == 1) {
-          leelaz = Lizzie.leelaz;
-        } else if (index == 2) {
-          leelaz = Lizzie.leelaz2;
-        }
-        if (leelaz != null && (leelaz.isKatago || leelaz.isSai)) return 9;
-        else if (index == 1
-            ? Lizzie.board.isContainsKataData()
-            : Lizzie.board.isContainsKataData2()) return 9;
-        else return 7;
+  class AnalysisTableModel extends AbstractTableModel {
+    private TableSnapshot snapshot = buildSnapshot();
+
+    RefreshResult refreshSnapshot() {
+      TableSnapshot nextSnapshot = buildSnapshot();
+      if (snapshot.equals(nextSnapshot)) {
+        return RefreshResult.UNCHANGED;
       }
+      boolean structureChanged = snapshot.getColumnCount() != nextSnapshot.getColumnCount();
+      snapshot = nextSnapshot;
+      if (structureChanged) {
+        fireTableStructureChanged();
+        return RefreshResult.STRUCTURE_CHANGED;
+      }
+      fireTableDataChanged();
+      return RefreshResult.DATA_CHANGED;
+    }
 
-      public int getRowCount() {
-        data2 = new ArrayList<MoveData>();
-        if (index == 1) {
-          if (EngineManager.isEngineGame && Lizzie.config.showPreviousBestmovesInEngineGame) {
-            if (Lizzie.board.getHistory().getCurrentHistoryNode().previous().isPresent())
-              if ((bestMoves = Lizzie.leelaz.getBestMoves()).isEmpty())
-                bestMoves =
-                    Lizzie.board
-                        .getHistory()
-                        .getCurrentHistoryNode()
-                        .previous()
-                        .get()
-                        .getData()
-                        .bestMoves;
+    @Override
+    public int getColumnCount() {
+      return snapshot.getColumnCount();
+    }
 
-          } else bestMoves = Lizzie.board.getHistory().getCurrentHistoryNode().getData().bestMoves;
-          if (bestMoves != null)
-            for (int i = 0; i < bestMoves.size(); i++) {
-              // if (!Lizzie.board.getData().bestMoves.get(i).coordinate.contains("ass"))
-              data2.add(bestMoves.get(i));
-            }
-        } else if (index == 2) {
-          if (Lizzie.board.getData().bestMoves2 != null) {
-            for (int i = 0; i < Lizzie.board.getData().bestMoves2.size(); i++) {
-              // if (!Lizzie.board.getData().bestMoves2.get(i).coordinate.contains("ass"))
-              data2.add(Lizzie.board.getData().bestMoves2.get(i));
-            }
+    @Override
+    public int getRowCount() {
+      return snapshot.getRows().size();
+    }
+
+    @Override
+    public String getColumnName(int column) {
+      if (column == 0) return resourceBundle.getString("AnalysisFrame.column1");
+      if (column == 1) return resourceBundle.getString("AnalysisFrame.column2");
+      if (column == 2) return resourceBundle.getString("AnalysisFrame.column3");
+      if (column == 3) return resourceBundle.getString("AnalysisFrame.column4");
+      if (column == 4) return resourceBundle.getString("AnalysisFrame.column5");
+      if (column == 5) return resourceBundle.getString("AnalysisFrame.column6");
+      if (column == 6) return resourceBundle.getString("AnalysisFrame.column7");
+      if (column == 7) return resourceBundle.getString("AnalysisFrame.column8");
+      if (column == 8) return resourceBundle.getString("AnalysisFrame.column9");
+      return "";
+    }
+
+    @Override
+    public Object getValueAt(int row, int col) {
+      RowSnapshot data = snapshot.getRows().get(row);
+      switch (col) {
+        case 0:
+          if (data.order == -100) {
+            return "\n" + resourceBundle.getString("AnalysisFrame.actual") + "\n";
           }
-        }
-        if (Lizzie.config.anaFrameShowNext
-            && Lizzie.board.getHistory().getCurrentHistoryNode().next().isPresent()) {
-          BoardHistoryNode next = Lizzie.board.getHistory().getCurrentHistoryNode().next().get();
-          if (next.getData().lastMove.isPresent()) {
-            int[] coords = next.getData().lastMove.get();
-            boolean hasData = false;
-            for (MoveData move : data2) {
-              if (Board.convertNameToCoordinates(move.coordinate)[0] == coords[0]
-                  && Board.convertNameToCoordinates(move.coordinate)[1] == coords[1]) {
-                if (move.order == 0) {
-                  move.winrate = data2.get(0).winrate;
-                  move.isNextMove = true;
-                  move.bestWinrate = data2.get(0).winrate;
-                  move.bestScoreMean = data2.get(0).scoreMean;
-                } else {
-                  if (index == 1) {
-                    if (data2.size() > 0
-                        && !hasData
-                        && !next.getData().bestMoves.isEmpty()
-                        && next.getData().getPlayouts() > move.playouts) {
-                      MoveData curMove = new MoveData();
-                      curMove.playouts = next.getData().getPlayouts();
-                      curMove.coordinate = Board.convertCoordinatesToName(coords[0], coords[1]);
-                      curMove.winrate = 100.0 - next.getData().winrate;
-                      curMove.policy = move.policy;
-                      curMove.scoreMean = -next.getData().scoreMean;
-                      curMove.scoreStdev = next.getData().scoreStdev;
-                      curMove.order = move.order;
-                      curMove.isNextMove = true;
-                      curMove.lcb = -10000;
-                      curMove.bestWinrate = data2.get(0).winrate;
-                      curMove.bestScoreMean = data2.get(0).scoreMean;
-                      data2.add(0, curMove);
-                      hasData = true;
-                      break;
-                    }
-                  } else {
-                    if (data2.size() > 0
-                        && !hasData
-                        && !next.getData().bestMoves2.isEmpty()
-                        && next.getData().getPlayouts2() > move.playouts) {
-                      MoveData curMove = new MoveData();
-                      curMove.playouts = next.getData().getPlayouts2();
-                      curMove.coordinate = Board.convertCoordinatesToName(coords[0], coords[1]);
-                      curMove.winrate = 100.0 - next.getData().winrate2;
-                      curMove.policy = move.policy;
-                      curMove.scoreMean = -next.getData().scoreMean2;
-                      curMove.scoreStdev = next.getData().scoreStdev2;
-                      curMove.order = move.order;
-                      curMove.isNextMove = true;
-                      curMove.lcb = -10000;
-                      curMove.bestWinrate = data2.get(0).winrate;
-                      curMove.bestScoreMean = data2.get(0).scoreMean;
-                      data2.add(0, curMove);
-                      hasData = true;
-                      break;
-                    }
-                  }
-                  MoveData curMove = new MoveData();
-                  curMove.order = move.order;
-                  curMove.playouts = move.playouts;
-                  curMove.coordinate = move.coordinate;
-                  curMove.winrate = move.winrate;
-                  curMove.policy = move.policy;
-                  curMove.scoreMean = move.scoreMean;
-                  curMove.scoreStdev = move.scoreStdev;
-                  curMove.order = move.order;
-                  curMove.isNextMove = true;
-                  curMove.lcb = move.lcb;
-                  curMove.bestWinrate = data2.get(0).winrate;
-                  curMove.bestScoreMean = data2.get(0).scoreMean;
-                  data2.add(0, curMove);
-                }
-                hasData = true;
-                break;
-              }
-            }
-            if (index == 1) {
-              if (data2.size() > 0 && !hasData && !next.getData().bestMoves.isEmpty()) {
-                MoveData curMove = new MoveData();
-                curMove.playouts = 0;
-                curMove.coordinate = Board.convertCoordinatesToName(coords[0], coords[1]);
-                curMove.winrate = 100.0 - next.getData().winrate;
-                curMove.policy = -10000;
-                curMove.scoreMean = -next.getData().scoreMean;
-                curMove.scoreStdev = next.getData().scoreStdev;
-                curMove.order = -100;
-                curMove.isNextMove = true;
-                curMove.lcb = -10000;
-                curMove.bestWinrate = data2.get(0).winrate;
-                curMove.bestScoreMean = data2.get(0).scoreMean;
-                data2.add(0, curMove);
-              }
-            } else {
-              if (data2.size() > 0 && !hasData && !next.getData().bestMoves2.isEmpty()) {
-                MoveData curMove = new MoveData();
-                curMove.playouts = 0;
-                curMove.coordinate = Board.convertCoordinatesToName(coords[0], coords[1]);
-                curMove.winrate = 100.0 - next.getData().winrate2;
-                curMove.policy = -10000;
-                curMove.scoreMean = -next.getData().scoreMean2;
-                curMove.scoreStdev = next.getData().scoreStdev2;
-                curMove.order = -100;
-                curMove.isNextMove = true;
-                curMove.lcb = -10000;
-                curMove.bestWinrate = data2.get(0).winrate;
-                curMove.bestScoreMean = data2.get(0).scoreMean;
-                data2.add(0, curMove);
-              }
-            }
+          if (data.isNextMove) {
+            return data.order + 1 + "(" + resourceBundle.getString("AnalysisFrame.actual") + ")";
           }
-        }
-
-        if (Lizzie.frame.isInPlayMode()) return 0;
-
-        return data2.size();
+          return data.order + 1;
+        case 1:
+          return Board.maybeConvertNormalCoordsToOther(data.coordinate);
+        case 2:
+          if (data.isNextMove && data.lcb < -1000) return "--";
+          return String.format(Locale.ENGLISH, "%.1f", data.lcb);
+        case 3:
+          if (data.isNextMove && data.order != 0) {
+            double diff = data.winrate - data.bestWinrate;
+            return (diff > 0 ? "↑" : "↓")
+                + String.format(Locale.ENGLISH, "%.1f", diff)
+                + "("
+                + String.format(Locale.ENGLISH, "%.1f", data.winrate)
+                + ")";
+          }
+          return String.format(Locale.ENGLISH, "%.1f", data.winrate);
+        case 4:
+          if (data.order == -100) return resourceBundle.getString("AnalysisFrame.exclude");
+          return Utils.getPlayoutsString(data.playouts);
+        case 5:
+          return String.format(
+              Locale.ENGLISH, "%.1f", (double) data.playouts * 100 / snapshot.getTotalPlayouts());
+        case 6:
+          if (data.isNextMove && data.policy < -1000) return "--";
+          return String.format(Locale.ENGLISH, "%.2f", data.policy);
+        case 7:
+          double score = snapshot.adjustScore(data.scoreMean);
+          if (data.isNextMove && data.order != 0) {
+            double diff = data.scoreMean - data.bestScoreMean;
+            return (diff > 0 ? "↑" : "↓")
+                + String.format(Locale.ENGLISH, "%.1f", diff)
+                + "("
+                + String.format(Locale.ENGLISH, "%.1f", score)
+                + ")";
+          }
+          return String.format(Locale.ENGLISH, "%.1f", score);
+        case 8:
+          return String.format(Locale.ENGLISH, "%.1f", data.scoreStdev);
+        default:
+          return "";
       }
+    }
 
-      public String getColumnName(int column) {
-        if (column == 0) return resourceBundle.getString("AnalysisFrame.column1"); // "序号";
-        if (column == 1) return resourceBundle.getString("AnalysisFrame.column2"); // "坐标";
-        if (column == 2) return resourceBundle.getString("AnalysisFrame.column3"); // "Lcb(%)";
-        if (column == 3) return resourceBundle.getString("AnalysisFrame.column4"); // "胜率(%)";
-        if (column == 4) return resourceBundle.getString("AnalysisFrame.column5"); // "计算量";
-        if (column == 5) return resourceBundle.getString("AnalysisFrame.column6"); // "占比(%)";
-        if (column == 6) return resourceBundle.getString("AnalysisFrame.column7"); // "策略网络(%)";
-        if (column == 7) return resourceBundle.getString("AnalysisFrame.column8"); // "目差";
-        if (column == 8) return resourceBundle.getString("AnalysisFrame.column9"); // "局面复杂度";
-        return "";
+    private TableSnapshot buildSnapshot() {
+      int columnCount = determineColumnCount();
+      ScoreDisplayState scoreState =
+          new ScoreDisplayState(
+              Lizzie.board.getHistory().isBlacksTurn(),
+              EngineManager.isEngineGame && EngineManager.engineGameInfo.isGenmove,
+              Lizzie.config.showKataGoScoreLeadWithKomi,
+              Lizzie.board.getData().getKomi());
+      if (Lizzie.frame.isInPlayMode()) {
+        return TableSnapshot.fromMoves(new ArrayList<MoveData>(), sortnum, columnCount, scoreState);
       }
+      return TableSnapshot.fromMoves(collectMoves(), sortnum, columnCount, scoreState);
+    }
 
-      public Object getValueAt(int row, int col) {
+    private int determineColumnCount() {
+      Leelaz leelaz = index == 1 ? Lizzie.leelaz : Lizzie.leelaz2;
+      if (leelaz != null && (leelaz.isKatago || leelaz.isSai)) {
+        return EXTENDED_COLUMN_COUNT;
+      }
+      boolean containsKataData =
+          index == 1 ? Lizzie.board.isContainsKataData() : Lizzie.board.isContainsKataData2();
+      return containsKataData ? EXTENDED_COLUMN_COUNT : STANDARD_COLUMN_COUNT;
+    }
 
-        // Collections.sort(data2) ;
-        Collections.sort(
-            data2,
-            new Comparator<MoveData>() {
+    private List<MoveData> collectMoves() {
+      List<MoveData> moves = copyMoves(resolveBestMoves());
+      addNextMoveIfNeeded(moves);
+      return moves;
+    }
 
-              @Override
-              public int compare(MoveData s1, MoveData s2) {
-                // 降序
-                //            	  if (sortnum == 0) {
-                //                      if (s1.order > s2.order) return 1;
-                //                      if (s1.order < s2.order) return -1;
-                //                    }
-                if (sortnum == 2) {
-                  if (s1.lcb < s2.lcb) return 1;
-                  if (s1.lcb > s2.lcb) return -1;
-                }
-                if (sortnum == 3) {
-                  if (s1.winrate < s2.winrate) return 1;
-                  if (s1.winrate > s2.winrate) return -1;
-                }
-                if (sortnum == 4) {
-                  if (s1.playouts < s2.playouts) return 1;
-                  if (s1.playouts > s2.playouts) return -1;
-                }
-                if (sortnum == 5) {
-                  if (s1.playouts < s2.playouts) return 1;
-                  if (s1.playouts > s2.playouts) return -1;
-                }
-                if (sortnum == 6) {
-                  if (s1.policy < s2.policy) return 1;
-                  if (s1.policy > s2.policy) return -1;
-                }
-                if (sortnum == 7) {
-                  if (s1.scoreMean < s2.scoreMean) return 1;
-                  if (s1.scoreMean > s2.scoreMean) return -1;
-                }
-                if (sortnum == 8) {
-                  if (s1.scoreStdev < s2.scoreStdev) return 1;
-                  if (s1.scoreStdev > s2.scoreStdev) return -1;
-                }
-                return 0;
-              }
-            });
+    private List<MoveData> resolveBestMoves() {
+      if (index == 1) {
+        return resolveMainEngineBestMoves();
+      }
+      return Lizzie.board.getData().bestMoves2;
+    }
 
-        // featurecat.lizzie.analysis.MoveDataSorter MoveDataSorter = new
-        // MoveDataSorter(data2);
-        // ArrayList sortedMoveData = MoveDataSorter.getSortedMoveDataByPolicy();
-        //   double maxlcb = 0;
-        int totalPlayouts = 0;
-        for (MoveData move : data2) {
-          totalPlayouts = totalPlayouts + move.playouts;
+    private List<MoveData> resolveMainEngineBestMoves() {
+      if (EngineManager.isEngineGame && Lizzie.config.showPreviousBestmovesInEngineGame) {
+        if (Lizzie.board.getHistory().getCurrentHistoryNode().previous().isPresent()) {
+          List<MoveData> currentBestMoves = Lizzie.leelaz.getBestMoves();
+          if (currentBestMoves.isEmpty()) {
+            return Lizzie.board
+                .getHistory()
+                .getCurrentHistoryNode()
+                .previous()
+                .get()
+                .getData()
+                .bestMoves;
+          }
+          return currentBestMoves;
         }
-        MoveData data = data2.get(row);
-        switch (col) {
-          case 0:
-            if (data.order == -100)
-              return "\n" + resourceBundle.getString("AnalysisFrame.actual") + "\n";
-            else if (data.isNextMove)
-              return data.order + 1 + "(" + resourceBundle.getString("AnalysisFrame.actual") + ")";
-            else return data.order + 1;
-          case 1:
-            //
-            // if(Lizzie.board.convertNameToCoordinates(data.coordinate)[0]==Lizzie.frame.suggestionclick[0]&&Lizzie.board.convertNameToCoordinates(data.coordinate)[1]==Lizzie.frame.suggestionclick[1])
-            // {return "*"+data.coordinate;}
-            // else
-            return Board.maybeConvertNormalCoordsToOther(data.coordinate);
-          case 2:
-            if (data.isNextMove && data.lcb < -1000) return "--";
-            return String.format(Locale.ENGLISH, "%.1f", data.lcb);
-          case 3:
-            if (data.isNextMove) {
-              if (data.order != 0) {
-                double diff = data.winrate - data.bestWinrate;
-                return (diff > 0 ? "↑" : "↓")
-                    + String.format(Locale.ENGLISH, "%.1f", diff)
-                    + "("
-                    + String.format(Locale.ENGLISH, "%.1f", data.winrate)
-                    + ")";
-              }
-            }
-            return String.format(Locale.ENGLISH, "%.1f", data.winrate);
-          case 4:
-            if (data.order == -100) return resourceBundle.getString("AnalysisFrame.exclude");
-            else return Utils.getPlayoutsString(data.playouts);
-          case 5:
-            return String.format(
-                Locale.ENGLISH, "%.1f", (double) data.playouts * 100 / totalPlayouts);
-          case 6:
-            if (data.isNextMove && data.policy < -1000) return "--";
-            return String.format(Locale.ENGLISH, "%.2f", data.policy);
-          case 7:
-            double score = data.scoreMean;
-            if (EngineManager.isEngineGame && EngineManager.engineGameInfo.isGenmove) {
-              if (!Lizzie.board.getHistory().isBlacksTurn()) {
-                if (Lizzie.config.showKataGoScoreLeadWithKomi) {
-                  score = score + Lizzie.board.getData().getKomi();
-                }
-              } else {
-                if (Lizzie.config.showKataGoScoreLeadWithKomi) {
-                  score = score - Lizzie.board.getData().getKomi();
-                }
-              }
-            } else {
-              if (Lizzie.board.getHistory().isBlacksTurn()) {
-                if (Lizzie.config.showKataGoScoreLeadWithKomi) {
-                  score = score + Lizzie.board.getData().getKomi();
-                }
-              } else {
-                if (Lizzie.config.showKataGoScoreLeadWithKomi) {
-                  score = score - Lizzie.board.getData().getKomi();
-                }
-              }
-            }
-            if (data.isNextMove && data.order != 0) {
-              double diff = data.scoreMean - data.bestScoreMean;
-              return (diff > 0 ? "↑" : "↓")
-                  + String.format(Locale.ENGLISH, "%.1f", diff)
-                  + "("
-                  + String.format(Locale.ENGLISH, "%.1f", score)
-                  + ")";
-            } else return String.format(Locale.ENGLISH, "%.1f", score);
-          case 8:
-            return String.format(Locale.ENGLISH, "%.1f", data.scoreStdev);
-          default:
-            return "";
+        return null;
+      }
+      return Lizzie.board.getHistory().getCurrentHistoryNode().getData().bestMoves;
+    }
+
+    private void addNextMoveIfNeeded(List<MoveData> moves) {
+      if (!Lizzie.config.anaFrameShowNext
+          || !Lizzie.board.getHistory().getCurrentHistoryNode().next().isPresent()
+          || moves.isEmpty()) {
+        return;
+      }
+      BoardHistoryNode next = Lizzie.board.getHistory().getCurrentHistoryNode().next().get();
+      if (!next.getData().lastMove.isPresent()) {
+        return;
+      }
+      int[] coords = next.getData().lastMove.get();
+      MoveData matchingMove = findMatchingMove(moves, coords);
+      if (matchingMove == null) {
+        prependMissingNextMove(moves, next, coords);
+        return;
+      }
+      if (matchingMove.order == 0) {
+        markTopMoveAsNext(matchingMove, moves.get(0));
+        return;
+      }
+      if (!prependUpgradedNextMove(moves, matchingMove, next, coords)) {
+        moves.add(0, createCopiedNextMove(matchingMove, moves.get(0)));
+      }
+    }
+
+    private MoveData findMatchingMove(List<MoveData> moves, int[] coords) {
+      for (MoveData move : moves) {
+        int[] moveCoords = Board.convertNameToCoordinates(move.coordinate);
+        if (moveCoords[0] == coords[0] && moveCoords[1] == coords[1]) {
+          return move;
         }
       }
-    };
+      return null;
+    }
+
+    private void markTopMoveAsNext(MoveData move, MoveData bestMove) {
+      move.winrate = bestMove.winrate;
+      move.isNextMove = true;
+      move.bestWinrate = bestMove.winrate;
+      move.bestScoreMean = bestMove.scoreMean;
+    }
+
+    private boolean prependUpgradedNextMove(
+        List<MoveData> moves, MoveData matchingMove, BoardHistoryNode next, int[] coords) {
+      MoveData bestMove = moves.get(0);
+      if (index == 1
+          && !next.getData().bestMoves.isEmpty()
+          && next.getData().getPlayouts() > matchingMove.playouts) {
+        moves.add(0, createUpdatedNextMove(next, coords, matchingMove, bestMove));
+        return true;
+      }
+      if (index == 2
+          && !next.getData().bestMoves2.isEmpty()
+          && next.getData().getPlayouts2() > matchingMove.playouts) {
+        moves.add(0, createUpdatedNextMove(next, coords, matchingMove, bestMove));
+        return true;
+      }
+      return false;
+    }
+
+    private void prependMissingNextMove(List<MoveData> moves, BoardHistoryNode next, int[] coords) {
+      if (index == 1 && !next.getData().bestMoves.isEmpty()) {
+        moves.add(0, createMissingNextMove(next, coords, moves.get(0)));
+      } else if (index == 2 && !next.getData().bestMoves2.isEmpty()) {
+        moves.add(0, createMissingNextMove(next, coords, moves.get(0)));
+      }
+    }
+
+    enum RefreshResult {
+      UNCHANGED(false, false),
+      DATA_CHANGED(true, false),
+      STRUCTURE_CHANGED(true, true);
+
+      private final boolean changed;
+      private final boolean structureChanged;
+
+      RefreshResult(boolean changed, boolean structureChanged) {
+        this.changed = changed;
+        this.structureChanged = structureChanged;
+      }
+
+      boolean isChanged() {
+        return changed;
+      }
+
+      boolean isStructureChanged() {
+        return structureChanged;
+      }
+    }
+  }
+
+  private static List<MoveData> copyMoves(List<MoveData> bestMoves) {
+    List<MoveData> copies = new ArrayList<MoveData>();
+    if (bestMoves == null) {
+      return copies;
+    }
+    for (MoveData move : bestMoves) {
+      copies.add(copyMove(move));
+    }
+    return copies;
+  }
+
+  private static MoveData copyMove(MoveData move) {
+    MoveData copy = new MoveData();
+    copy.coordinate = move.coordinate;
+    copy.playouts = move.playouts;
+    copy.winrate = move.winrate;
+    copy.lcb = move.lcb;
+    copy.policy = move.policy;
+    copy.scoreMean = move.scoreMean;
+    copy.scoreStdev = move.scoreStdev;
+    copy.order = move.order;
+    copy.isNextMove = move.isNextMove;
+    copy.bestWinrate = move.bestWinrate;
+    copy.bestScoreMean = move.bestScoreMean;
+    return copy;
+  }
+
+  private MoveData createCopiedNextMove(MoveData move, MoveData bestMove) {
+    MoveData nextMove = copyMove(move);
+    nextMove.isNextMove = true;
+    nextMove.bestWinrate = bestMove.winrate;
+    nextMove.bestScoreMean = bestMove.scoreMean;
+    return nextMove;
+  }
+
+  private MoveData createUpdatedNextMove(
+      BoardHistoryNode next, int[] coords, MoveData move, MoveData bestMove) {
+    MoveData nextMove = new MoveData();
+    nextMove.playouts = index == 1 ? next.getData().getPlayouts() : next.getData().getPlayouts2();
+    nextMove.coordinate = Board.convertCoordinatesToName(coords[0], coords[1]);
+    nextMove.winrate =
+        index == 1 ? 100.0 - next.getData().winrate : 100.0 - next.getData().winrate2;
+    nextMove.policy = move.policy;
+    nextMove.scoreMean = index == 1 ? -next.getData().scoreMean : -next.getData().scoreMean2;
+    nextMove.scoreStdev = index == 1 ? next.getData().scoreStdev : next.getData().scoreStdev2;
+    nextMove.order = move.order;
+    nextMove.isNextMove = true;
+    nextMove.lcb = -10000;
+    nextMove.bestWinrate = bestMove.winrate;
+    nextMove.bestScoreMean = bestMove.scoreMean;
+    return nextMove;
+  }
+
+  private MoveData createMissingNextMove(BoardHistoryNode next, int[] coords, MoveData bestMove) {
+    MoveData nextMove = new MoveData();
+    nextMove.playouts = 0;
+    nextMove.coordinate = Board.convertCoordinatesToName(coords[0], coords[1]);
+    nextMove.winrate =
+        index == 1 ? 100.0 - next.getData().winrate : 100.0 - next.getData().winrate2;
+    nextMove.policy = -10000;
+    nextMove.scoreMean = index == 1 ? -next.getData().scoreMean : -next.getData().scoreMean2;
+    nextMove.scoreStdev = index == 1 ? next.getData().scoreStdev : next.getData().scoreStdev2;
+    nextMove.order = -100;
+    nextMove.isNextMove = true;
+    nextMove.lcb = -10000;
+    nextMove.bestWinrate = bestMove.winrate;
+    nextMove.bestScoreMean = bestMove.scoreMean;
+    return nextMove;
+  }
+
+  static final class TableSnapshot {
+    private final int columnCount;
+    private final List<RowSnapshot> rows;
+    private final int totalPlayouts;
+    private final ScoreDisplayState scoreState;
+
+    static TableSnapshot fromMoves(
+        List<MoveData> moves, int sortColumn, int columnCount, ScoreDisplayState scoreState) {
+      List<RowSnapshot> rows = new ArrayList<RowSnapshot>();
+      for (MoveData move : moves) {
+        rows.add(RowSnapshot.fromMove(move));
+      }
+      if (sortColumn != -1) {
+        rows.sort((left, right) -> compareRows(left, right, sortColumn));
+      }
+      return new TableSnapshot(columnCount, rows, calculateTotalPlayouts(rows), scoreState);
+    }
+
+    static TableSnapshot fromMoves(
+        List<MoveData> moves,
+        int sortColumn,
+        int columnCount,
+        boolean blacksTurn,
+        boolean engineGameGenmove,
+        boolean showScoreLeadWithKomi,
+        double komi) {
+      return fromMoves(
+          moves,
+          sortColumn,
+          columnCount,
+          new ScoreDisplayState(blacksTurn, engineGameGenmove, showScoreLeadWithKomi, komi));
+    }
+
+    private TableSnapshot(
+        int columnCount, List<RowSnapshot> rows, int totalPlayouts, ScoreDisplayState scoreState) {
+      this.columnCount = columnCount;
+      this.rows = List.copyOf(rows);
+      this.totalPlayouts = totalPlayouts;
+      this.scoreState = scoreState;
+    }
+
+    int getColumnCount() {
+      return columnCount;
+    }
+
+    List<RowSnapshot> getRows() {
+      return rows;
+    }
+
+    int getTotalPlayouts() {
+      return totalPlayouts;
+    }
+
+    double adjustScore(double scoreMean) {
+      return scoreState.adjustScore(scoreMean);
+    }
+
+    private static int calculateTotalPlayouts(List<RowSnapshot> rows) {
+      int total = 0;
+      for (RowSnapshot row : rows) {
+        total += row.playouts;
+      }
+      return total;
+    }
+
+    private static int compareRows(RowSnapshot left, RowSnapshot right, int sortColumn) {
+      if (sortColumn == 2) return Double.compare(right.lcb, left.lcb);
+      if (sortColumn == 3) return Double.compare(right.winrate, left.winrate);
+      if (sortColumn == 4 || sortColumn == 5) return Integer.compare(right.playouts, left.playouts);
+      if (sortColumn == 6) return Double.compare(right.policy, left.policy);
+      if (sortColumn == 7) return Double.compare(right.scoreMean, left.scoreMean);
+      if (sortColumn == 8) return Double.compare(right.scoreStdev, left.scoreStdev);
+      return 0;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (this == other) return true;
+      if (!(other instanceof TableSnapshot)) return false;
+      TableSnapshot that = (TableSnapshot) other;
+      return columnCount == that.columnCount
+          && totalPlayouts == that.totalPlayouts
+          && rows.equals(that.rows)
+          && scoreState.equals(that.scoreState);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(columnCount, rows, totalPlayouts, scoreState);
+    }
+  }
+
+  static final class RowSnapshot {
+    final String coordinate;
+    final int playouts;
+    final double winrate;
+    final double lcb;
+    final double policy;
+    final double scoreMean;
+    final double scoreStdev;
+    final int order;
+    final boolean isNextMove;
+    final double bestWinrate;
+    final double bestScoreMean;
+
+    private RowSnapshot(
+        String coordinate,
+        int playouts,
+        double winrate,
+        double lcb,
+        double policy,
+        double scoreMean,
+        double scoreStdev,
+        int order,
+        boolean isNextMove,
+        double bestWinrate,
+        double bestScoreMean) {
+      this.coordinate = coordinate;
+      this.playouts = playouts;
+      this.winrate = winrate;
+      this.lcb = lcb;
+      this.policy = policy;
+      this.scoreMean = scoreMean;
+      this.scoreStdev = scoreStdev;
+      this.order = order;
+      this.isNextMove = isNextMove;
+      this.bestWinrate = bestWinrate;
+      this.bestScoreMean = bestScoreMean;
+    }
+
+    static RowSnapshot fromMove(MoveData move) {
+      return new RowSnapshot(
+          move.coordinate,
+          move.playouts,
+          move.winrate,
+          move.lcb,
+          move.policy,
+          move.scoreMean,
+          move.scoreStdev,
+          move.order,
+          move.isNextMove,
+          move.bestWinrate,
+          move.bestScoreMean);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (this == other) return true;
+      if (!(other instanceof RowSnapshot)) return false;
+      RowSnapshot that = (RowSnapshot) other;
+      return playouts == that.playouts
+          && Double.compare(winrate, that.winrate) == 0
+          && Double.compare(lcb, that.lcb) == 0
+          && Double.compare(policy, that.policy) == 0
+          && Double.compare(scoreMean, that.scoreMean) == 0
+          && Double.compare(scoreStdev, that.scoreStdev) == 0
+          && order == that.order
+          && isNextMove == that.isNextMove
+          && Double.compare(bestWinrate, that.bestWinrate) == 0
+          && Double.compare(bestScoreMean, that.bestScoreMean) == 0
+          && Objects.equals(coordinate, that.coordinate);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(
+          coordinate,
+          playouts,
+          winrate,
+          lcb,
+          policy,
+          scoreMean,
+          scoreStdev,
+          order,
+          isNextMove,
+          bestWinrate,
+          bestScoreMean);
+    }
+  }
+
+  static final class ScoreDisplayState {
+    private final boolean blacksTurn;
+    private final boolean engineGameGenmove;
+    private final boolean showScoreLeadWithKomi;
+    private final double komi;
+
+    private ScoreDisplayState(
+        boolean blacksTurn, boolean engineGameGenmove, boolean showScoreLeadWithKomi, double komi) {
+      this.blacksTurn = blacksTurn;
+      this.engineGameGenmove = engineGameGenmove;
+      this.showScoreLeadWithKomi = showScoreLeadWithKomi;
+      this.komi = komi;
+    }
+
+    double adjustScore(double scoreMean) {
+      if (!showScoreLeadWithKomi) {
+        return scoreMean;
+      }
+      boolean addKomi = engineGameGenmove ? !blacksTurn : blacksTurn;
+      return addKomi ? scoreMean + komi : scoreMean - komi;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (this == other) return true;
+      if (!(other instanceof ScoreDisplayState)) return false;
+      ScoreDisplayState that = (ScoreDisplayState) other;
+      return blacksTurn == that.blacksTurn
+          && engineGameGenmove == that.engineGameGenmove
+          && showScoreLeadWithKomi == that.showScoreLeadWithKomi
+          && Double.compare(komi, that.komi) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(blacksTurn, engineGameGenmove, showScoreLeadWithKomi, komi);
+    }
   }
 }

--- a/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
+++ b/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
@@ -105,6 +105,9 @@ public class BoardRenderer {
 
   private BufferedImage branchStonesImage = emptyImage;
   private BufferedImage branchStonesShadowImage;
+  private static final long INVALID_OVERLAY_KEY = Long.MIN_VALUE;
+  private long cachedBranchOverlayKey = INVALID_OVERLAY_KEY;
+  private long cachedEstimateOverlayKey = INVALID_OVERLAY_KEY;
 
   // private boolean lastInScoreMode = false;
 
@@ -297,18 +300,10 @@ public class BoardRenderer {
         && Lizzie.config.showKataGoEstimate
         && Lizzie.config.showKataGoEstimateOnMainbord) {
       if (estimateArray != null) {
-        if (Lizzie.config.showKataGoEstimateBySize) {
-          drawKataEstimateBySize(estimateArray, shouldShowPreviousBestMoves());
-        } else {
-          drawKataEstimateByTransparent(estimateArray, shouldShowPreviousBestMoves(), false);
-        }
+        refreshEstimateOverlay(estimateArray, shouldShowPreviousBestMoves(), false);
         hasDraw = true;
       } else if (preEstimateArray != null) {
-        if (Lizzie.config.showKataGoEstimateBySize) {
-          drawKataEstimateBySize(preEstimateArray, true);
-        } else {
-          drawKataEstimateByTransparent(preEstimateArray, true, false);
-        }
+        refreshEstimateOverlay(preEstimateArray, true, false);
         hasDraw = true;
       }
     }
@@ -1084,6 +1079,7 @@ public class BoardRenderer {
   }
 
   public void removeKataEstimateImage() {
+    cachedEstimateOverlayKey = INVALID_OVERLAY_KEY;
     kataEstimateImage = new BufferedImage(boardWidth, boardHeight, TYPE_INT_ARGB);
   }
 
@@ -1608,17 +1604,21 @@ public class BoardRenderer {
     branchOpt = Optional.of(branch);
     variationOpt = Optional.of(variation);
     isShowingBranch = true;
-    if (!changedSize) {
-      if (Lizzie.config.noRefreshOnMouseMove) {
-        if (variation == cachedVariation
-            && displayedBranchLength == cachedDisplayedBranchLengthFroBranch) return;
-      } else {
-        if (compareVariationListEquals(variation, cachedVariation)
-            && displayedBranchLength == cachedDisplayedBranchLengthFroBranch) return;
-      }
-    } else changedSize = false;
+    int[] hoverCoordinate =
+        isIndependBoard
+            ? Lizzie.frame.independentMainBoard.mouseOverCoordinate
+            : Lizzie.frame.mouseOverCoordinate;
+    long branchOverlayKey =
+        buildBranchOverlayKey(
+            variation,
+            branch.data.zobrist.hashCode(),
+            hoverCoordinate[0],
+            hoverCoordinate[1]);
     cachedVariation = variation;
     cachedDisplayedBranchLengthFroBranch = displayedBranchLength;
+    if (!changedSize && branchOverlayKey == cachedBranchOverlayKey) return;
+    changedSize = false;
+    cachedBranchOverlayKey = branchOverlayKey;
     BufferedImage tempBranchStonesImage = new BufferedImage(boardWidth, boardHeight, TYPE_INT_ARGB);
     BufferedImage tempBranchStonesShadowImage =
         new BufferedImage(boardWidth, boardHeight, TYPE_INT_ARGB);
@@ -4443,6 +4443,86 @@ public class BoardRenderer {
 
   public void clearBranch() {
     isShowingBranch = false;
+    cachedBranchOverlayKey = INVALID_OVERLAY_KEY;
+  }
+
+  private void refreshEstimateOverlay(
+      ArrayList<Double> currentEstimate, boolean reverse, boolean fromRawNet) {
+    long estimateOverlayKey = buildEstimateOverlayKey(currentEstimate, reverse, fromRawNet);
+    if (estimateOverlayKey == cachedEstimateOverlayKey) return;
+    cachedEstimateOverlayKey = estimateOverlayKey;
+    if (Lizzie.config.showKataGoEstimateBySize) {
+      drawKataEstimateBySize(currentEstimate, reverse);
+      return;
+    }
+    drawKataEstimateByTransparent(currentEstimate, reverse, fromRawNet);
+  }
+
+  private long buildBranchOverlayKey(
+      List<String> currentVariation, int branchZobristHash, int hoverX, int hoverY) {
+    long key = INVALID_OVERLAY_KEY + 1;
+    key = mixOverlayKey(key, boardWidth);
+    key = mixOverlayKey(key, boardHeight);
+    key = mixOverlayKey(key, squareWidth);
+    key = mixOverlayKey(key, squareHeight);
+    key = mixOverlayKey(key, stoneRadius);
+    key = mixOverlayKey(key, displayedBranchLength);
+    key = mixOverlayKey(key, maxBranchMoves(false));
+    key = mixOverlayKey(key, boardIndex);
+    key = mixOverlayKey(key, Lizzie.board.getData().zobrist.hashCode());
+    key = mixOverlayKey(key, branchZobristHash);
+    key = mixOverlayKey(key, shouldShowPreviousBestMoves() ? 1 : 0);
+    key = mixOverlayKey(key, Lizzie.config.usePureStone ? 1 : 0);
+    key = mixOverlayKey(key, Lizzie.config.removeDeadChainInVariation ? 1 : 0);
+    key = mixOverlayKey(key, Lizzie.config.showStoneShadow ? 1 : 0);
+    key = mixOverlayKey(key, Lizzie.config.shadowSize);
+    key = mixOverlayKey(key, Lizzie.config.showHoverGlow ? 1 : 0);
+    key = mixOverlayKey(key, hoverX);
+    key = mixOverlayKey(key, hoverY);
+    return mixOverlayKey(key, listSignature(currentVariation));
+  }
+
+  private long buildEstimateOverlayKey(
+      List<Double> currentEstimate, boolean reverse, boolean fromRawNet) {
+    long key = INVALID_OVERLAY_KEY + 1;
+    key = mixOverlayKey(key, boardWidth);
+    key = mixOverlayKey(key, boardHeight);
+    key = mixOverlayKey(key, squareWidth);
+    key = mixOverlayKey(key, squareHeight);
+    key = mixOverlayKey(key, stoneRadius);
+    key = mixOverlayKey(key, boardIndex);
+    key = mixOverlayKey(key, Lizzie.board.getData().zobrist.hashCode());
+    key = mixOverlayKey(key, Lizzie.board.getHistory().isBlacksTurn() ? 1 : 0);
+    key = mixOverlayKey(key, reverse ? 1 : 0);
+    key = mixOverlayKey(key, fromRawNet ? 1 : 0);
+    key = mixOverlayKey(key, Lizzie.config.showKataGoEstimateBySize ? 1 : 0);
+    key = mixOverlayKey(key, shouldShowCountBlockBig() ? 1 : 0);
+    key = mixOverlayKey(key, Lizzie.config.showKataGoEstimateSmall ? 1 : 0);
+    key = mixOverlayKey(key, Lizzie.config.showKataGoEstimateNotOnlive ? 1 : 0);
+    key = mixOverlayKey(key, Lizzie.config.showPureEstimateNotOnlive ? 1 : 0);
+    return mixOverlayKey(key, doubleListSignature(currentEstimate));
+  }
+
+  private long listSignature(List<String> values) {
+    long key = 1L;
+    if (values == null) return key;
+    for (String value : values) {
+      key = mixOverlayKey(key, value == null ? 0 : value.hashCode());
+    }
+    return key;
+  }
+
+  private long doubleListSignature(List<Double> values) {
+    long key = 1L;
+    if (values == null) return key;
+    for (Double value : values) {
+      key = mixOverlayKey(key, value == null ? 0L : Double.doubleToLongBits(value));
+    }
+    return key;
+  }
+
+  private long mixOverlayKey(long seed, long value) {
+    return seed * 31L + value;
   }
 
   public boolean isInside(int x1, int y1) {

--- a/src/main/java/featurecat/lizzie/gui/BottomToolbar.java
+++ b/src/main/java/featurecat/lizzie/gui/BottomToolbar.java
@@ -8,6 +8,7 @@ import featurecat.lizzie.rules.BoardHistoryNode;
 import featurecat.lizzie.rules.Movelist;
 import featurecat.lizzie.rules.SGFParser;
 import featurecat.lizzie.theme.MorandiPalette;
+import featurecat.lizzie.util.ResourceImageCache;
 import featurecat.lizzie.util.Utils;
 import java.awt.Color;
 import java.awt.Dimension;
@@ -31,7 +32,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Random;
 import java.util.ResourceBundle;
-import javax.imageio.ImageIO;
 import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
@@ -337,20 +337,13 @@ public class BottomToolbar extends JPanel {
     autoPlay =
         new JFontButton(Lizzie.resourceBundle.getString("BottomToolbar.autoPlay")); // ("自动播放");
 
-    iconUp = new ImageIcon();
-
     try {
-      iconUp.setImage(ImageIO.read(getClass().getResourceAsStream("/assets/up.png")));
+      iconUp = ResourceImageCache.getIcon("/assets/up.png");
+      iconDown = ResourceImageCache.getIcon("/assets/down.png");
     } catch (IOException e) {
-      // TODO Auto-generated catch block
       e.printStackTrace();
-    }
-    iconDown = new ImageIcon();
-    try {
-      iconDown.setImage(ImageIO.read(getClass().getResourceAsStream("/assets/down.png")));
-    } catch (IOException e) {
-      // TODO Auto-generated catch block
-      e.printStackTrace();
+      iconUp = new ImageIcon();
+      iconDown = new ImageIcon();
     }
     detail = new JButton("");
     detail.setBackground(MorandiPalette.TOOLBAR_BUTTON_BG);

--- a/src/main/java/featurecat/lizzie/gui/BrowserFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/BrowserFrame.java
@@ -2,6 +2,7 @@ package featurecat.lizzie.gui;
 
 import featurecat.lizzie.Lizzie;
 import featurecat.lizzie.util.MultiOutputStream;
+import featurecat.lizzie.util.ResourceImageCache;
 import featurecat.lizzie.util.Utils;
 import java.awt.*;
 import java.awt.event.*;
@@ -13,7 +14,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
-import javax.imageio.ImageIO;
 import javax.swing.*;
 import me.friwi.jcefmaven.*;
 import org.cef.CefApp;
@@ -54,7 +54,7 @@ public class BrowserFrame extends JFrame {
     this.isYike = yike;
     this.setTitle(title);
     try {
-      setIconImage(ImageIO.read(getClass().getResourceAsStream("/assets/logo.png")));
+      setIconImage(ResourceImageCache.getImage("/assets/logo.png"));
     } catch (IOException e) {
       e.printStackTrace();
     }
@@ -238,14 +238,12 @@ public class BrowserFrame extends JFrame {
     toolbar.setFloatable(false);
     // toolbarPanel.setLayout(new BorderLayout(0, 0));
 
-    ImageIcon iconLeft = new ImageIcon();
+    JButton back = new JButton();
     try {
-      iconLeft.setImage(ImageIO.read(getClass().getResourceAsStream("/assets/left.png")));
+      back.setIcon(ResourceImageCache.getIcon("/assets/left.png"));
     } catch (IOException e) {
-      // TODO Auto-generated catch block
       e.printStackTrace();
     }
-    JButton back = new JButton(iconLeft);
     back.addActionListener(
         new ActionListener() {
           public void actionPerformed(ActionEvent e) {
@@ -253,6 +251,7 @@ public class BrowserFrame extends JFrame {
           }
         });
     back.setFocusable(false);
+    toolbar.add(back);
 
     JButton load = new JButton(Lizzie.resourceBundle.getString("LizzieFrame.onLoad")); // ("加载");
     load.setFocusable(false);

--- a/src/main/java/featurecat/lizzie/gui/CaptureTsumeGoFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/CaptureTsumeGoFrame.java
@@ -1,6 +1,7 @@
 package featurecat.lizzie.gui;
 
 import featurecat.lizzie.Lizzie;
+import featurecat.lizzie.util.ResourceImageCache;
 import java.awt.BorderLayout;
 import java.awt.GridLayout;
 import java.awt.event.ActionEvent;
@@ -8,8 +9,6 @@ import java.awt.event.ActionListener;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
 import java.io.IOException;
-import javax.imageio.ImageIO;
-import javax.swing.ImageIcon;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -79,12 +78,9 @@ public class CaptureTsumeGoFrame extends JFrame {
     buttonPane.add(lblTip, BorderLayout.CENTER);
 
     try {
-      capture1.setIcon(
-          new ImageIcon(ImageIO.read(getClass().getResourceAsStream("/assets/capture1.png"))));
-      capture2.setIcon(
-          new ImageIcon(ImageIO.read(getClass().getResourceAsStream("/assets/capture2.png"))));
-      capture3.setIcon(
-          new ImageIcon(ImageIO.read(getClass().getResourceAsStream("/assets/capture3.png"))));
+      capture1.setIcon(ResourceImageCache.getIcon("/assets/capture1.png"));
+      capture2.setIcon(ResourceImageCache.getIcon("/assets/capture2.png"));
+      capture3.setIcon(ResourceImageCache.getIcon("/assets/capture3.png"));
     } catch (IOException e1) {
       // TODO Auto-generated catch block
       e1.printStackTrace();
@@ -103,7 +99,7 @@ public class CaptureTsumeGoFrame extends JFrame {
     pack();
     setAlwaysOnTop(true);
     try {
-      setIconImage(ImageIO.read(getClass().getResourceAsStream("/assets/logo.png")));
+      setIconImage(ResourceImageCache.getImage("/assets/logo.png"));
     } catch (IOException e) {
       e.printStackTrace();
     }

--- a/src/main/java/featurecat/lizzie/gui/ConfigDialog2.java
+++ b/src/main/java/featurecat/lizzie/gui/ConfigDialog2.java
@@ -24,7 +24,6 @@ import java.awt.FontFormatException;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.GraphicsEnvironment;
-import java.awt.Image;
 import java.awt.Insets;
 import java.awt.Paint;
 import java.awt.RadialGradientPaint;
@@ -55,6 +54,7 @@ import java.util.ResourceBundle;
 import java.util.Vector;
 import java.util.stream.Collectors;
 import javax.imageio.ImageIO;
+import javax.swing.AbstractButton;
 import javax.swing.AbstractCellEditor;
 import javax.swing.BorderFactory;
 import javax.swing.ButtonGroup;
@@ -89,6 +89,8 @@ import javax.swing.SwingUtilities;
 import javax.swing.border.Border;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
 import javax.swing.event.HyperlinkEvent;
 import javax.swing.event.HyperlinkListener;
 import javax.swing.filechooser.FileNameExtensionFilter;
@@ -117,7 +119,23 @@ public class ConfigDialog2 extends JDialog {
   private PanelWithToolTips aboutTab;
   private JButton okButton;
 
+  private static final int PREVIEW_TIMER_DELAY_MS = 100;
+  private static final int PREVIEW_MARGIN = 30;
+  private static final int PREVIEW_GRID_ORIGIN = 60;
+  private static final int PREVIEW_SQUARE_LENGTH = 30;
+  private static final int PREVIEW_BLACK_STONE_X = 2;
+  private static final int PREVIEW_BLACK_STONE_Y = 3;
+  private static final int PREVIEW_WHITE_STONE_X = 1;
+  private static final int PREVIEW_WHITE_STONE_Y = 2;
+  private static final float PREVIEW_TOP_SHADOW_RATIO = 0.2f;
+  private static final float PREVIEW_FAR_SHADOW_RATIO = 0.17f;
+
   javax.swing.Timer timer;
+  private boolean themeTabInitialized;
+  private boolean suppressPreviewRefresh;
+  private boolean previewDirty = true;
+  private String previewCacheKey = "";
+  private BufferedImage previewCacheImage;
   // UI Tab
   private JFormattedTextField txtMaxAnalyzeTime;
   private JFormattedTextField txtMaxGameThinkingTime;
@@ -1965,13 +1983,125 @@ public class ConfigDialog2 extends JDialog {
     addWindowListener(
         new WindowAdapter() {
           public void windowClosing(WindowEvent e) {
-            if (timer != null) timer.stop();
+            stopPreviewTimer();
           }
         });
   }
 
+  @Override
+  public void setVisible(boolean visible) {
+    if (!visible) {
+      stopPreviewTimer();
+    }
+    super.setVisible(visible);
+    if (visible) {
+      schedulePreviewRefresh();
+      updatePreviewTimerState();
+    }
+  }
+
+  private void initPreviewTimer() {
+    if (timer != null) return;
+    timer =
+        new javax.swing.Timer(
+            PREVIEW_TIMER_DELAY_MS,
+            new ActionListener() {
+              public void actionPerformed(ActionEvent evt) {
+                refreshPreviewNow();
+              }
+            });
+  }
+
+  private void stopPreviewTimer() {
+    if (timer != null && timer.isRunning()) {
+      timer.stop();
+    }
+  }
+
+  private void updatePreviewTimerState() {
+    if (timer == null) return;
+    if (isPreviewActive()) {
+      if (!timer.isRunning()) timer.start();
+      return;
+    }
+    stopPreviewTimer();
+  }
+
+  private boolean isPreviewActive() {
+    return pnlBoardPreview != null
+        && tabbedPane != null
+        && tabbedPane.getSelectedIndex() == 1
+        && isVisible();
+  }
+
+  private void schedulePreviewRefresh() {
+    previewDirty = true;
+    if (suppressPreviewRefresh) return;
+    if (isPreviewActive()) refreshPreviewNow();
+    updatePreviewTimerState();
+  }
+
+  private void refreshPreviewNow() {
+    if (!isPreviewActive()) {
+      updatePreviewTimerState();
+      return;
+    }
+    if (syncPreviewCache()) pnlBoardPreview.repaint();
+  }
+
+  private boolean syncPreviewCache() {
+    if (pnlBoardPreview == null) return false;
+    int width = pnlBoardPreview.getWidth();
+    int height = pnlBoardPreview.getHeight();
+    if (width <= 0 || height <= 0) return false;
+    String nextKey = buildPreviewCacheKey(width, height);
+    if (!previewDirty && nextKey.equals(previewCacheKey)) return false;
+    previewCacheImage = buildPreviewImage(width, height);
+    previewCacheKey = nextKey;
+    previewDirty = false;
+    return true;
+  }
+
+  private String buildPreviewCacheKey(int width, int height) {
+    StringBuilder key = new StringBuilder();
+    appendPreviewKey(key, width + "x" + height);
+    appendPreviewKey(key, cmbThemes == null ? -1 : cmbThemes.getSelectedIndex());
+    appendPreviewKey(key, cmbThemes == null ? "" : cmbThemes.getSelectedItem());
+    appendPreviewKey(key, txtBackgroundPath == null ? "" : txtBackgroundPath.getText().trim());
+    appendPreviewKey(key, txtBoardPath == null ? "" : txtBoardPath.getText().trim());
+    appendPreviewKey(key, txtBlackStonePath == null ? "" : txtBlackStonePath.getText().trim());
+    appendPreviewKey(key, txtWhiteStonePath == null ? "" : txtWhiteStonePath.getText().trim());
+    appendPreviewKey(key, chkPureBackground != null && chkPureBackground.isSelected());
+    appendPreviewKey(key, chkPureBoard != null && chkPureBoard.isSelected());
+    appendPreviewKey(key, chkPureStone != null && chkPureStone.isSelected());
+    appendPreviewKey(key, chkShowStoneShaow != null && chkShowStoneShaow.isSelected());
+    appendPreviewKey(key, spnShadowSize == null ? "" : spnShadowSize.getValue());
+    appendPreviewKey(key, colorKey(lblPureBackgroundColor));
+    appendPreviewKey(key, colorKey(lblPureBoardColor));
+    return key.toString();
+  }
+
+  private void appendPreviewKey(StringBuilder key, Object value) {
+    key.append('|').append(value == null ? "" : value);
+  }
+
+  private String colorKey(ColorLabel colorLabel) {
+    if (colorLabel == null || colorLabel.getColor() == null) return "";
+    Color color = colorLabel.getColor();
+    return color.getRGB() + ":" + color.getAlpha();
+  }
+
   private void loadThemeTab() {
-    if (tabbedPane.getSelectedIndex() != 1) return;
+    if (tabbedPane.getSelectedIndex() != 1) {
+      updatePreviewTimerState();
+      return;
+    }
+    if (themeTabInitialized) {
+      schedulePreviewRefresh();
+      updatePreviewTimerState();
+      return;
+    }
+    themeTabInitialized = true;
     // TODO Auto-generated method stub
     File themeFolder = new File(Theme.pathPrefix);
     File[] themes =
@@ -2041,6 +2171,7 @@ public class ConfigDialog2 extends JDialog {
     cmbThemes.addItemListener(
         new ItemListener() {
           public void itemStateChanged(ItemEvent e) {
+            if (e.getStateChange() != ItemEvent.SELECTED) return;
             readThemeValues();
             if (cmbThemes.getSelectedIndex() == 0) btnDeleteTheme.setEnabled(false);
             else btnDeleteTheme.setEnabled(true);
@@ -2465,10 +2596,7 @@ public class ConfigDialog2 extends JDialog {
         new ActionListener() {
           public void actionPerformed(ActionEvent e) {
             String ip = getImagePath();
-            if (!ip.isEmpty()) {
-              txtBackgroundPath.setText(ip);
-              pnlBoardPreview.repaint();
-            }
+            if (!ip.isEmpty()) txtBackgroundPath.setText(ip);
           }
         });
     btnBackgroundPath.setBounds(759, 223, 40, 26);
@@ -2479,10 +2607,7 @@ public class ConfigDialog2 extends JDialog {
         new ActionListener() {
           public void actionPerformed(ActionEvent e) {
             String ip = getImagePath();
-            if (!ip.isEmpty()) {
-              txtBoardPath.setText(ip);
-              pnlBoardPreview.repaint();
-            }
+            if (!ip.isEmpty()) txtBoardPath.setText(ip);
           }
         });
     btnBoardPath.setBounds(759, 253, 40, 26);
@@ -2493,10 +2618,7 @@ public class ConfigDialog2 extends JDialog {
         new ActionListener() {
           public void actionPerformed(ActionEvent e) {
             String ip = getImagePath();
-            if (!ip.isEmpty()) {
-              txtBlackStonePath.setText(ip);
-              pnlBoardPreview.repaint();
-            }
+            if (!ip.isEmpty()) txtBlackStonePath.setText(ip);
           }
         });
     btnBlackStonePath.setBounds(759, 283, 40, 26);
@@ -2507,10 +2629,7 @@ public class ConfigDialog2 extends JDialog {
         new ActionListener() {
           public void actionPerformed(ActionEvent e) {
             String ip = getImagePath();
-            if (!ip.isEmpty()) {
-              txtWhiteStonePath.setText(ip);
-              pnlBoardPreview.repaint();
-            }
+            if (!ip.isEmpty()) txtWhiteStonePath.setText(ip);
           }
         });
     btnWhiteStonePath.setBounds(759, 313, 40, 26);
@@ -2584,220 +2703,273 @@ public class ConfigDialog2 extends JDialog {
         new JPanel() {
           @Override
           public void paintComponent(Graphics g) {
+            super.paintComponent(g);
             if (tabbedPane.getSelectedIndex() != 1) return;
-            if (g instanceof Graphics2D) {
-              int width = getWidth();
-              int height = getHeight();
-              Graphics2D bsGraphics = (Graphics2D) g;
-              Paint originalPaint = bsGraphics.getPaint();
-              bsGraphics.setRenderingHint(
-                  RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
-              bsGraphics.setRenderingHint(KEY_ANTIALIASING, VALUE_ANTIALIAS_ON);
-
-              BufferedImage backgroundImage = null;
-              try {
-                if (cmbThemes.getSelectedIndex() <= 0) {
-                  backgroundImage =
-                      ImageIO.read(getClass().getResourceAsStream(txtBackgroundPath.getText()));
-                } else {
-                  backgroundImage =
-                      ImageIO.read(
-                          new File(theme == null ? "" : theme.path + txtBackgroundPath.getText()));
-                }
-                TexturePaint paint =
-                    new TexturePaint(
-                        backgroundImage,
-                        new Rectangle(
-                            0, 0, backgroundImage.getWidth(), backgroundImage.getHeight()));
-                if (chkPureBackground.isSelected()) g.setColor(lblPureBackgroundColor.getColor());
-                else bsGraphics.setPaint(paint);
-                int drawWidth = max(backgroundImage.getWidth(), width);
-                int drawHeight = max(backgroundImage.getHeight(), height);
-                bsGraphics.fill(new Rectangle(0, 0, drawWidth, drawHeight));
-                bsGraphics.setPaint(originalPaint);
-              } catch (IOException e0) {
-              }
-              BufferedImage boardImage = null;
-              try {
-                if (cmbThemes.getSelectedIndex() <= 0) {
-                  boardImage = ImageIO.read(getClass().getResourceAsStream(txtBoardPath.getText()));
-                } else {
-                  boardImage =
-                      ImageIO.read(
-                          new File(theme == null ? "" : theme.path + txtBoardPath.getText()));
-                }
-                TexturePaint paint =
-                    new TexturePaint(
-                        boardImage,
-                        new Rectangle(0, 0, boardImage.getWidth(), boardImage.getHeight()));
-                if (chkPureBoard.isSelected()) g.setColor(lblPureBoardColor.getColor());
-                else bsGraphics.setPaint(paint);
-                int drawWidth = max(boardImage.getWidth(), width);
-                int drawHeight = max(boardImage.getHeight(), height);
-                bsGraphics.fill(new Rectangle(30, 30, drawWidth, drawHeight));
-                bsGraphics.setPaint(originalPaint);
-              } catch (IOException e0) {
-              }
-              // Draw the lines
-              int x = 60;
-              int y = 60;
-              int squareLength = 30;
-              int stoneRadius = squareLength < 4 ? 1 : squareLength / 2 - 1;
-              int size = stoneRadius * 2 + 1;
-              double r = stoneRadius * (int) spnShadowSize.getValue() / 100;
-              int shadowSize = (int) (r * 0.2) == 0 ? 1 : (int) (r * 0.2);
-              int fartherShadowSize = (int) (r * 0.17) == 0 ? 1 : (int) (r * 0.17);
-              int stoneX = x + squareLength * 2;
-              int stoneY = y + squareLength * 3;
-
-              g.setColor(Color.BLACK);
-              for (int i = 0; i < Board.boardWidth; i++) {
-                g.drawLine(x, y + squareLength * i, height, y + squareLength * i);
-              }
-              for (int i = 0; i < Board.boardHeight; i++) {
-                g.drawLine(x + squareLength * i, y, x + squareLength * i, width);
-              }
-
-              BufferedImage blackStoneImage = null;
-              try {
-                if (cmbThemes.getSelectedIndex() <= 0) {
-                  blackStoneImage =
-                      ImageIO.read(getClass().getResourceAsStream(txtBlackStonePath.getText()));
-                } else {
-                  blackStoneImage =
-                      ImageIO.read(
-                          new File(theme == null ? "" : theme.path + txtBlackStonePath.getText()));
-                }
-                BufferedImage stoneImage = new BufferedImage(size, size, TYPE_INT_ARGB);
-                if (chkShowStoneShaow.isSelected()) {
-                  RadialGradientPaint TOP_GRADIENT_PAINT =
-                      new RadialGradientPaint(
-                          new Point2D.Float(stoneX, stoneY),
-                          stoneRadius + shadowSize,
-                          new float[] {0.3f, 1.0f},
-                          new Color[] {new Color(50, 50, 50, 150), new Color(0, 0, 0, 0)});
-                  RadialGradientPaint LOWER_RIGHT_GRADIENT_PAINT =
-                      new RadialGradientPaint(
-                          new Point2D.Float(stoneX + shadowSize, stoneY + shadowSize),
-                          stoneRadius + fartherShadowSize,
-                          new float[] {0.6f, 1.0f},
-                          new Color[] {new Color(0, 0, 0, 140), new Color(0, 0, 0, 0)});
-                  originalPaint = bsGraphics.getPaint();
-
-                  bsGraphics.setPaint(TOP_GRADIENT_PAINT);
-                  bsGraphics.fillOval(
-                      stoneX - stoneRadius - shadowSize,
-                      stoneY - stoneRadius - shadowSize,
-                      2 * (stoneRadius + shadowSize) + 1,
-                      2 * (stoneRadius + shadowSize) + 1);
-                  bsGraphics.setPaint(LOWER_RIGHT_GRADIENT_PAINT);
-                  bsGraphics.fillOval(
-                      stoneX + shadowSize - stoneRadius - fartherShadowSize,
-                      stoneY + shadowSize - stoneRadius - fartherShadowSize,
-                      2 * (stoneRadius + fartherShadowSize) + 1,
-                      2 * (stoneRadius + fartherShadowSize) + 1);
-                  bsGraphics.setPaint(originalPaint);
-                }
-                if (chkPureStone.isSelected()) {
-                  drawStoneSimple(bsGraphics, stoneX, stoneY, true, stoneRadius);
-                } else {
-                  Image img = blackStoneImage;
-                  Graphics2D g2 = stoneImage.createGraphics();
-                  g2.setRenderingHint(
-                      RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
-                  g2.setRenderingHint(KEY_ANTIALIASING, VALUE_ANTIALIAS_ON);
-                  g2.drawImage(
-                      img.getScaledInstance(size, size, java.awt.Image.SCALE_SMOOTH), 0, 0, null);
-                  g2.dispose();
-                  bsGraphics.drawImage(
-                      stoneImage, stoneX - stoneRadius, stoneY - stoneRadius, null);
-                }
-              } catch (IOException e0) {
-              }
-
-              stoneX = x + squareLength * 1;
-              stoneY = y + squareLength * 2;
-
-              BufferedImage whiteStoneImage = null;
-              try {
-                if (cmbThemes.getSelectedIndex() <= 0) {
-                  whiteStoneImage =
-                      ImageIO.read(getClass().getResourceAsStream(txtWhiteStonePath.getText()));
-                } else {
-                  whiteStoneImage =
-                      ImageIO.read(
-                          new File(theme == null ? "" : theme.path + txtWhiteStonePath.getText()));
-                }
-                BufferedImage stoneImage = new BufferedImage(size, size, TYPE_INT_ARGB);
-                if (chkShowStoneShaow.isSelected()) {
-                  RadialGradientPaint TOP_GRADIENT_PAINT =
-                      new RadialGradientPaint(
-                          new Point2D.Float(stoneX, stoneY),
-                          stoneRadius + shadowSize,
-                          new float[] {0.3f, 1.0f},
-                          new Color[] {new Color(50, 50, 50, 150), new Color(0, 0, 0, 0)});
-                  RadialGradientPaint LOWER_RIGHT_GRADIENT_PAINT =
-                      new RadialGradientPaint(
-                          new Point2D.Float(stoneX + shadowSize, stoneY + shadowSize),
-                          stoneRadius + fartherShadowSize,
-                          new float[] {0.6f, 1.0f},
-                          new Color[] {new Color(0, 0, 0, 140), new Color(0, 0, 0, 0)});
-                  originalPaint = bsGraphics.getPaint();
-
-                  bsGraphics.setPaint(TOP_GRADIENT_PAINT);
-                  bsGraphics.fillOval(
-                      stoneX - stoneRadius - shadowSize,
-                      stoneY - stoneRadius - shadowSize,
-                      2 * (stoneRadius + shadowSize) + 1,
-                      2 * (stoneRadius + shadowSize) + 1);
-                  bsGraphics.setPaint(LOWER_RIGHT_GRADIENT_PAINT);
-                  bsGraphics.fillOval(
-                      stoneX + shadowSize - stoneRadius - fartherShadowSize,
-                      stoneY + shadowSize - stoneRadius - fartherShadowSize,
-                      2 * (stoneRadius + fartherShadowSize) + 1,
-                      2 * (stoneRadius + fartherShadowSize) + 1);
-                  bsGraphics.setPaint(originalPaint);
-                }
-                if (chkPureStone.isSelected()) {
-                  drawStoneSimple(bsGraphics, stoneX, stoneY, false, stoneRadius);
-                } else {
-                  Image img = whiteStoneImage;
-                  Graphics2D g2 = stoneImage.createGraphics();
-                  g2.setRenderingHint(
-                      RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
-                  g2.setRenderingHint(KEY_ANTIALIASING, VALUE_ANTIALIAS_ON);
-                  g2.drawImage(
-                      img.getScaledInstance(size, size, java.awt.Image.SCALE_SMOOTH), 0, 0, null);
-                  g2.dispose();
-                  bsGraphics.drawImage(
-                      stoneImage, stoneX - stoneRadius, stoneY - stoneRadius, null);
-                }
-              } catch (IOException e0) {
-              }
-            }
+            if (previewCacheImage != null) g.drawImage(previewCacheImage, 0, 0, null);
           }
         };
     pnlBoardPreview.setBounds(530, 11, 200, 200);
     themeTab.add(pnlBoardPreview);
     Utils.changeFontRecursive(themeTab, Config.sysDefaultFontName);
+    installPreviewInputListeners();
+    initPreviewTimer();
 
     cmbThemes.setSelectedItem(
         Lizzie.config.uiConfig.optString(
             "theme", resourceBundle.getString("LizzieConfig.title.defaultTheme")));
     if (cmbThemes.getSelectedIndex() == 0) btnDeleteTheme.setEnabled(false);
     else btnDeleteTheme.setEnabled(true);
-    timer =
-        new javax.swing.Timer(
-            100,
-            new ActionListener() {
-              public void actionPerformed(ActionEvent evt) {
-                if (tabbedPane.getSelectedIndex() == 1) {
-                  pnlBoardPreview.repaint();
-                  tabbedPane.repaint();
-                }
+    schedulePreviewRefresh();
+    updatePreviewTimerState();
+  }
+
+  private void installPreviewInputListeners() {
+    addPreviewListener(chkShowStoneShaow);
+    addPreviewListener(chkPureBackground);
+    addPreviewListener(chkPureBoard);
+    addPreviewListener(chkPureStone);
+    addPreviewListener(txtBackgroundPath);
+    addPreviewListener(txtBoardPath);
+    addPreviewListener(txtBlackStonePath);
+    addPreviewListener(txtWhiteStonePath);
+    spnShadowSize.addChangeListener(
+        new ChangeListener() {
+          public void stateChanged(ChangeEvent e) {
+            schedulePreviewRefresh();
+          }
+        });
+  }
+
+  private void addPreviewListener(AbstractButton button) {
+    button.addActionListener(
+        new ActionListener() {
+          public void actionPerformed(ActionEvent e) {
+            schedulePreviewRefresh();
+          }
+        });
+  }
+
+  private void addPreviewListener(JTextField field) {
+    field
+        .getDocument()
+        .addDocumentListener(
+            new DocumentListener() {
+              public void insertUpdate(DocumentEvent e) {
+                schedulePreviewRefresh();
+              }
+
+              public void removeUpdate(DocumentEvent e) {
+                schedulePreviewRefresh();
+              }
+
+              public void changedUpdate(DocumentEvent e) {
+                schedulePreviewRefresh();
               }
             });
-    timer.start();
+  }
+
+  private BufferedImage buildPreviewImage(int width, int height) {
+    BufferedImage previewImage = new BufferedImage(width, height, TYPE_INT_ARGB);
+    Graphics2D graphics = previewImage.createGraphics();
+    try {
+      graphics.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+      graphics.setRenderingHint(KEY_ANTIALIASING, VALUE_ANTIALIAS_ON);
+      drawPreviewSurface(
+          graphics,
+          resolveBackgroundPreviewImage(),
+          chkPureBackground.isSelected(),
+          lblPureBackgroundColor.getColor(),
+          0,
+          0,
+          width,
+          height);
+      drawPreviewSurface(
+          graphics,
+          resolveBoardPreviewImage(),
+          chkPureBoard.isSelected(),
+          lblPureBoardColor.getColor(),
+          PREVIEW_MARGIN,
+          PREVIEW_MARGIN,
+          max(width - PREVIEW_MARGIN, 0),
+          max(height - PREVIEW_MARGIN, 0));
+      drawPreviewGrid(graphics, width, height);
+      drawPreviewStones(graphics);
+    } finally {
+      graphics.dispose();
+    }
+    return previewImage;
+  }
+
+  private void drawPreviewSurface(
+      Graphics2D graphics,
+      BufferedImage image,
+      boolean usePureColor,
+      Color pureColor,
+      int x,
+      int y,
+      int width,
+      int height) {
+    if (width <= 0 || height <= 0) return;
+    if (usePureColor) {
+      graphics.setColor(pureColor);
+      graphics.fillRect(x, y, width, height);
+      return;
+    }
+    if (image == null) return;
+    Paint originalPaint = graphics.getPaint();
+    graphics.setPaint(
+        new TexturePaint(image, new Rectangle(0, 0, image.getWidth(), image.getHeight())));
+    graphics.fillRect(x, y, width, height);
+    graphics.setPaint(originalPaint);
+  }
+
+  private void drawPreviewGrid(Graphics2D graphics, int width, int height) {
+    graphics.setColor(Color.BLACK);
+    for (int i = 0; i < Board.boardWidth; i++) {
+      int y = PREVIEW_GRID_ORIGIN + PREVIEW_SQUARE_LENGTH * i;
+      graphics.drawLine(PREVIEW_GRID_ORIGIN, y, width, y);
+    }
+    for (int i = 0; i < Board.boardHeight; i++) {
+      int x = PREVIEW_GRID_ORIGIN + PREVIEW_SQUARE_LENGTH * i;
+      graphics.drawLine(x, PREVIEW_GRID_ORIGIN, x, height);
+    }
+  }
+
+  private void drawPreviewStones(Graphics2D graphics) {
+    int stoneRadius = PREVIEW_SQUARE_LENGTH < 4 ? 1 : PREVIEW_SQUARE_LENGTH / 2 - 1;
+    double shadowRadiusBase = stoneRadius * ((Integer) spnShadowSize.getValue()) / 100.0;
+    int shadowSize = Math.max(1, (int) (shadowRadiusBase * PREVIEW_TOP_SHADOW_RATIO));
+    int fartherShadowSize = Math.max(1, (int) (shadowRadiusBase * PREVIEW_FAR_SHADOW_RATIO));
+    drawPreviewStone(
+        graphics,
+        resolveBlackStonePreviewImage(),
+        PREVIEW_GRID_ORIGIN + PREVIEW_SQUARE_LENGTH * PREVIEW_BLACK_STONE_X,
+        PREVIEW_GRID_ORIGIN + PREVIEW_SQUARE_LENGTH * PREVIEW_BLACK_STONE_Y,
+        true,
+        stoneRadius,
+        shadowSize,
+        fartherShadowSize);
+    drawPreviewStone(
+        graphics,
+        resolveWhiteStonePreviewImage(),
+        PREVIEW_GRID_ORIGIN + PREVIEW_SQUARE_LENGTH * PREVIEW_WHITE_STONE_X,
+        PREVIEW_GRID_ORIGIN + PREVIEW_SQUARE_LENGTH * PREVIEW_WHITE_STONE_Y,
+        false,
+        stoneRadius,
+        shadowSize,
+        fartherShadowSize);
+  }
+
+  private void drawPreviewStone(
+      Graphics2D graphics,
+      BufferedImage stoneImage,
+      int centerX,
+      int centerY,
+      boolean isBlack,
+      int stoneRadius,
+      int shadowSize,
+      int fartherShadowSize) {
+    if (chkShowStoneShaow.isSelected()) {
+      drawStoneShadow(graphics, centerX, centerY, stoneRadius, shadowSize, fartherShadowSize);
+    }
+    if (chkPureStone.isSelected() || stoneImage == null) {
+      drawStoneSimple(graphics, centerX, centerY, isBlack, stoneRadius);
+      return;
+    }
+    int diameter = stoneRadius * 2 + 1;
+    graphics.drawImage(
+        stoneImage, centerX - stoneRadius, centerY - stoneRadius, diameter, diameter, null);
+  }
+
+  private void drawStoneShadow(
+      Graphics2D graphics,
+      int centerX,
+      int centerY,
+      int stoneRadius,
+      int shadowSize,
+      int fartherShadowSize) {
+    Paint originalPaint = graphics.getPaint();
+    graphics.setPaint(
+        new RadialGradientPaint(
+            new Point2D.Float(centerX, centerY),
+            stoneRadius + shadowSize,
+            new float[] {0.3f, 1.0f},
+            new Color[] {new Color(50, 50, 50, 150), new Color(0, 0, 0, 0)}));
+    graphics.fillOval(
+        centerX - stoneRadius - shadowSize,
+        centerY - stoneRadius - shadowSize,
+        2 * (stoneRadius + shadowSize) + 1,
+        2 * (stoneRadius + shadowSize) + 1);
+    graphics.setPaint(
+        new RadialGradientPaint(
+            new Point2D.Float(centerX + shadowSize, centerY + shadowSize),
+            stoneRadius + fartherShadowSize,
+            new float[] {0.6f, 1.0f},
+            new Color[] {new Color(0, 0, 0, 140), new Color(0, 0, 0, 0)}));
+    graphics.fillOval(
+        centerX + shadowSize - stoneRadius - fartherShadowSize,
+        centerY + shadowSize - stoneRadius - fartherShadowSize,
+        2 * (stoneRadius + fartherShadowSize) + 1,
+        2 * (stoneRadius + fartherShadowSize) + 1);
+    graphics.setPaint(originalPaint);
+  }
+
+  private BufferedImage resolveBackgroundPreviewImage() {
+    if (shouldUseThemePreviewImage(
+        txtBackgroundPath.getText(), theme == null ? null : theme.backgroundPath()))
+      return theme.background();
+    return loadPreviewImage(txtBackgroundPath.getText());
+  }
+
+  private BufferedImage resolveBoardPreviewImage() {
+    if (shouldUseThemePreviewImage(
+        txtBoardPath.getText(), theme == null ? null : theme.boardPath())) return theme.board();
+    return loadPreviewImage(txtBoardPath.getText());
+  }
+
+  private BufferedImage resolveBlackStonePreviewImage() {
+    if (shouldUseThemePreviewImage(
+        txtBlackStonePath.getText(), theme == null ? null : theme.blackStonePath()))
+      return theme.blackStone();
+    return loadPreviewImage(txtBlackStonePath.getText());
+  }
+
+  private BufferedImage resolveWhiteStonePreviewImage() {
+    if (shouldUseThemePreviewImage(
+        txtWhiteStonePath.getText(), theme == null ? null : theme.whiteStonePath()))
+      return theme.whiteStone();
+    return loadPreviewImage(txtWhiteStonePath.getText());
+  }
+
+  private boolean shouldUseThemePreviewImage(String currentPath, String themePath) {
+    return cmbThemes != null
+        && cmbThemes.getSelectedIndex() > 0
+        && theme != null
+        && currentPath != null
+        && currentPath.trim().equals(themePath);
+  }
+
+  private BufferedImage loadPreviewImage(String imagePath) {
+    if (imagePath == null || imagePath.trim().isEmpty()) return null;
+    try {
+      if (cmbThemes != null && cmbThemes.getSelectedIndex() <= 0)
+        return loadBundledPreviewImage(imagePath);
+      return loadThemePreviewImage(imagePath);
+    } catch (IOException e) {
+      return null;
+    }
+  }
+
+  private BufferedImage loadBundledPreviewImage(String imagePath) throws IOException {
+    if (getClass().getResource(imagePath) == null) return null;
+    return ImageIO.read(getClass().getResource(imagePath));
+  }
+
+  private BufferedImage loadThemePreviewImage(String imagePath) throws IOException {
+    File imageFile = new File(imagePath);
+    if (!imageFile.isAbsolute()) imageFile = new File(theme == null ? "" : theme.path + imagePath);
+    if (!imageFile.canRead()) return null;
+    return ImageIO.read(imageFile);
   }
 
   public void setChkSuggestionInfo() {
@@ -2956,6 +3128,7 @@ public class ConfigDialog2 extends JDialog {
       if (useAplha) curColor = c;
       else curColor = Utils.getNoneAlphaColor(c);
       setBackground(curColor);
+      schedulePreviewRefresh();
     }
 
     public Color getColor() {
@@ -3328,74 +3501,80 @@ public class ConfigDialog2 extends JDialog {
   }
 
   private void readThemeValues() {
-    if (cmbThemes.getSelectedIndex() <= 0) {
-      // Default
-      readDefaultTheme();
-    } else {
-      // Read the Theme
-      String themeName = (String) cmbThemes.getSelectedItem();
-      if (themeName == null || themeName.isEmpty()) {
+    suppressPreviewRefresh = true;
+    try {
+      if (cmbThemes.getSelectedIndex() <= 0) {
+        theme = null;
         readDefaultTheme();
       } else {
-        theme = new Theme(themeName);
-        chkPureStone.setSelected(theme.usePureStone(false));
-        chkPureBackground.setSelected(theme.usePureBackground(false));
-        lblPureBackgroundColor.setColor(theme.pureBackgroundColor());
-        chkShowStoneShaow.setSelected(theme.showStoneShadow(false));
-        spnShadowSize.setEnabled(chkShowStoneShaow.isSelected());
-        chkPureBoard.setSelected(theme.usePureBoard(false));
-        lblPureBoardColor.setColor(theme.pureBoardColor());
-        spnWinrateStrokeWidth.setValue(theme.winrateStrokeWidth());
-        spnScoreLeadStrokeWidth.setValue(theme.scoreLeadStrokeWidth());
-        spnMinimumBlunderBarWidth.setValue(theme.minimumBlunderBarWidth());
-        spnShadowSize.setValue(theme.shadowSize());
-        setFontValue(cmbFontName, theme.fontName());
-        setFontValue(cmbUiFontName, theme.uiFontName());
-        setFontValue(cmbWinrateFontName, theme.winrateFontName());
-        btnBackgroundPath.setEnabled(!chkPureBackground.isSelected());
-        txtBackgroundPath.setEnabled(!chkPureBackground.isSelected());
-        txtBackgroundFilter.setEnabled(!chkPureBackground.isSelected());
-        txtBackgroundPath.setText(theme.backgroundPath());
-        btnBoardPath.setEnabled(!chkPureBoard.isSelected());
-        txtBoardPath.setEnabled(!chkPureBoard.isSelected());
-        txtBoardPath.setText(theme.boardPath());
-        txtBlackStonePath.setText(theme.blackStonePath());
-        btnBlackStonePath.setEnabled(!chkPureStone.isSelected());
-        btnWhiteStonePath.setEnabled(!chkPureStone.isSelected());
-        txtBlackStonePath.setEnabled(!chkPureStone.isSelected());
-        txtWhiteStonePath.setEnabled(!chkPureStone.isSelected());
-        txtWhiteStonePath.setText(theme.whiteStonePath());
-        lblWinrateLineColor.setColor(theme.winrateLineColor());
-        lblWinrateMissLineColor.setColor(theme.winrateMissLineColor());
-        lblBlunderBarColor.setColor(theme.blunderBarColor());
-        lblScoreMeanLineColor.setColor(theme.scoreMeanLineColor());
-        setStoneIndicatorType(theme.stoneIndicatorType());
-        chkShowCommentNodeColor.setSelected(theme.showCommentNodeColor(false));
-        chkUseScoreDiff.setSelected(theme.useScoreDiffInVariationTree(false));
-        txtPercentScoreDiff.setText(
-            String.valueOf(theme.scoreDiffInVariationTreeFactor(false) * 100));
-        txtPercentScoreDiff.setEnabled(chkUseScoreDiff.isSelected());
-        lblCommentNodeColor.setColor(theme.commentNodeColor());
-        lblCommentBackgroundColor.setColor(theme.commentBackgroundColor());
-        lblCommentFontColor.setColor(theme.commentFontColor());
-        Color BestCl = theme.bestMoveColor();
-        lblBestMoveColor.setColor(
-            new Color(BestCl.getRed(), BestCl.getGreen(), BestCl.getBlue(), 240));
-        txtCommentFontSize.setText(String.valueOf(theme.commentFontSize()));
-        txtBackgroundFilter.setText(String.valueOf(theme.backgroundFilter()));
-        tblBlunderNodes.setModel(
-            new BlunderNodeTableModel(
-                theme.blunderWinrateThresholds().orElse(null),
-                theme.blunderNodeColors().orElse(null),
-                columsBlunderNodes));
-        TableColumn colorCol = tblBlunderNodes.getColumnModel().getColumn(1);
-        colorCol.setCellRenderer(new ColorRenderer(false));
-        colorCol.setCellEditor(new ColorEditor(this));
+        String themeName = (String) cmbThemes.getSelectedItem();
+        if (themeName == null || themeName.isEmpty()) {
+          theme = null;
+          readDefaultTheme();
+        } else {
+          applyThemeValues(new Theme(themeName));
+        }
       }
+    } finally {
+      suppressPreviewRefresh = false;
     }
-    if (this.pnlBoardPreview != null) {
-      tabbedPane.repaint();
-    }
+    schedulePreviewRefresh();
+  }
+
+  private void applyThemeValues(Theme selectedTheme) {
+    theme = selectedTheme;
+    chkPureStone.setSelected(theme.usePureStone(false));
+    chkPureBackground.setSelected(theme.usePureBackground(false));
+    lblPureBackgroundColor.setColor(theme.pureBackgroundColor());
+    chkShowStoneShaow.setSelected(theme.showStoneShadow(false));
+    spnShadowSize.setEnabled(chkShowStoneShaow.isSelected());
+    chkPureBoard.setSelected(theme.usePureBoard(false));
+    lblPureBoardColor.setColor(theme.pureBoardColor());
+    spnWinrateStrokeWidth.setValue(theme.winrateStrokeWidth());
+    spnScoreLeadStrokeWidth.setValue(theme.scoreLeadStrokeWidth());
+    spnMinimumBlunderBarWidth.setValue(theme.minimumBlunderBarWidth());
+    spnShadowSize.setValue(theme.shadowSize());
+    setFontValue(cmbFontName, theme.fontName());
+    setFontValue(cmbUiFontName, theme.uiFontName());
+    setFontValue(cmbWinrateFontName, theme.winrateFontName());
+    btnBackgroundPath.setEnabled(!chkPureBackground.isSelected());
+    txtBackgroundPath.setEnabled(!chkPureBackground.isSelected());
+    txtBackgroundFilter.setEnabled(!chkPureBackground.isSelected());
+    txtBackgroundPath.setText(theme.backgroundPath());
+    btnBoardPath.setEnabled(!chkPureBoard.isSelected());
+    txtBoardPath.setEnabled(!chkPureBoard.isSelected());
+    txtBoardPath.setText(theme.boardPath());
+    txtBlackStonePath.setText(theme.blackStonePath());
+    btnBlackStonePath.setEnabled(!chkPureStone.isSelected());
+    btnWhiteStonePath.setEnabled(!chkPureStone.isSelected());
+    txtBlackStonePath.setEnabled(!chkPureStone.isSelected());
+    txtWhiteStonePath.setEnabled(!chkPureStone.isSelected());
+    txtWhiteStonePath.setText(theme.whiteStonePath());
+    lblWinrateLineColor.setColor(theme.winrateLineColor());
+    lblWinrateMissLineColor.setColor(theme.winrateMissLineColor());
+    lblBlunderBarColor.setColor(theme.blunderBarColor());
+    lblScoreMeanLineColor.setColor(theme.scoreMeanLineColor());
+    setStoneIndicatorType(theme.stoneIndicatorType());
+    chkShowCommentNodeColor.setSelected(theme.showCommentNodeColor(false));
+    chkUseScoreDiff.setSelected(theme.useScoreDiffInVariationTree(false));
+    txtPercentScoreDiff.setText(String.valueOf(theme.scoreDiffInVariationTreeFactor(false) * 100));
+    txtPercentScoreDiff.setEnabled(chkUseScoreDiff.isSelected());
+    lblCommentNodeColor.setColor(theme.commentNodeColor());
+    lblCommentBackgroundColor.setColor(theme.commentBackgroundColor());
+    lblCommentFontColor.setColor(theme.commentFontColor());
+    Color bestColor = theme.bestMoveColor();
+    lblBestMoveColor.setColor(
+        new Color(bestColor.getRed(), bestColor.getGreen(), bestColor.getBlue(), 240));
+    txtCommentFontSize.setText(String.valueOf(theme.commentFontSize()));
+    txtBackgroundFilter.setText(String.valueOf(theme.backgroundFilter()));
+    tblBlunderNodes.setModel(
+        new BlunderNodeTableModel(
+            theme.blunderWinrateThresholds().orElse(null),
+            theme.blunderNodeColors().orElse(null),
+            columsBlunderNodes));
+    TableColumn colorCol = tblBlunderNodes.getColumnModel().getColumn(1);
+    colorCol.setCellRenderer(new ColorRenderer(false));
+    colorCol.setCellEditor(new ColorEditor(this));
   }
 
   private void writeThemeValues() {

--- a/src/main/java/featurecat/lizzie/gui/DrawPainting.java
+++ b/src/main/java/featurecat/lizzie/gui/DrawPainting.java
@@ -19,6 +19,8 @@ import java.awt.Point;
 import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.ComponentAdapter;
+import java.awt.event.ComponentEvent;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
@@ -36,7 +38,9 @@ import javax.swing.JPanel;
 import javax.swing.border.EmptyBorder;
 
 public class DrawPainting extends JDialog {
+  private static final BasicStroke PEN_STROKE = new BasicStroke(3);
   private BufferedImage cachedImage;
+  private boolean canvasDirty = true;
   private List<DrawPoint> list = new ArrayList<DrawPoint>();
   private List<List<DrawPoint>> drawlist = new ArrayList<List<DrawPoint>>();
   private JPanel mainPanel;
@@ -129,17 +133,19 @@ public class DrawPainting extends JDialog {
         new MouseMotionListener() {
           @Override
           public void mouseDragged(MouseEvent e) {
-            // TODO Auto-generated method stub
-            //  System.out.println("1");
             DrawPoint p1 = new DrawPoint((e.getX()), (e.getY()), colorIndex);
             list.add(p1);
-            draw();
+            drawLatestSegment();
           }
 
           @Override
-          public void mouseMoved(MouseEvent arg0) {
-            // TODO Auto-generated method stub
-
+          public void mouseMoved(MouseEvent arg0) {}
+        });
+    addComponentListener(
+        new ComponentAdapter() {
+          @Override
+          public void componentResized(ComponentEvent e) {
+            rebuildCanvas();
           }
         });
     btnPanel = new JPanel();
@@ -249,7 +255,7 @@ public class DrawPainting extends JDialog {
           public void actionPerformed(ActionEvent e) {
             if (drawlist.size() > 0) {
               drawlist.remove(drawlist.size() - 1);
-              draw();
+              rebuildCanvas();
             }
           }
         });
@@ -264,7 +270,7 @@ public class DrawPainting extends JDialog {
           public void actionPerformed(ActionEvent e) {
             list.clear();
             drawlist.clear();
-            draw();
+            rebuildCanvas();
           }
         });
 
@@ -282,6 +288,7 @@ public class DrawPainting extends JDialog {
             dispose();
           }
         });
+    rebuildCanvas();
   }
 
   protected void saveLastColor() {
@@ -321,37 +328,75 @@ public class DrawPainting extends JDialog {
     }
   }
 
-  private void draw() {
-    cachedImage =
-        new BufferedImage(Utils.zoomOut(totalWidth), Utils.zoomOut(totalHeight), TYPE_INT_ARGB);
-    Graphics2D g0 = (Graphics2D) cachedImage.getGraphics();
-    g0.setBackground(backgroundColor);
-    g0.clearRect(0, 0, cachedImage.getWidth(), cachedImage.getHeight());
-    g0.setRenderingHint(KEY_ANTIALIASING, VALUE_ANTIALIAS_ON);
-    g0.setStroke(new BasicStroke(3));
-
-    for (int s = 0; s < drawlist.size(); s++) {
-      List<DrawPoint> list = drawlist.get(s);
-
-      for (int i = 1; i < list.size(); i++) {
-        int x0 = list.get(i - 1).x;
-        int y0 = list.get(i - 1).y;
-        int x1 = list.get(i).x;
-        int y1 = list.get(i).y;
-        setColor(list.get(i).color, g0);
-        g0.drawLine(x1, y1, x0, y0);
-      }
+  private void drawLatestSegment() {
+    ensureCanvasSize();
+    if (canvasDirty) {
+      redrawCanvasImage();
+      repaint();
+      return;
     }
-    for (int i = 1; i < list.size(); i++) {
-      int x0 = list.get(i - 1).x;
-      int y0 = list.get(i - 1).y;
-      int x1 = list.get(i).x;
-      int y1 = list.get(i).y;
-      setColor(list.get(i).color, g0);
-      g0.drawLine(x1, y1, x0, y0);
+    if (cachedImage == null || list.size() < 2) {
+      repaint();
+      return;
     }
+    Graphics2D g0 = createCanvasGraphics();
+    drawSegment(g0, list.get(list.size() - 2), list.get(list.size() - 1));
     g0.dispose();
     repaint();
+  }
+
+  private void rebuildCanvas() {
+    ensureCanvasSize();
+    if (cachedImage == null) return;
+    redrawCanvasImage();
+    repaint();
+  }
+
+  private void redrawCanvasImage() {
+    if (cachedImage == null) return;
+    Graphics2D g0 = createCanvasGraphics();
+    clearCanvas(g0);
+    for (List<DrawPoint> stroke : drawlist) {
+      drawStroke(g0, stroke);
+    }
+    drawStroke(g0, list);
+    g0.dispose();
+    canvasDirty = false;
+  }
+
+  private void ensureCanvasSize() {
+    int canvasWidth = Math.max(1, Utils.zoomOut(getWidth()));
+    int canvasHeight = Math.max(1, Utils.zoomOut(getHeight()));
+    if (cachedImage != null
+        && cachedImage.getWidth() == canvasWidth
+        && cachedImage.getHeight() == canvasHeight) {
+      return;
+    }
+    cachedImage = new BufferedImage(canvasWidth, canvasHeight, TYPE_INT_ARGB);
+    canvasDirty = true;
+  }
+
+  private Graphics2D createCanvasGraphics() {
+    Graphics2D g0 = (Graphics2D) cachedImage.getGraphics();
+    g0.setBackground(backgroundColor);
+    g0.setRenderingHint(KEY_ANTIALIASING, VALUE_ANTIALIAS_ON);
+    g0.setStroke(PEN_STROKE);
+    return g0;
+  }
+
+  private void clearCanvas(Graphics2D g0) {
+    g0.clearRect(0, 0, cachedImage.getWidth(), cachedImage.getHeight());
+  }
+
+  private void drawStroke(Graphics2D g0, List<DrawPoint> stroke) {
+    for (int i = 1; i < stroke.size(); i++) {
+      drawSegment(g0, stroke.get(i - 1), stroke.get(i));
+    }
+  }
+
+  private void drawSegment(Graphics2D g0, DrawPoint start, DrawPoint end) {
+    setColor(end.color, g0);
+    g0.drawLine(end.x, end.y, start.x, start.y);
   }
 
   private void setColor(PEN_COLOR color, Graphics2D g0) {
@@ -371,12 +416,18 @@ public class DrawPainting extends JDialog {
 
   @Override
   public void paint(Graphics g) {
-    super.paint(g);
-    // ((Graphics2D) g).setComposite(AlphaComposite.getInstance(AlphaComposite.SRC));
-    if (cachedImage != null) {
-      g.drawImage(cachedImage, 0, 0, this);
+    ensureCanvasSize();
+    if (canvasDirty) {
+      redrawCanvasImage();
     }
-    btnPanel.repaint();
+    super.paint(g);
+    if (cachedImage != null) {
+      Graphics2D g2 = (Graphics2D) g.create();
+      int clipTop = btnPanel == null ? 0 : btnPanel.getHeight();
+      g2.clipRect(0, clipTop, getWidth(), Math.max(0, getHeight() - clipTop));
+      g2.drawImage(cachedImage, 0, 0, this);
+      g2.dispose();
+    }
   }
 
   public class DrawPoint {

--- a/src/main/java/featurecat/lizzie/gui/FastCommands.java
+++ b/src/main/java/featurecat/lizzie/gui/FastCommands.java
@@ -1,6 +1,7 @@
 package featurecat.lizzie.gui;
 
 import featurecat.lizzie.Lizzie;
+import featurecat.lizzie.util.ResourceImageCache;
 import java.awt.BorderLayout;
 import java.awt.Container;
 import java.awt.Dimension;
@@ -21,7 +22,6 @@ import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.io.IOException;
 import java.util.List;
-import javax.imageio.ImageIO;
 import javax.swing.JButton;
 import javax.swing.JDialog;
 import javax.swing.JPanel;
@@ -42,7 +42,7 @@ public class FastCommands extends JDialog {
     super(owner);
     initComponents();
     try {
-      this.setIconImage(ImageIO.read(getClass().getResourceAsStream("/assets/logo.png")));
+      this.setIconImage(ResourceImageCache.getImage("/assets/logo.png"));
     } catch (IOException e) {
       e.printStackTrace();
     }

--- a/src/main/java/featurecat/lizzie/gui/FloatBoardRenderer.java
+++ b/src/main/java/featurecat/lizzie/gui/FloatBoardRenderer.java
@@ -88,6 +88,9 @@ public class FloatBoardRenderer {
 
   private BufferedImage branchStonesImage = emptyImage;
   private BufferedImage branchStonesShadowImage;
+  private static final long INVALID_OVERLAY_KEY = Long.MIN_VALUE;
+  private long cachedBranchOverlayKey = INVALID_OVERLAY_KEY;
+  private long cachedEstimateOverlayKey = INVALID_OVERLAY_KEY;
 
   // private boolean lastInScoreMode = false;
 
@@ -475,6 +478,7 @@ public class FloatBoardRenderer {
   }
 
   public void removeKataEstimateImage() {
+    cachedEstimateOverlayKey = INVALID_OVERLAY_KEY;
     kataEstimateImage = new BufferedImage(boardWidth, boardHeight, TYPE_INT_ARGB);
   }
 
@@ -683,18 +687,10 @@ public class FloatBoardRenderer {
         && Lizzie.config.showKataGoEstimate
         && Lizzie.config.showKataGoEstimateOnMainbord) {
       if (estimateArray != null) {
-        if (Lizzie.config.showKataGoEstimateBySize) {
-          drawKataEstimateBySize(estimateArray, estimateBlackToPlay);
-        } else {
-          drawKataEstimateByTransparent(estimateArray, estimateBlackToPlay, false);
-        }
+        refreshEstimateOverlay(estimateArray, estimateBlackToPlay, false);
         hasDraw = true;
       } else if (preEstimateArray != null) {
-        if (Lizzie.config.showKataGoEstimateBySize) {
-          drawKataEstimateBySize(preEstimateArray, estimateBlackToPlay);
-        } else {
-          drawKataEstimateByTransparent(preEstimateArray, estimateBlackToPlay, false);
-        }
+        refreshEstimateOverlay(preEstimateArray, estimateBlackToPlay, false);
         hasDraw = true;
       }
     }
@@ -818,16 +814,11 @@ public class FloatBoardRenderer {
     variationOpt = Optional.of(variation);
     showingBranch = true;
     isShowingBranch = true;
-
-    if (Lizzie.config.noRefreshOnMouseMove) {
-      if (variation == cachedVariation
-          && displayedBranchLength == cachedDisplayedBranchLengthFroBranch) return;
-    } else {
-      if (compareVariationListEquals(variation, cachedVariation)
-          && displayedBranchLength == cachedDisplayedBranchLengthFroBranch) return;
-    }
+    long branchOverlayKey = buildBranchOverlayKey(variation, branch.data.zobrist.hashCode());
     cachedVariation = variation;
     cachedDisplayedBranchLengthFroBranch = displayedBranchLength;
+    if (branchOverlayKey == cachedBranchOverlayKey) return;
+    cachedBranchOverlayKey = branchOverlayKey;
 
     BufferedImage tempBranchStonesImage = new BufferedImage(boardWidth, boardHeight, TYPE_INT_ARGB);
     BufferedImage tempBranchStonesShadowImage =
@@ -2784,6 +2775,81 @@ public class FloatBoardRenderer {
   public void clearBranch() {
     isShowingBranch = false;
     showingBranch = false;
+    cachedBranchOverlayKey = INVALID_OVERLAY_KEY;
+  }
+
+  private void refreshEstimateOverlay(
+      ArrayList<Double> currentEstimate, boolean blackToPlay, boolean fromRawNet) {
+    long estimateOverlayKey =
+        buildEstimateOverlayKey(currentEstimate, blackToPlay, fromRawNet);
+    if (estimateOverlayKey == cachedEstimateOverlayKey) return;
+    cachedEstimateOverlayKey = estimateOverlayKey;
+    if (Lizzie.config.showKataGoEstimateBySize) {
+      drawKataEstimateBySize(currentEstimate, blackToPlay);
+      return;
+    }
+    drawKataEstimateByTransparent(currentEstimate, blackToPlay, fromRawNet);
+  }
+
+  private long buildBranchOverlayKey(List<String> currentVariation, int branchZobristHash) {
+    long key = INVALID_OVERLAY_KEY + 1;
+    key = mixOverlayKey(key, boardWidth);
+    key = mixOverlayKey(key, boardHeight);
+    key = mixOverlayKey(key, squareWidth);
+    key = mixOverlayKey(key, squareHeight);
+    key = mixOverlayKey(key, stoneRadius);
+    key = mixOverlayKey(key, displayedBranchLength);
+    key = mixOverlayKey(key, maxBranchMoves(false));
+    key = mixOverlayKey(key, editMode ? 1 : 0);
+    key = mixOverlayKey(key, Lizzie.board.getData().zobrist.hashCode());
+    key = mixOverlayKey(key, branchZobristHash);
+    key = mixOverlayKey(key, Lizzie.config.usePureStone ? 1 : 0);
+    key = mixOverlayKey(key, Lizzie.config.removeDeadChainInVariation ? 1 : 0);
+    key = mixOverlayKey(key, Lizzie.config.showStoneShadow ? 1 : 0);
+    key = mixOverlayKey(key, Lizzie.config.shadowSize);
+    return mixOverlayKey(key, listSignature(currentVariation));
+  }
+
+  private long buildEstimateOverlayKey(
+      List<Double> currentEstimate, boolean blackToPlay, boolean fromRawNet) {
+    long key = INVALID_OVERLAY_KEY + 1;
+    key = mixOverlayKey(key, boardWidth);
+    key = mixOverlayKey(key, boardHeight);
+    key = mixOverlayKey(key, squareWidth);
+    key = mixOverlayKey(key, squareHeight);
+    key = mixOverlayKey(key, stoneRadius);
+    key = mixOverlayKey(key, Lizzie.board.getHistory().getData().zobrist.hashCode());
+    key = mixOverlayKey(key, editMode ? 1 : 0);
+    key = mixOverlayKey(key, blackToPlay ? 1 : 0);
+    key = mixOverlayKey(key, fromRawNet ? 1 : 0);
+    key = mixOverlayKey(key, Lizzie.config.showKataGoEstimateBySize ? 1 : 0);
+    key = mixOverlayKey(key, shouldShowCountBlockBig() ? 1 : 0);
+    key = mixOverlayKey(key, Lizzie.config.showKataGoEstimateSmall ? 1 : 0);
+    key = mixOverlayKey(key, Lizzie.config.showKataGoEstimateNotOnlive ? 1 : 0);
+    key = mixOverlayKey(key, Lizzie.config.showPureEstimateNotOnlive ? 1 : 0);
+    return mixOverlayKey(key, doubleListSignature(currentEstimate));
+  }
+
+  private long listSignature(List<String> values) {
+    long key = 1L;
+    if (values == null) return key;
+    for (String value : values) {
+      key = mixOverlayKey(key, value == null ? 0 : value.hashCode());
+    }
+    return key;
+  }
+
+  private long doubleListSignature(List<Double> values) {
+    long key = 1L;
+    if (values == null) return key;
+    for (Double value : values) {
+      key = mixOverlayKey(key, value == null ? 0L : Double.doubleToLongBits(value));
+    }
+    return key;
+  }
+
+  private long mixOverlayKey(long seed, long value) {
+    return seed * 31L + value;
   }
 
   public boolean isInside(int x1, int y1) {

--- a/src/main/java/featurecat/lizzie/gui/MoveListFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/MoveListFrame.java
@@ -10,6 +10,7 @@ import featurecat.lizzie.analysis.EngineManager;
 import featurecat.lizzie.rules.Board;
 import featurecat.lizzie.rules.BoardHistoryNode;
 import featurecat.lizzie.rules.NodeInfo;
+import featurecat.lizzie.util.ResourceImageCache;
 import featurecat.lizzie.util.Utils;
 import java.awt.*;
 import java.awt.event.ActionEvent;
@@ -39,7 +40,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import javax.imageio.ImageIO;
 import javax.swing.*;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
@@ -287,7 +287,7 @@ public class MoveListFrame extends JFrame {
       else setBounds(737, 0, Lizzie.config.isChinese ? 856 : 996, 565);
     }
     try {
-      setIconImage(ImageIO.read(MoveListFrame.class.getResourceAsStream("/assets/logo.png")));
+      setIconImage(ResourceImageCache.getImage("/assets/logo.png"));
     } catch (IOException e) {
       e.printStackTrace();
     }
@@ -759,23 +759,15 @@ public class MoveListFrame extends JFrame {
     detail = new JButton("");
     hideMove = new JButton("");
     hideMove.setPreferredSize(new Dimension(20, 20));
-    iconUp = new ImageIcon();
     try {
-      iconUp.setImage(ImageIO.read(getClass().getResourceAsStream("/assets/up.png")));
+      iconUp = ResourceImageCache.getIcon("/assets/up.png");
+      iconDown = ResourceImageCache.getIcon("/assets/down.png");
+      iconSettings = ResourceImageCache.getIcon("/assets/settings.png");
     } catch (IOException e) {
       e.printStackTrace();
-    }
-    iconDown = new ImageIcon();
-    try {
-      iconDown.setImage(ImageIO.read(getClass().getResourceAsStream("/assets/down.png")));
-    } catch (IOException e) {
-      e.printStackTrace();
-    }
-    iconSettings = new ImageIcon();
-    try {
-      iconSettings.setImage(ImageIO.read(getClass().getResourceAsStream("/assets/settings.png")));
-    } catch (IOException e) {
-      e.printStackTrace();
+      iconUp = new ImageIcon();
+      iconDown = new ImageIcon();
+      iconSettings = new ImageIcon();
     }
 
     if (isShowingWinrateGraph) detail.setIcon(iconDown);

--- a/src/main/java/featurecat/lizzie/gui/SubBoardRenderer.java
+++ b/src/main/java/featurecat/lizzie/gui/SubBoardRenderer.java
@@ -70,6 +70,10 @@ public class SubBoardRenderer {
   private Zobrist cachedZhash = new Zobrist(); // defaults to an empty board
 
   private BufferedImage cachedHeatImage = emptyImage;
+  private static final long INVALID_OVERLAY_KEY = Long.MIN_VALUE;
+  private long cachedBranchOverlayKey = INVALID_OVERLAY_KEY;
+  private long cachedEstimateOverlayKey = INVALID_OVERLAY_KEY;
+  private long cachedHeatOverlayKey = INVALID_OVERLAY_KEY;
 
   private BufferedImage branchStonesImage = emptyImage;
   //  private BufferedImage branchStonesShadowImage;
@@ -197,18 +201,10 @@ public class SubBoardRenderer {
         && Lizzie.config.showKataGoEstimate
         && Lizzie.config.showKataGoEstimateOnSubbord) {
       if (estimateArray != null) {
-        if (Lizzie.config.showKataGoEstimateBySize) {
-          drawKataEstimateBySize(estimateArray, false);
-        } else {
-          drawKataEstimateByTransparent(estimateArray, false, false);
-        }
+        refreshEstimateOverlay(estimateArray, false, false);
         hasDraw = true;
       } else if (preEstimateArray != null) {
-        if (Lizzie.config.showKataGoEstimateBySize) {
-          drawKataEstimateBySize(preEstimateArray, true);
-        } else {
-          drawKataEstimateByTransparent(preEstimateArray, true, false);
-        }
+        refreshEstimateOverlay(preEstimateArray, true, false);
         hasDraw = true;
       }
     }
@@ -274,6 +270,7 @@ public class SubBoardRenderer {
   }
 
   public void clearBranch() {
+    cachedBranchOverlayKey = INVALID_OVERLAY_KEY;
     branchStonesImage = new BufferedImage(boardWidth, boardHeight, TYPE_INT_ARGB);
   }
 
@@ -472,6 +469,7 @@ public class SubBoardRenderer {
   }
 
   public void removeKataEstimateImage() {
+    cachedEstimateOverlayKey = INVALID_OVERLAY_KEY;
     try {
       kataEstimateImage = new BufferedImage(boardWidth, boardHeight, TYPE_INT_ARGB);
     } catch (Exception ex) {
@@ -637,6 +635,7 @@ public class SubBoardRenderer {
   }
 
   public void removeHeat() {
+    cachedHeatOverlayKey = INVALID_OVERLAY_KEY;
     heatimage = new BufferedImage(boardWidth, boardHeight, TYPE_INT_ARGB);
   }
 
@@ -759,24 +758,14 @@ public class SubBoardRenderer {
   /** Draw the 'ghost stones' which show a variationOpt Leelaz is thinking about */
   private void drawBranch() {
     showingBranch = false;
-    BufferedImage newImage = new BufferedImage(boardWidth, boardHeight, TYPE_INT_ARGB);
-    // branchStonesImage = new BufferedImage(boardWidth, boardHeight, TYPE_INT_ARGB);
-    // branchStonesShadowImage = new BufferedImage(boardWidth, boardHeight, TYPE_INT_ARGB);
     branchOpt = Optional.empty();
-
-    //    if (Lizzie.frame.isPlayingAgainstLeelaz) {
-    //      branchStonesImage = newImage;
-    //      return;
-    //    }
-
-    // Leela Zero isn't connected yet
     if (Lizzie.leelaz == null) {
-      branchStonesImage = newImage;
+      long emptyBranchKey = buildBranchOverlayKey(0, 0, 0L, 0L, false);
+      if (emptyBranchKey == cachedBranchOverlayKey) return;
+      cachedBranchOverlayKey = emptyBranchKey;
+      branchStonesImage = new BufferedImage(boardWidth, boardHeight, TYPE_INT_ARGB);
       return;
     }
-    // calculate best moves and branch
-    //  if (Lizzie.frame.toolbar.isEnginePk && Lizzie.frame.toolbar.isGenmove) {
-    // reverseBestmoves = false;
     if (!isMouseOver) {
       BoardHistoryNode bestMoveNode;
       if (!Lizzie.board.getHistory().getCurrentHistoryNode().getData().bestMoves.isEmpty()) {
@@ -803,26 +792,25 @@ public class SubBoardRenderer {
     }
 
     variationOpt = Optional.empty();
-
-    Graphics2D g = (Graphics2D) newImage.getGraphics();
-    g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
-    //  Graphics2D gShadow = (Graphics2D) branchStonesShadowImage.getGraphics();
-    //   gShadow.setRenderingHint(RenderingHints.KEY_RENDERING,
-    // RenderingHints.VALUE_RENDER_QUALITY);
-
     Optional<MoveData> suggestedMove = getBestMove();
     if (Lizzie.config.useMovesOwnership) {
       ArrayList<Double> array = getEstimateArray();
       if (array != null) estimateArray = array;
     }
     if (!suggestedMove.isPresent()) {
+      long emptyBranchKey =
+          buildBranchOverlayKey(bestmovesNum + 1, 1, stoneArraySignature(stonesTemp), 0L, false);
+      if (emptyBranchKey == cachedBranchOverlayKey) return;
+      cachedBranchOverlayKey = emptyBranchKey;
+      BufferedImage newImage = new BufferedImage(boardWidth, boardHeight, TYPE_INT_ARGB);
+      Graphics2D g = (Graphics2D) newImage.getGraphics();
       g.setColor(new Color(0, 0, 0, 255));
       g.setFont(new Font(Config.sysDefaultFontName, Font.BOLD, stoneRadius * 3 / 2));
       g.drawString(
           "" + (this.bestmovesNum + 1),
           boardWidth - stoneRadius * 9 / 5,
           boardHeight - stoneRadius * 1 / 5);
-
+      g.dispose();
       branchStonesImage = newImage;
       return;
     }
@@ -853,36 +841,24 @@ public class SubBoardRenderer {
             stonesTemp,
             false,
             null);
-    //    mouseOverCoords = suggestedMove.get().coordinate;
     branchOpt = Optional.of(branch);
     variationOpt = Optional.of(variation);
-
-    //
-    //    List<String> variation = suggestedMove.get().variation;
-    //    Branch branch = null;
-    //    if (Lizzie.frame.toolbar.isEnginePk && Lizzie.frame.toolbar.isGenmove)
-    //      branch =
-    //          new Branch(
-    //              Lizzie.board,
-    //              variation,
-    //              true,
-    //              this.displayedBranchLength > 0 ? displayedBranchLength : 199);
-    //    else
-    //      branch =
-    //          new Branch(
-    //              Lizzie.board,
-    //              variation,
-    //              reverseBestmoves,
-    //              this.displayedBranchLength > 0 ? displayedBranchLength : 199);
-    //    branchOpt = Optional.of(branch);
-    //    variationOpt = Optional.of(variation);
     showingBranch = true;
-
+    long branchOverlayKey =
+        buildBranchOverlayKey(
+            bestmovesNum + 1,
+            branch.data.zobrist.hashCode(),
+            stoneArraySignature(stonesTemp),
+            listSignature(variation),
+            true);
+    if (branchOverlayKey == cachedBranchOverlayKey) return;
+    cachedBranchOverlayKey = branchOverlayKey;
+    BufferedImage newImage = new BufferedImage(boardWidth, boardHeight, TYPE_INT_ARGB);
+    Graphics2D g = (Graphics2D) newImage.getGraphics();
+    g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
     g.setRenderingHint(KEY_ANTIALIASING, VALUE_ANTIALIAS_ON);
-
     for (int i = 0; i < Board.boardWidth; i++) {
       for (int j = 0; j < Board.boardHeight; j++) {
-        // Display latest stone for ghost dead stone
         int index = Board.getIndex(i, j);
         Stone stone = branch.data.stones[index];
         if (stonesTemp != null && stonesTemp[index] != Stone.EMPTY) {
@@ -918,10 +894,7 @@ public class SubBoardRenderer {
         } else drawStone(g, stoneX, stoneY, stone.unGhosted(), i, j);
       }
     }
-    g = (Graphics2D) newImage.getGraphics();
     g.setColor(new Color(0, 0, 0, 255));
-    // g.setFont(new Font("幼圆", Font.BOLD, stoneRadius * 5 / 4));
-    //  g.drawString("变化", boardWidth - stoneRadius * 14 / 3, boardWidth - stoneRadius * 2 / 7);
     g.setFont(new Font(Config.sysDefaultFontName, Font.BOLD, stoneRadius * 3 / 2));
     g.drawString(
         String.valueOf(this.bestmovesNum + 1),
@@ -1102,11 +1075,12 @@ public class SubBoardRenderer {
    * Draw all of Leelaz's suggestions as colored stones with winrate/playout statistics overlayed
    */
   private void drawLeelazSuggestions() {
-
+    bestMoves = Lizzie.board.getHistory().getData().bestMoves;
+    long heatOverlayKey = buildHeatOverlayKey(bestMoves);
+    if (heatOverlayKey == cachedHeatOverlayKey) return;
+    cachedHeatOverlayKey = heatOverlayKey;
     heatimage = new BufferedImage(boardWidth, boardHeight, TYPE_INT_ARGB);
     Graphics2D g = heatimage.createGraphics();
-
-    bestMoves = Lizzie.board.getHistory().getData().bestMoves;
     if (bestMoves != null && !bestMoves.isEmpty()) {
 
       // Collections.sort(bestMoves);
@@ -1199,6 +1173,116 @@ public class SubBoardRenderer {
     }
     g.dispose();
     //   }
+  }
+
+  private void refreshEstimateOverlay(
+      ArrayList<Double> currentEstimate, boolean reverse, boolean fromRawNet) {
+    long estimateOverlayKey = buildEstimateOverlayKey(currentEstimate, reverse, fromRawNet);
+    if (estimateOverlayKey == cachedEstimateOverlayKey) return;
+    cachedEstimateOverlayKey = estimateOverlayKey;
+    if (Lizzie.config.showKataGoEstimateBySize) {
+      drawKataEstimateBySize(currentEstimate, reverse);
+      return;
+    }
+    drawKataEstimateByTransparent(currentEstimate, reverse, fromRawNet);
+  }
+
+  private long buildBranchOverlayKey(
+      int labelIndex, int branchZobristHash, long baseStoneSignature, long variationSignature,
+      boolean branchPresent) {
+    long key = INVALID_OVERLAY_KEY + 1;
+    key = mixOverlayKey(key, boardWidth);
+    key = mixOverlayKey(key, boardHeight);
+    key = mixOverlayKey(key, squareWidth);
+    key = mixOverlayKey(key, squareHeight);
+    key = mixOverlayKey(key, stoneRadius);
+    key = mixOverlayKey(key, displayedBranchLength);
+    key = mixOverlayKey(key, maxBranchMoves());
+    key = mixOverlayKey(key, labelIndex);
+    key = mixOverlayKey(key, branchPresent ? 1 : 0);
+    key = mixOverlayKey(key, variationBlackToPlay ? 1 : 0);
+    key = mixOverlayKey(key, branchZobristHash);
+    key = mixOverlayKey(key, baseStoneSignature);
+    key = mixOverlayKey(key, Lizzie.config.removeDeadChainInVariation ? 1 : 0);
+    return mixOverlayKey(key, variationSignature);
+  }
+
+  private long buildEstimateOverlayKey(
+      List<Double> currentEstimate, boolean reverse, boolean fromRawNet) {
+    long key = INVALID_OVERLAY_KEY + 1;
+    key = mixOverlayKey(key, boardWidth);
+    key = mixOverlayKey(key, boardHeight);
+    key = mixOverlayKey(key, squareWidth);
+    key = mixOverlayKey(key, squareHeight);
+    key = mixOverlayKey(key, stoneRadius);
+    key = mixOverlayKey(key, Lizzie.board.getData().zobrist.hashCode());
+    key = mixOverlayKey(key, Lizzie.board.getHistory().isBlacksTurn() ? 1 : 0);
+    key = mixOverlayKey(key, reverse ? 1 : 0);
+    key = mixOverlayKey(key, fromRawNet ? 1 : 0);
+    key = mixOverlayKey(key, Lizzie.config.showKataGoEstimateBySize ? 1 : 0);
+    key = mixOverlayKey(key, shouldShowCountBlockBig() ? 1 : 0);
+    key = mixOverlayKey(key, Lizzie.config.showKataGoEstimateSmall ? 1 : 0);
+    key = mixOverlayKey(key, Lizzie.config.showKataGoEstimateNotOnlive ? 1 : 0);
+    key = mixOverlayKey(key, Lizzie.config.showPureEstimateNotOnlive ? 1 : 0);
+    return mixOverlayKey(key, doubleListSignature(currentEstimate));
+  }
+
+  private long buildHeatOverlayKey(List<MoveData> currentMoves) {
+    long key = INVALID_OVERLAY_KEY + 1;
+    key = mixOverlayKey(key, boardWidth);
+    key = mixOverlayKey(key, boardHeight);
+    key = mixOverlayKey(key, squareWidth);
+    key = mixOverlayKey(key, squareHeight);
+    key = mixOverlayKey(key, showHeat ? 1 : 0);
+    key = mixOverlayKey(key, showHeatAfterCalc ? 1 : 0);
+    key = mixOverlayKey(key, Lizzie.config.leelaversion);
+    key = mixOverlayKey(key, Lizzie.config.showlcbcolor ? 1 : 0);
+    return mixOverlayKey(key, moveListSignature(currentMoves));
+  }
+
+  private long moveListSignature(List<MoveData> moves) {
+    long key = 1L;
+    if (moves == null) return key;
+    for (MoveData move : moves) {
+      key = mixOverlayKey(key, move == null ? 0 : move.coordinate == null ? 0 : move.coordinate.hashCode());
+      if (move == null) continue;
+      key = mixOverlayKey(key, move.playouts);
+      key = mixOverlayKey(key, Double.doubleToLongBits(move.policy));
+      key = mixOverlayKey(key, Double.doubleToLongBits(move.lcb));
+      key = mixOverlayKey(key, Double.doubleToLongBits(move.winrate));
+    }
+    return key;
+  }
+
+  private long listSignature(List<String> values) {
+    long key = 1L;
+    if (values == null) return key;
+    for (String value : values) {
+      key = mixOverlayKey(key, value == null ? 0 : value.hashCode());
+    }
+    return key;
+  }
+
+  private long doubleListSignature(List<Double> values) {
+    long key = 1L;
+    if (values == null) return key;
+    for (Double value : values) {
+      key = mixOverlayKey(key, value == null ? 0L : Double.doubleToLongBits(value));
+    }
+    return key;
+  }
+
+  private long stoneArraySignature(Stone[] stones) {
+    long key = 1L;
+    if (stones == null) return key;
+    for (Stone stone : stones) {
+      key = mixOverlayKey(key, stone == null ? -1 : stone.ordinal());
+    }
+    return key;
+  }
+
+  private long mixOverlayKey(long seed, long value) {
+    return seed * 31L + value;
   }
 
   private void drawWoodenBoard(Graphics2D g) {

--- a/src/main/java/featurecat/lizzie/gui/WinrateGraph.java
+++ b/src/main/java/featurecat/lizzie/gui/WinrateGraph.java
@@ -7,10 +7,13 @@ import featurecat.lizzie.rules.Board;
 import featurecat.lizzie.rules.BoardHistoryNode;
 import featurecat.lizzie.util.Utils;
 import java.awt.*;
+import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 
 public class WinrateGraph {
@@ -39,6 +42,146 @@ public class WinrateGraph {
     }
   }
 
+  private static class QuickOverviewPathCache {
+    final BoardHistoryNode endNode;
+    final List<BoardHistoryNode> pathNodes;
+    final List<QuickOverviewMove> moves;
+    final long dataSignature;
+    final double maxSwing;
+    final double maxWinrateSpread;
+
+    QuickOverviewPathCache(
+        BoardHistoryNode endNode,
+        List<BoardHistoryNode> pathNodes,
+        List<QuickOverviewMove> moves,
+        long dataSignature,
+        double maxSwing,
+        double maxWinrateSpread) {
+      this.endNode = endNode;
+      this.pathNodes = pathNodes;
+      this.moves = moves;
+      this.dataSignature = dataSignature;
+      this.maxSwing = maxSwing;
+      this.maxWinrateSpread = maxWinrateSpread;
+    }
+  }
+
+  private static class QuickOverviewLayout {
+    final int drawX;
+    final int drawY;
+    final int imageWidth;
+    final int imageHeight;
+    final int innerX;
+    final int innerY;
+    final int innerWidth;
+    final int innerHeight;
+    final int centerY;
+    final int dotSize;
+    final int barWidth;
+
+    QuickOverviewLayout(int posx, int width, int numMoves, int[] origParams, int dotRadius) {
+      int overviewHeight = Math.max(42, Math.min(68, origParams[3] / 5));
+      int innerPadding = Math.max(4, overviewHeight / 8);
+      this.drawX = posx - 2;
+      this.drawY = origParams[1] + origParams[3] - overviewHeight - 4;
+      this.imageWidth = width + 4;
+      this.imageHeight = overviewHeight;
+      this.innerX = 2 + innerPadding;
+      this.innerY = innerPadding;
+      this.innerWidth = Math.max(10, width - innerPadding * 2);
+      this.innerHeight = Math.max(10, overviewHeight - innerPadding * 2);
+      this.centerY = innerY + innerHeight / 2;
+      this.dotSize = Math.max(4, dotRadius * 2);
+      this.barWidth = Math.max(2, (int) Math.ceil(innerWidth / Math.max(70.0, numMoves)));
+    }
+
+    int toAbsoluteX(int localX) {
+      return drawX + localX;
+    }
+
+    int toAbsoluteY(int localY) {
+      return drawY + localY;
+    }
+  }
+
+  private static class QuickOverviewBitmapKey {
+    final int imageWidth;
+    final int imageHeight;
+    final int innerWidth;
+    final int innerHeight;
+    final int numMoves;
+    final long dataSignature;
+    final long issueThresholdBits;
+    final int lineColorRgb;
+    final int strokeWidthBits;
+
+    QuickOverviewBitmapKey(
+        QuickOverviewLayout layout,
+        int numMoves,
+        long dataSignature,
+        double issueThreshold,
+        Color lineColor,
+        float strokeWidth) {
+      this.imageWidth = layout.imageWidth;
+      this.imageHeight = layout.imageHeight;
+      this.innerWidth = layout.innerWidth;
+      this.innerHeight = layout.innerHeight;
+      this.numMoves = numMoves;
+      this.dataSignature = dataSignature;
+      this.issueThresholdBits = Double.doubleToLongBits(issueThreshold);
+      this.lineColorRgb = lineColor.getRGB();
+      this.strokeWidthBits = Float.floatToIntBits(strokeWidth);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj) return true;
+      if (!(obj instanceof QuickOverviewBitmapKey)) return false;
+      QuickOverviewBitmapKey other = (QuickOverviewBitmapKey) obj;
+      return imageWidth == other.imageWidth
+          && imageHeight == other.imageHeight
+          && innerWidth == other.innerWidth
+          && innerHeight == other.innerHeight
+          && numMoves == other.numMoves
+          && dataSignature == other.dataSignature
+          && issueThresholdBits == other.issueThresholdBits
+          && lineColorRgb == other.lineColorRgb
+          && strokeWidthBits == other.strokeWidthBits;
+    }
+
+    @Override
+    public int hashCode() {
+      int result = imageWidth;
+      result = 31 * result + imageHeight;
+      result = 31 * result + innerWidth;
+      result = 31 * result + innerHeight;
+      result = 31 * result + numMoves;
+      result = 31 * result + Long.hashCode(dataSignature);
+      result = 31 * result + Long.hashCode(issueThresholdBits);
+      result = 31 * result + lineColorRgb;
+      result = 31 * result + strokeWidthBits;
+      return result;
+    }
+  }
+
+  private static class QuickOverviewRenderCache {
+    final QuickOverviewBitmapKey key;
+    final BufferedImage backgroundImage;
+    final BufferedImage blunderImage;
+    final BufferedImage lineImage;
+
+    QuickOverviewRenderCache(
+        QuickOverviewBitmapKey key,
+        BufferedImage backgroundImage,
+        BufferedImage blunderImage,
+        BufferedImage lineImage) {
+      this.key = key;
+      this.backgroundImage = backgroundImage;
+      this.blunderImage = blunderImage;
+      this.lineImage = lineImage;
+    }
+  }
+
   private int DOT_RADIUS = 3;
   private int[] origParams = {0, 0, 0, 0};
   private int[] params = {0, 0, 0, 0, 0};
@@ -53,6 +196,9 @@ public class WinrateGraph {
   private boolean scoreAjustBelow;
   private Color whiteColor = new Color(240, 240, 240);
   private boolean noC = false;
+  private final Map<String, Font> fontCache = new HashMap<>();
+  private QuickOverviewPathCache quickOverviewPathCache;
+  private QuickOverviewRenderCache quickOverviewRenderCache;
 
   private Color getBlunderColor(double winrateDrop, double scoreDrop) {
     if (scoreDrop > 5.0 || winrateDrop > 20.0) return new Color(235, 60, 60, 220);
@@ -148,8 +294,7 @@ public class WinrateGraph {
     //      numMoves = this.numMovesOfPlayed;
     //    }
     if (!Lizzie.config.showBlunderBar && width >= 150) {
-      gBackground.setFont(
-          new Font(Config.sysDefaultFontName, Font.PLAIN, largeEnough ? Utils.zoomOut(11) : 11));
+      gBackground.setFont(getGraphFont(Font.PLAIN, largeEnough ? Utils.zoomOut(11) : 11));
       gBackground.setColor(new Color(200, 200, 200));
       if (numMoves <= 63) {
         for (int i = 1; i <= (numMoves / 10); i++)
@@ -217,8 +362,7 @@ public class WinrateGraph {
       //      }
       g.setColor(Color.WHITE);
       if (Lizzie.board.getHistory().getCurrentHistoryNode() != Lizzie.board.getHistory().getEnd()) {
-        Font f =
-            new Font(Config.sysDefaultFontName, Font.BOLD, largeEnough ? Utils.zoomOut(12) : 12);
+        Font f = getGraphFont(Font.BOLD, largeEnough ? Utils.zoomOut(12) : 12);
         g.setFont(f);
         g.setColor(Color.WHITE);
         int moveNum = Lizzie.board.getHistory().getCurrentHistoryNode().getData().moveNumber;
@@ -391,8 +535,7 @@ public class WinrateGraph {
               posy + height - (int) (saveCurWr * height / 100) - DOT_RADIUS,
               DOT_RADIUS * 2,
               DOT_RADIUS * 2);
-          Font f =
-              new Font(Config.sysDefaultFontName, Font.BOLD, largeEnough ? Utils.zoomOut(16) : 16);
+          Font f = getGraphFont(Font.BOLD, largeEnough ? Utils.zoomOut(16) : 16);
           g.setFont(f);
           if (saveCurWr > 50) {
             if (saveCurWr > 90) {
@@ -426,8 +569,7 @@ public class WinrateGraph {
               posy + height - (int) (saveCurWr * height / 100) - DOT_RADIUS,
               DOT_RADIUS * 2,
               DOT_RADIUS * 2);
-          Font f =
-              new Font(Config.sysDefaultFontName, Font.BOLD, largeEnough ? Utils.zoomOut(16) : 16);
+          Font f = getGraphFont(Font.BOLD, largeEnough ? Utils.zoomOut(16) : 16);
           g.setFont(f);
           g.setColor(Color.WHITE);
           if (saveCurWr > 50) {
@@ -1249,7 +1391,7 @@ public class WinrateGraph {
           DOT_RADIUS * 2,
           DOT_RADIUS * 2);
       g.setColor(Color.WHITE);
-      Font f = new Font(Config.sysDefaultFontName, Font.BOLD, largeEnough ? Utils.zoomOut(16) : 16);
+      Font f = getGraphFont(Font.BOLD, largeEnough ? Utils.zoomOut(16) : 16);
       g.setFont(f);
       oriMWrHeight = posy + (height - (int) (mwr * height / 100));
       mwrHeight = oriMWrHeight + (mwr < 10 ? -5 : (mwr > 90 ? 6 : -2) * DOT_RADIUS);
@@ -1273,7 +1415,7 @@ public class WinrateGraph {
       //          numMoves = this.numMovesOfPlayed;
       //        }
       g.setColor(Color.YELLOW);
-      Font f = new Font(Config.sysDefaultFontName, Font.BOLD, largeEnough ? Utils.zoomOut(14) : 14);
+      Font f = getGraphFont(Font.BOLD, largeEnough ? Utils.zoomOut(14) : 14);
       g.setFont(f);
       double scoreHeight = convertScoreLead(drawmSoreMean) * height / 2 / maxScoreLead;
       int mScoreHeight = posy + height / 2 - (int) scoreHeight - 3;
@@ -1308,7 +1450,7 @@ public class WinrateGraph {
     int oriWrHeight = -1;
     noC = false;
     if (cwr >= 0) {
-      Font f = new Font(Config.sysDefaultFontName, Font.BOLD, largeEnough ? Utils.zoomOut(16) : 16);
+      Font f = getGraphFont(Font.BOLD, largeEnough ? Utils.zoomOut(16) : 16);
       g.setFont(f);
       g.setColor(Color.WHITE);
       oriWrHeight = posy + (height - (int) (cwr * height / 100));
@@ -1329,7 +1471,7 @@ public class WinrateGraph {
     }
     if (curScoreMoveNum >= 0 && !noC) {
       g.setColor(Color.YELLOW);
-      Font f = new Font(Config.sysDefaultFontName, Font.BOLD, largeEnough ? Utils.zoomOut(14) : 14);
+      Font f = getGraphFont(Font.BOLD, largeEnough ? Utils.zoomOut(14) : 14);
       g.setFont(f);
       double scoreHeight = convertScoreLead(drawCurSoreMean) * height / 2 / maxScoreLead;
       int cScoreHeight = posy + height / 2 - (int) scoreHeight - 3;
@@ -1392,144 +1534,292 @@ public class WinrateGraph {
       int numMoves) {
     if (origParams[2] < 180 || origParams[3] < 120 || width < 140 || numMoves < 2) return;
 
-    List<QuickOverviewMove> moves = buildQuickOverviewMoves(curMove);
-    if (moves.size() < 2) return;
+    QuickOverviewPathCache pathCache = getQuickOverviewPathCache(curMove);
+    if (pathCache.moves.size() < 2) return;
 
-    int overviewHeight = Math.max(42, Math.min(68, origParams[3] / 5));
-    int overviewY = origParams[1] + origParams[3] - overviewHeight - 4;
-    int overviewX = posx;
-    int overviewWidth = width;
-    int innerPadding = Math.max(4, overviewHeight / 8);
-    int innerX = overviewX + innerPadding;
-    int innerY = overviewY + innerPadding;
-    int innerWidth = Math.max(10, overviewWidth - innerPadding * 2);
-    int innerHeight = Math.max(10, overviewHeight - innerPadding * 2);
-    int centerY = innerY + innerHeight / 2;
-    int dotSize = Math.max(4, DOT_RADIUS * 2);
-    int barWidth = Math.max(2, (int) Math.ceil(innerWidth / Math.max(70.0, numMoves)));
+    QuickOverviewLayout layout =
+        new QuickOverviewLayout(posx, width, numMoves, origParams, DOT_RADIUS);
     double issueThreshold =
         Lizzie.config.blunderWinThreshold > 0 ? Lizzie.config.blunderWinThreshold : 3.0;
-    double maxSwing = issueThreshold;
-    double maxWinrateSpread = 10;
+    double winrateScale = Math.max(10.0, Math.ceil(pathCache.maxWinrateSpread / 5.0) * 5.0);
+    QuickOverviewRenderCache renderCache =
+        getQuickOverviewRenderCache(layout, pathCache, numMoves, issueThreshold);
 
-    for (QuickOverviewMove move : moves) {
-      if (move.hasAnalysis) {
-        maxSwing = Math.max(maxSwing, move.swing);
-        maxWinrateSpread = Math.max(maxWinrateSpread, Math.abs(move.winrate - 50.0));
-      }
-    }
+    gBackground.drawImage(renderCache.backgroundImage, layout.drawX, layout.drawY, null);
+    gBlunder.drawImage(renderCache.blunderImage, layout.drawX, layout.drawY, null);
+    g.drawImage(renderCache.lineImage, layout.drawX, layout.drawY, null);
 
-    double winrateScale = Math.max(10.0, Math.ceil(maxWinrateSpread / 5.0) * 5.0);
-    double swingScale = Math.max(issueThreshold, Math.ceil(maxSwing / 5.0) * 5.0);
-    Color overviewLineColor =
-        Lizzie.config.winrateLineColor != null
-            ? Lizzie.config.winrateLineColor.brighter()
-            : new Color(255, 208, 84);
-    Stroke previousStroke = g.getStroke();
-
-    gBackground.setColor(new Color(15, 20, 28, 205));
-    gBackground.fillRoundRect(overviewX - 2, overviewY, overviewWidth + 4, overviewHeight, 12, 12);
-    gBackground.setColor(new Color(255, 255, 255, 65));
-    gBackground.drawRoundRect(overviewX - 2, overviewY, overviewWidth + 4, overviewHeight, 12, 12);
-    gBackground.setColor(new Color(255, 255, 255, 40));
-    gBackground.drawLine(innerX, centerY, innerX + innerWidth, centerY);
-
-    QuickOverviewMove lastMove = null;
-    int lastX = -1;
-    int lastY = -1;
-    for (QuickOverviewMove move : moves) {
-      int x = innerX + (move.moveNumber - 1) * innerWidth / numMoves;
-      int y =
-          centerY
-              - (int) Math.round((move.winrate - 50.0) * (innerHeight / 2.0 - 2) / winrateScale);
-
-      if (move.hasAnalysis && move.swing >= issueThreshold) {
-        int barHeight = Math.max(3, (int) Math.round(move.swing * innerHeight * 0.75 / swingScale));
-        gBlunder.setColor(quickOverviewBarColor(move.swing, issueThreshold, swingScale));
-        gBlunder.fillRoundRect(
-            x - barWidth / 2, innerY + innerHeight - barHeight, barWidth, barHeight, 4, 4);
-      }
-
-      if (lastMove != null) {
-        g.setColor(
-            lastMove.hasAnalysis && move.hasAnalysis
-                ? overviewLineColor
-                : new Color(180, 180, 180, 140));
-        g.setStroke(new BasicStroke(Math.max(1.6f, (float) Lizzie.config.winrateStrokeWidth)));
-        g.drawLine(lastX, lastY, x, y);
-      }
-      lastMove = move;
-      lastX = x;
-      lastY = y;
-    }
-    g.setStroke(previousStroke);
-
-    QuickOverviewMove currentMove = findQuickOverviewMove(moves, curMove);
-    QuickOverviewMove hoverMove = findQuickOverviewMove(moves, mouseOverNode);
+    QuickOverviewMove currentMove = findQuickOverviewMove(pathCache.moves, curMove);
+    QuickOverviewMove hoverMove = findQuickOverviewMove(pathCache.moves, mouseOverNode);
 
     if (currentMove != null) {
-      int x = innerX + (currentMove.moveNumber - 1) * innerWidth / numMoves;
+      int x =
+          layout.toAbsoluteX(
+              layout.innerX + (currentMove.moveNumber - 1) * layout.innerWidth / numMoves);
       int y =
-          centerY
-              - (int)
-                  Math.round((currentMove.winrate - 50.0) * (innerHeight / 2.0 - 2) / winrateScale);
+          layout.toAbsoluteY(
+              layout.centerY
+                  - (int)
+                      Math.round(
+                          (currentMove.winrate - 50.0)
+                              * (layout.innerHeight / 2.0 - 2)
+                              / winrateScale));
       g.setColor(new Color(255, 255, 255, 170));
-      g.drawLine(x, innerY, x, innerY + innerHeight);
-      g.fillOval(x - dotSize / 2, y - dotSize / 2, dotSize, dotSize);
+      g.drawLine(
+          x,
+          layout.toAbsoluteY(layout.innerY),
+          x,
+          layout.toAbsoluteY(layout.innerY + layout.innerHeight));
+      g.fillOval(x - layout.dotSize / 2, y - layout.dotSize / 2, layout.dotSize, layout.dotSize);
     }
 
     if (hoverMove != null) {
-      int x = innerX + (hoverMove.moveNumber - 1) * innerWidth / numMoves;
+      int x =
+          layout.toAbsoluteX(
+              layout.innerX + (hoverMove.moveNumber - 1) * layout.innerWidth / numMoves);
       int y =
-          centerY
-              - (int)
-                  Math.round((hoverMove.winrate - 50.0) * (innerHeight / 2.0 - 2) / winrateScale);
+          layout.toAbsoluteY(
+              layout.centerY
+                  - (int)
+                      Math.round(
+                          (hoverMove.winrate - 50.0)
+                              * (layout.innerHeight / 2.0 - 2)
+                              / winrateScale));
       g.setColor(new Color(61, 204, 255, 230));
-      g.drawLine(x, innerY, x, innerY + innerHeight);
-      g.fillOval(x - dotSize / 2, y - dotSize / 2, dotSize, dotSize);
-      drawQuickOverviewLabel(g, hoverMove, x, overviewY, innerX, innerX + innerWidth);
+      g.drawLine(
+          x,
+          layout.toAbsoluteY(layout.innerY),
+          x,
+          layout.toAbsoluteY(layout.innerY + layout.innerHeight));
+      g.fillOval(x - layout.dotSize / 2, y - layout.dotSize / 2, layout.dotSize, layout.dotSize);
+      drawQuickOverviewLabel(
+          g,
+          hoverMove,
+          x,
+          layout.drawY,
+          layout.toAbsoluteX(layout.innerX),
+          layout.toAbsoluteX(layout.innerX + layout.innerWidth));
     }
   }
 
-  private List<QuickOverviewMove> buildQuickOverviewMoves(BoardHistoryNode curMove) {
-    ArrayList<BoardHistoryNode> path = new ArrayList<>();
-    ArrayList<QuickOverviewMove> moves = new ArrayList<>();
-    BoardHistoryNode node = curMove;
-    double lastWinrate = 50;
-
-    while (node.next().isPresent()) {
-      node = node.next().get();
+  private QuickOverviewPathCache getQuickOverviewPathCache(BoardHistoryNode curMove) {
+    BoardHistoryNode endNode = curMove;
+    while (endNode.next().isPresent()) {
+      endNode = endNode.next().get();
     }
-    path.add(node);
+    if (quickOverviewPathCache == null || quickOverviewPathCache.endNode != endNode) {
+      List<BoardHistoryNode> pathNodes = buildQuickOverviewPathNodes(endNode);
+      quickOverviewPathCache = buildQuickOverviewPathCache(endNode, pathNodes);
+      quickOverviewRenderCache = null;
+      return quickOverviewPathCache;
+    }
+
+    long dataSignature = computeQuickOverviewDataSignature(quickOverviewPathCache.pathNodes);
+    if (dataSignature != quickOverviewPathCache.dataSignature) {
+      quickOverviewPathCache =
+          buildQuickOverviewPathCache(
+              quickOverviewPathCache.endNode, quickOverviewPathCache.pathNodes);
+      quickOverviewRenderCache = null;
+    }
+    return quickOverviewPathCache;
+  }
+
+  private List<BoardHistoryNode> buildQuickOverviewPathNodes(BoardHistoryNode endNode) {
+    ArrayList<BoardHistoryNode> pathNodes = new ArrayList<>();
+    BoardHistoryNode node = endNode;
+    pathNodes.add(node);
     while (node.previous().isPresent()) {
       node = node.previous().get();
-      path.add(node);
+      pathNodes.add(node);
     }
-    Collections.reverse(path);
+    Collections.reverse(pathNodes);
+    return pathNodes;
+  }
 
-    for (BoardHistoryNode pathNode : path) {
+  private QuickOverviewPathCache buildQuickOverviewPathCache(
+      BoardHistoryNode endNode, List<BoardHistoryNode> pathNodes) {
+    ArrayList<QuickOverviewMove> moves = new ArrayList<>(Math.max(0, pathNodes.size() - 1));
+    double lastWinrate = 50;
+    double maxSwing = 0;
+    double maxWinrateSpread = 10;
+
+    for (BoardHistoryNode pathNode : pathNodes) {
       if (!pathNode.previous().isPresent()) continue;
 
       double previousWinrate = lastWinrate;
       double currentWinrate = resolveQuickOverviewWinrate(pathNode, previousWinrate);
       lastWinrate = currentWinrate;
-      String moveName =
-          pathNode.getData().lastMove.isPresent()
-              ? Board.convertCoordinatesToName(
-                  pathNode.getData().lastMove.get()[0], pathNode.getData().lastMove.get()[1])
-              : "PASS";
       boolean hasAnalysis = pathNode.getData().getPlayouts() > 0;
       double swing = resolveQuickOverviewSwing(pathNode, previousWinrate, currentWinrate);
+      maxSwing = Math.max(maxSwing, swing);
+      if (hasAnalysis) {
+        maxWinrateSpread = Math.max(maxWinrateSpread, Math.abs(currentWinrate - 50.0));
+      }
       moves.add(
           new QuickOverviewMove(
               pathNode,
               pathNode.getData().moveNumber,
-              moveName,
+              resolveQuickOverviewMoveName(pathNode),
               currentWinrate,
               swing,
               hasAnalysis));
     }
-    return moves;
+
+    return new QuickOverviewPathCache(
+        endNode,
+        pathNodes,
+        moves,
+        computeQuickOverviewDataSignature(pathNodes),
+        maxSwing,
+        maxWinrateSpread);
+  }
+
+  private long computeQuickOverviewDataSignature(List<BoardHistoryNode> pathNodes) {
+    long signature = 17L;
+    for (BoardHistoryNode pathNode : pathNodes) {
+      signature = 31L * signature + pathNode.getData().moveNumber;
+      signature = 31L * signature + (pathNode.getData().blackToPlay ? 1L : 0L);
+      signature = appendQuickOverviewMoveLabelSignature(signature, pathNode);
+      signature = 31L * signature + pathNode.getData().getPlayouts();
+      signature = 31L * signature + Double.doubleToLongBits(pathNode.getData().winrate);
+      signature = 31L * signature + Double.doubleToLongBits(pathNode.getData().scoreMean);
+      if (pathNode.nodeInfo != null) {
+        signature = 31L * signature + pathNode.nodeInfo.moveNum;
+        signature = 31L * signature + (pathNode.nodeInfo.analyzed ? 1L : 0L);
+        signature = 31L * signature + Double.doubleToLongBits(pathNode.nodeInfo.diffWinrate);
+      }
+    }
+    return signature;
+  }
+
+  private long appendQuickOverviewMoveLabelSignature(long signature, BoardHistoryNode pathNode) {
+    if (!pathNode.getData().lastMove.isPresent()) {
+      return 31L * signature + 1L;
+    }
+    int[] lastMove = pathNode.getData().lastMove.get();
+    signature = 31L * signature + 2L;
+    signature = 31L * signature + lastMove[0];
+    signature = 31L * signature + lastMove[1];
+    return signature;
+  }
+
+  private QuickOverviewRenderCache getQuickOverviewRenderCache(
+      QuickOverviewLayout layout,
+      QuickOverviewPathCache pathCache,
+      int numMoves,
+      double issueThreshold) {
+    Color lineColor =
+        Lizzie.config.winrateLineColor != null
+            ? Lizzie.config.winrateLineColor.brighter()
+            : new Color(255, 208, 84);
+    float strokeWidth = Math.max(1.6f, (float) Lizzie.config.winrateStrokeWidth);
+    QuickOverviewBitmapKey key =
+        new QuickOverviewBitmapKey(
+            layout, numMoves, pathCache.dataSignature, issueThreshold, lineColor, strokeWidth);
+    if (quickOverviewRenderCache != null && key.equals(quickOverviewRenderCache.key)) {
+      return quickOverviewRenderCache;
+    }
+
+    double winrateScale = Math.max(10.0, Math.ceil(pathCache.maxWinrateSpread / 5.0) * 5.0);
+    double swingScale = Math.max(issueThreshold, Math.ceil(pathCache.maxSwing / 5.0) * 5.0);
+    BufferedImage backgroundImage =
+        new BufferedImage(layout.imageWidth, layout.imageHeight, BufferedImage.TYPE_INT_ARGB);
+    BufferedImage blunderImage =
+        new BufferedImage(layout.imageWidth, layout.imageHeight, BufferedImage.TYPE_INT_ARGB);
+    BufferedImage lineImage =
+        new BufferedImage(layout.imageWidth, layout.imageHeight, BufferedImage.TYPE_INT_ARGB);
+
+    paintQuickOverviewBackground(backgroundImage, layout);
+    paintQuickOverviewBlunders(
+        blunderImage, layout, pathCache.moves, numMoves, issueThreshold, swingScale);
+    paintQuickOverviewLines(
+        lineImage, layout, pathCache.moves, numMoves, winrateScale, lineColor, strokeWidth);
+
+    quickOverviewRenderCache =
+        new QuickOverviewRenderCache(key, backgroundImage, blunderImage, lineImage);
+    return quickOverviewRenderCache;
+  }
+
+  private void paintQuickOverviewBackground(BufferedImage image, QuickOverviewLayout layout) {
+    Graphics2D graphics = createOverviewGraphics(image);
+    graphics.setColor(new Color(15, 20, 28, 205));
+    graphics.fillRoundRect(0, 0, layout.imageWidth, layout.imageHeight, 12, 12);
+    graphics.setColor(new Color(255, 255, 255, 65));
+    graphics.drawRoundRect(0, 0, layout.imageWidth - 1, layout.imageHeight - 1, 12, 12);
+    graphics.setColor(new Color(255, 255, 255, 40));
+    graphics.drawLine(
+        layout.innerX, layout.centerY, layout.innerX + layout.innerWidth, layout.centerY);
+    graphics.dispose();
+  }
+
+  private void paintQuickOverviewBlunders(
+      BufferedImage image,
+      QuickOverviewLayout layout,
+      List<QuickOverviewMove> moves,
+      int numMoves,
+      double issueThreshold,
+      double swingScale) {
+    Graphics2D graphics = createOverviewGraphics(image);
+    for (QuickOverviewMove move : moves) {
+      if (!move.hasAnalysis || move.swing < issueThreshold) continue;
+      int x = layout.innerX + (move.moveNumber - 1) * layout.innerWidth / numMoves;
+      int barHeight =
+          Math.max(3, (int) Math.round(move.swing * layout.innerHeight * 0.75 / swingScale));
+      graphics.setColor(quickOverviewBarColor(move.swing, issueThreshold, swingScale));
+      graphics.fillRoundRect(
+          x - layout.barWidth / 2,
+          layout.innerY + layout.innerHeight - barHeight,
+          layout.barWidth,
+          barHeight,
+          4,
+          4);
+    }
+    graphics.dispose();
+  }
+
+  private void paintQuickOverviewLines(
+      BufferedImage image,
+      QuickOverviewLayout layout,
+      List<QuickOverviewMove> moves,
+      int numMoves,
+      double winrateScale,
+      Color lineColor,
+      float strokeWidth) {
+    Graphics2D graphics = createOverviewGraphics(image);
+    graphics.setStroke(new BasicStroke(strokeWidth));
+
+    QuickOverviewMove lastMove = null;
+    int lastX = -1;
+    int lastY = -1;
+    for (QuickOverviewMove move : moves) {
+      int x = layout.innerX + (move.moveNumber - 1) * layout.innerWidth / numMoves;
+      int y =
+          layout.centerY
+              - (int)
+                  Math.round((move.winrate - 50.0) * (layout.innerHeight / 2.0 - 2) / winrateScale);
+      if (lastMove != null) {
+        graphics.setColor(
+            lastMove.hasAnalysis && move.hasAnalysis ? lineColor : new Color(180, 180, 180, 140));
+        graphics.drawLine(lastX, lastY, x, y);
+      }
+      lastMove = move;
+      lastX = x;
+      lastY = y;
+    }
+    graphics.dispose();
+  }
+
+  private Graphics2D createOverviewGraphics(BufferedImage image) {
+    Graphics2D graphics = image.createGraphics();
+    graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+    graphics.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+    return graphics;
+  }
+
+  private String resolveQuickOverviewMoveName(BoardHistoryNode node) {
+    if (!node.getData().lastMove.isPresent()) return "PASS";
+    int[] lastMove = node.getData().lastMove.get();
+    return Board.convertCoordinatesToName(lastMove[0], lastMove[1]);
   }
 
   private double resolveQuickOverviewWinrate(BoardHistoryNode node, double fallback) {
@@ -1564,8 +1854,7 @@ public class WinrateGraph {
   private void drawQuickOverviewLabel(
       Graphics2D g, QuickOverviewMove move, int x, int overviewY, int minX, int maxX) {
     Font previousFont = g.getFont();
-    Font font =
-        new Font(Config.sysDefaultFontName, Font.BOLD, largeEnough ? Utils.zoomOut(11) : 11);
+    Font font = getGraphFont(Font.BOLD, largeEnough ? Utils.zoomOut(11) : 11);
     g.setFont(font);
 
     String label =
@@ -1591,6 +1880,16 @@ public class WinrateGraph {
     g.setColor(Color.WHITE);
     g.drawString(label, labelX + paddingX, labelY + paddingY + metrics.getAscent() - 1);
     g.setFont(previousFont);
+  }
+
+  private Font getGraphFont(int style, int size) {
+    String key = style + ":" + size + ":" + Config.sysDefaultFontName;
+    Font font = fontCache.get(key);
+    if (font == null) {
+      font = new Font(Config.sysDefaultFontName, style, size);
+      fontCache.put(key, font);
+    }
+    return font;
   }
 
   private Color quickOverviewBarColor(double swing, double threshold, double swingScale) {
@@ -1631,6 +1930,8 @@ public class WinrateGraph {
   public void clearParames() {
     origParams = new int[] {0, 0, 0, 0};
     params = new int[] {0, 0, 0, 0, 0};
+    quickOverviewRenderCache = null;
+    quickOverviewPathCache = null;
   }
 
   public int moveNumber(int x, int y) {

--- a/src/main/java/featurecat/lizzie/util/ResourceImageCache.java
+++ b/src/main/java/featurecat/lizzie/util/ResourceImageCache.java
@@ -1,0 +1,93 @@
+package featurecat.lizzie.util;
+
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.imageio.ImageIO;
+import javax.swing.ImageIcon;
+
+public final class ResourceImageCache {
+  private static final ConcurrentHashMap<String, BufferedImage> IMAGE_CACHE =
+      new ConcurrentHashMap<String, BufferedImage>();
+  private static final ConcurrentHashMap<String, ImageIcon> ICON_CACHE =
+      new ConcurrentHashMap<String, ImageIcon>();
+  private static volatile ImageLoader imageLoader = ResourceImageCache::loadFromClasspath;
+
+  private ResourceImageCache() {}
+
+  public static BufferedImage getImage(String resourcePath) throws IOException {
+    validatePath(resourcePath);
+    try {
+      return IMAGE_CACHE.computeIfAbsent(resourcePath, ResourceImageCache::loadImageUnchecked);
+    } catch (UncheckedIOException error) {
+      throw error.getCause();
+    }
+  }
+
+  public static ImageIcon getIcon(String resourcePath) throws IOException {
+    validatePath(resourcePath);
+    try {
+      return ICON_CACHE.computeIfAbsent(resourcePath, ResourceImageCache::loadIconUnchecked);
+    } catch (UncheckedIOException error) {
+      throw error.getCause();
+    }
+  }
+
+  static void setImageLoaderForTest(ImageLoader loader) {
+    imageLoader = Objects.requireNonNull(loader);
+    clearCacheForTest();
+  }
+
+  static void resetImageLoaderForTest() {
+    imageLoader = ResourceImageCache::loadFromClasspath;
+    clearCacheForTest();
+  }
+
+  static void clearCacheForTest() {
+    IMAGE_CACHE.clear();
+    ICON_CACHE.clear();
+  }
+
+  private static BufferedImage loadImageUnchecked(String resourcePath) {
+    try {
+      return imageLoader.load(resourcePath);
+    } catch (IOException error) {
+      throw new UncheckedIOException(error);
+    }
+  }
+
+  private static ImageIcon loadIconUnchecked(String resourcePath) {
+    try {
+      return new ImageIcon(getImage(resourcePath));
+    } catch (IOException error) {
+      throw new UncheckedIOException(error);
+    }
+  }
+
+  private static BufferedImage loadFromClasspath(String resourcePath) throws IOException {
+    try (InputStream stream = ResourceImageCache.class.getResourceAsStream(resourcePath)) {
+      if (stream == null) {
+        throw new IOException("Missing classpath image resource: " + resourcePath);
+      }
+      BufferedImage image = ImageIO.read(stream);
+      if (image == null) {
+        throw new IOException("Unsupported classpath image resource: " + resourcePath);
+      }
+      return image;
+    }
+  }
+
+  private static void validatePath(String resourcePath) {
+    if (resourcePath == null || resourcePath.isBlank()) {
+      throw new IllegalArgumentException("resourcePath must not be blank");
+    }
+  }
+
+  @FunctionalInterface
+  interface ImageLoader {
+    BufferedImage load(String resourcePath) throws IOException;
+  }
+}

--- a/src/test/java/featurecat/lizzie/gui/AnalysisFrameTest.java
+++ b/src/test/java/featurecat/lizzie/gui/AnalysisFrameTest.java
@@ -1,0 +1,284 @@
+package featurecat.lizzie.gui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import featurecat.lizzie.Config;
+import featurecat.lizzie.Lizzie;
+import featurecat.lizzie.analysis.EngineManager;
+import featurecat.lizzie.analysis.Leelaz;
+import featurecat.lizzie.analysis.MoveData;
+import featurecat.lizzie.rules.Board;
+import featurecat.lizzie.rules.BoardData;
+import featurecat.lizzie.rules.BoardHistoryList;
+import featurecat.lizzie.rules.Stone;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import javax.swing.event.TableModelEvent;
+import org.junit.jupiter.api.Test;
+import sun.misc.Unsafe;
+
+public class AnalysisFrameTest {
+  private static final Unsafe UNSAFE = loadUnsafe();
+
+  @Test
+  void tableSnapshotSortsBySelectedColumnAndPreservesOrderForTies() {
+    MoveData first = move("D4", 120, 51.2, 45.0, 10.0, 1.0, 2);
+    MoveData second = move("Q16", 80, 51.2, 30.0, 20.0, 2.0, 0);
+    MoveData third = move("C3", 60, 48.1, 60.0, 30.0, 3.0, 1);
+
+    AnalysisFrame.TableSnapshot snapshot =
+        AnalysisFrame.TableSnapshot.fromMoves(
+            Arrays.asList(first, second, third), 3, 9, false, false, true, 6.5);
+
+    assertEquals(3, snapshot.getRows().size());
+    assertEquals("D4", snapshot.getRows().get(0).coordinate);
+    assertEquals("Q16", snapshot.getRows().get(1).coordinate);
+    assertEquals("C3", snapshot.getRows().get(2).coordinate);
+  }
+
+  @Test
+  void tableSnapshotComputesTotalPlayouts() {
+    AnalysisFrame.TableSnapshot snapshot =
+        AnalysisFrame.TableSnapshot.fromMoves(
+            Arrays.asList(
+                move("D4", 120, 51.2, 45.0, 10.0, 1.0, 0),
+                move("Q16", 80, 50.0, 44.0, 15.0, 2.0, 1),
+                move("C3", 60, 48.1, 43.0, 20.0, 3.0, 2)),
+            4,
+            9,
+            false,
+            false,
+            true,
+            6.5);
+
+    assertEquals(260, snapshot.getTotalPlayouts());
+  }
+
+  @Test
+  void tableSnapshotEqualityDetectsDisplayChanges() {
+    List<MoveData> rows = Arrays.asList(move("D4", 120, 51.2, 45.0, 10.0, 1.0, 0));
+
+    AnalysisFrame.TableSnapshot first =
+        AnalysisFrame.TableSnapshot.fromMoves(rows, 4, 9, false, false, true, 6.5);
+    AnalysisFrame.TableSnapshot same =
+        AnalysisFrame.TableSnapshot.fromMoves(rows, 4, 9, false, false, true, 6.5);
+    AnalysisFrame.TableSnapshot changed =
+        AnalysisFrame.TableSnapshot.fromMoves(rows, 4, 9, true, false, true, 6.5);
+
+    assertEquals(first, same);
+    assertNotEquals(first, changed);
+  }
+
+  @Test
+  void tableModelPrependsMissingActualMoveFromNextNode() throws Exception {
+    BoardData current = boardData(null, Stone.EMPTY, true, 50.0, 0, 0.0, 0.0);
+    current.bestMoves =
+        Arrays.asList(
+            move("D4", 120, 55.0, 54.0, 12.0, 1.5, 0), move("C3", 80, 52.0, 51.0, 10.0, 0.5, 1));
+
+    BoardData next = boardData("Q16", Stone.BLACK, false, 61.5, 40, 2.5, 0.6);
+    next.bestMoves = Arrays.asList(move("Q16", 40, 38.5, 37.0, 8.0, -2.5, 0));
+
+    try (TestEnvironment environment = installEnvironment(historyWithCurrentAndNext(current, next))) {
+      AnalysisFrame.AnalysisTableModel model = newTableModel(1);
+      AnalysisFrame.RowSnapshot actualMove = snapshotOf(model).getRows().get(0);
+
+      assertEquals(3, snapshotOf(model).getRows().size());
+      assertEquals("Q16", actualMove.coordinate);
+      assertEquals(0, actualMove.playouts);
+      assertEquals(-100, actualMove.order);
+      assertTrue(actualMove.isNextMove);
+      assertEquals(-10000.0, actualMove.lcb);
+      assertEquals(-10000.0, actualMove.policy);
+      assertEquals(38.5, actualMove.winrate);
+      assertEquals(-2.5, actualMove.scoreMean);
+      assertEquals(55.0, actualMove.bestWinrate);
+      assertEquals(1.5, actualMove.bestScoreMean);
+    }
+  }
+
+  @Test
+  void tableModelPrependsUpgradedActualMoveWhenNextNodeHasMorePlayouts() throws Exception {
+    BoardData current = boardData(null, Stone.EMPTY, true, 50.0, 0, 0.0, 0.0);
+    current.bestMoves =
+        Arrays.asList(
+            move("D4", 120, 55.0, 54.0, 12.0, 1.5, 0),
+            move("Q16", 80, 48.0, 47.0, 9.0, 0.5, 2));
+
+    BoardData next = boardData("Q16", Stone.BLACK, false, 63.0, 240, 1.8, 0.7);
+    next.bestMoves = Arrays.asList(move("Q16", 200, 37.0, 36.5, 9.0, -1.8, 0));
+
+    try (TestEnvironment environment = installEnvironment(historyWithCurrentAndNext(current, next))) {
+      AnalysisFrame.AnalysisTableModel model = newTableModel(1);
+      AnalysisFrame.RowSnapshot actualMove = snapshotOf(model).getRows().get(0);
+
+      assertEquals(3, snapshotOf(model).getRows().size());
+      assertEquals("Q16", actualMove.coordinate);
+      assertEquals(240, actualMove.playouts);
+      assertEquals(2, actualMove.order);
+      assertTrue(actualMove.isNextMove);
+      assertEquals(-10000.0, actualMove.lcb);
+      assertEquals(9.0, actualMove.policy);
+      assertEquals(37.0, actualMove.winrate);
+      assertEquals(-1.8, actualMove.scoreMean);
+      assertEquals(0.7, actualMove.scoreStdev);
+      assertEquals(55.0, actualMove.bestWinrate);
+      assertEquals(1.5, actualMove.bestScoreMean);
+    }
+  }
+
+  @Test
+  void refreshSnapshotSignalsStructureChangeWhenColumnCountSwitches() throws Exception {
+    BoardData current = boardData(null, Stone.EMPTY, true, 50.0, 0, 0.0, 0.0);
+    current.bestMoves = Arrays.asList(move("D4", 120, 55.0, 54.0, 12.0, 1.5, 0));
+    BoardHistoryList history = historyWithCurrent(current);
+
+    try (TestEnvironment environment = installEnvironment(history)) {
+      AnalysisFrame.AnalysisTableModel model = newTableModel(1);
+      List<TableModelEvent> events = new ArrayList<TableModelEvent>();
+
+      model.addTableModelListener(events::add);
+      assertEquals(7, model.getColumnCount());
+
+      history.getStart().getData().isKataData = true;
+
+      AnalysisFrame.AnalysisTableModel.RefreshResult result = model.refreshSnapshot();
+
+      assertEquals(AnalysisFrame.AnalysisTableModel.RefreshResult.STRUCTURE_CHANGED, result);
+      assertEquals(9, model.getColumnCount());
+      assertTrue(
+          events.stream().anyMatch(event -> event.getFirstRow() == TableModelEvent.HEADER_ROW));
+    }
+  }
+
+  private static MoveData move(
+      String coordinate,
+      int playouts,
+      double winrate,
+      double lcb,
+      double policy,
+      double scoreMean,
+      int order) {
+    MoveData move = new MoveData();
+    move.coordinate = coordinate;
+    move.playouts = playouts;
+    move.winrate = winrate;
+    move.lcb = lcb;
+    move.policy = policy;
+    move.scoreMean = scoreMean;
+    move.order = order;
+    move.scoreStdev = order;
+    return move;
+  }
+
+  private static BoardData boardData(
+      String coordinate,
+      Stone lastMoveColor,
+      boolean blackToPlay,
+      double winrate,
+      int playouts,
+      double scoreMean,
+      double scoreStdev) {
+    BoardData data = BoardData.empty(19, 19);
+    data.lastMove =
+        coordinate == null ? Optional.empty() : Optional.of(Board.convertNameToCoordinates(coordinate));
+    data.lastMoveColor = lastMoveColor;
+    data.blackToPlay = blackToPlay;
+    data.winrate = winrate;
+    data.scoreMean = scoreMean;
+    data.scoreStdev = scoreStdev;
+    data.setPlayouts(playouts);
+    return data;
+  }
+
+  private static BoardHistoryList historyWithCurrentAndNext(BoardData current, BoardData next) {
+    BoardHistoryList history = historyWithCurrent(current);
+    history.add(next);
+    history.previous();
+    return history;
+  }
+
+  private static BoardHistoryList historyWithCurrent(BoardData current) {
+    BoardHistoryList history = new BoardHistoryList(BoardData.empty(19, 19));
+    history.add(current);
+    return history;
+  }
+
+  private static AnalysisFrame.AnalysisTableModel newTableModel(int index) throws Exception {
+    AnalysisFrame frame = (AnalysisFrame) UNSAFE.allocateInstance(AnalysisFrame.class);
+    frame.index = index;
+    frame.sortnum = -1;
+    return frame.new AnalysisTableModel();
+  }
+
+  private static AnalysisFrame.TableSnapshot snapshotOf(AnalysisFrame.AnalysisTableModel model)
+      throws Exception {
+    Field snapshotField = AnalysisFrame.AnalysisTableModel.class.getDeclaredField("snapshot");
+    snapshotField.setAccessible(true);
+    return (AnalysisFrame.TableSnapshot) snapshotField.get(model);
+  }
+
+  private static TestEnvironment installEnvironment(BoardHistoryList history) throws Exception {
+    Config config = (Config) UNSAFE.allocateInstance(Config.class);
+    config.anaFrameShowNext = true;
+    config.showPreviousBestmovesInEngineGame = false;
+    config.showKataGoScoreLeadWithKomi = false;
+
+    Board board = (Board) UNSAFE.allocateInstance(Board.class);
+    Field historyField = Board.class.getDeclaredField("history");
+    historyField.setAccessible(true);
+    historyField.set(board, history);
+    LizzieFrame frame = (LizzieFrame) UNSAFE.allocateInstance(LizzieFrame.class);
+    return new TestEnvironment(config, board, frame);
+  }
+
+  @SuppressWarnings("restriction")
+  private static Unsafe loadUnsafe() {
+    try {
+      Field field = Unsafe.class.getDeclaredField("theUnsafe");
+      field.setAccessible(true);
+      return (Unsafe) field.get(null);
+    } catch (ReflectiveOperationException exception) {
+      throw new IllegalStateException(exception);
+    }
+  }
+
+  private static final class TestEnvironment implements AutoCloseable {
+    private final Config previousConfig;
+    private final Board previousBoard;
+    private final LizzieFrame previousFrame;
+    private final Leelaz previousLeelaz;
+    private final Leelaz previousLeelaz2;
+    private final boolean previousEngineGame;
+
+    private TestEnvironment(Config config, Board board, LizzieFrame frame) {
+      previousConfig = Lizzie.config;
+      previousBoard = Lizzie.board;
+      previousFrame = Lizzie.frame;
+      previousLeelaz = Lizzie.leelaz;
+      previousLeelaz2 = Lizzie.leelaz2;
+      previousEngineGame = EngineManager.isEngineGame;
+      Lizzie.config = config;
+      Lizzie.board = board;
+      Lizzie.frame = frame;
+      Lizzie.leelaz = null;
+      Lizzie.leelaz2 = null;
+      EngineManager.isEngineGame = false;
+    }
+
+    @Override
+    public void close() {
+      Lizzie.config = previousConfig;
+      Lizzie.board = previousBoard;
+      Lizzie.frame = previousFrame;
+      Lizzie.leelaz = previousLeelaz;
+      Lizzie.leelaz2 = previousLeelaz2;
+      EngineManager.isEngineGame = previousEngineGame;
+    }
+  }
+}

--- a/src/test/java/featurecat/lizzie/util/ResourceImageCacheTest.java
+++ b/src/test/java/featurecat/lizzie/util/ResourceImageCacheTest.java
@@ -1,0 +1,65 @@
+package featurecat.lizzie.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+public class ResourceImageCacheTest {
+  @AfterEach
+  void tearDown() {
+    ResourceImageCache.resetImageLoaderForTest();
+    ResourceImageCache.clearCacheForTest();
+  }
+
+  @Test
+  void samePathReusesCachedImageAndIconInstances() throws Exception {
+    BufferedImage image = ResourceImageCache.getImage("/assets/logo.png");
+
+    assertSame(image, ResourceImageCache.getImage("/assets/logo.png"));
+    assertSame(image, ResourceImageCache.getIcon("/assets/logo.png").getImage());
+    assertSame(
+        ResourceImageCache.getIcon("/assets/logo.png"),
+        ResourceImageCache.getIcon("/assets/logo.png"));
+  }
+
+  @Test
+  void missingResourceThrowsIOException() {
+    IOException error =
+        assertThrows(
+            IOException.class, () -> ResourceImageCache.getImage("/assets/not-found-image.png"));
+
+    assertTrue(error.getMessage().contains("/assets/not-found-image.png"));
+  }
+
+  @Test
+  void loaderExceptionsArePropagatedAndDoNotPoisonCache() throws Exception {
+    IOException failure = new IOException("boom");
+    ResourceImageCache.setImageLoaderForTest(
+        path -> {
+          throw failure;
+        });
+
+    IOException thrown =
+        assertThrows(IOException.class, () -> ResourceImageCache.getImage("/assets/injected.png"));
+    assertSame(failure, thrown);
+
+    AtomicInteger loads = new AtomicInteger();
+    BufferedImage expected = new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB);
+    ResourceImageCache.setImageLoaderForTest(
+        path -> {
+          loads.incrementAndGet();
+          return expected;
+        });
+
+    assertSame(expected, ResourceImageCache.getImage("/assets/injected.png"));
+    assertSame(expected, ResourceImageCache.getImage("/assets/injected.png"));
+    assertEquals(1, loads.get());
+  }
+}


### PR DESCRIPTION
配置窗口预览优化：ConfigDialog2.java

收口了预览 Timer 生命周期，隐藏/关闭时会停掉。
预览从 paintComponent 同步读图改成缓存重建，避免重复 ImageIO.read 和重复建图。
主题切换只处理 ItemEvent.SELECTED，减少重复刷新。
共享图标缓存：ResourceImageCache.java

把 classpath 小图标做了共享缓存。
已接到 FastCommands.java、CaptureTsumeGoFrame.java、BottomToolbar.java、BrowserFrame.java、MoveListFrame.java。
新增测试：ResourceImageCacheTest.java。
分析表刷新模型：AnalysisFrame.java

改成快照驱动，排序/汇总/行构造移出 getRowCount() / getValueAt()。
快照没变时不再无条件 repaint()。
新增测试：AnalysisFrameTest.java。
棋盘 overlay 缓存：BoardRenderer.java、FloatBoardRenderer.java、SubBoardRenderer.java

给 branch / estimate / heat 图层补了缓存失效键。
reviewer 抓到的两个缓存漏洞也已经补掉：branch 阴影配置变更会失效，quick overview 的 moveName 会跟 lastMove 一起失效重建。
图表和涂鸦局部重绘：WinrateGraph.java、DrawPainting.java

WinrateGraph 对 quick overview 的路径、字体、位图做了缓存。
DrawPainting 改成 backing image + 增量绘制，去掉了末尾无收益的额外重绘。