### PR TITLE
feat: 接入弈客对弈房间棋谱同步并修复相关稳定性问题

### DIFF
--- a/docs/FOX_READBOARD_AUTOPAUSE_BUG.md
+++ b/docs/FOX_READBOARD_AUTOPAUSE_BUG.md
@@ -1,0 +1,93 @@
+# 野狐 readboard 同步期间分析自动暂停问题
+
+**日期**：2026-04-29
+**状态**：未修复，已诊断根因
+
+## 现象
+
+使用 readboard 同步野狐对局时：
+
+- 野狐双方下棋很快（连续多手）
+- lizzieyzy-next 棋盘历史能跟上、当前位置在主线末尾
+- 但底栏的"停止分析"按钮会**自动翻成"开始分析"**——分析被关掉
+- 手动点"开始分析"可以恢复
+
+不影响弈客 / 弈城 / 新浪等其他平台。
+
+## 根因
+
+`src/main/java/featurecat/lizzie/analysis/Leelaz.java:1556-1558`：
+
+```java
+if (!isInputCommand && params.length == 2) {
+  isPondering = false;
+}
+```
+
+这一段在解析 KataGo 输出 `play <move>` 行时执行。设计意图是 KataGo 自发 genmove（lz-genmove_analyze 等）后停掉 ponder 状态。
+
+野狐 readboard 路径：
+
+1. readboard 发 `play b D4` 给 lizzieyzy
+2. lizzieyzy 调 `Leelaz.playMove(...)` → 设 `isInputCommand=true`、`sendCommand("play b D4")`
+3. KataGo 异步回 `= ` 应答（成功），params.length=1，不触发上面那行
+4. 同时 KataGo 持续输出 lz-analyze 的 `info ...` 和偶尔的 `play <move>`
+5. **快速连续走子时**，前一个 `play` 命令的 `isInputCommand=true` 还没复位（line 1561 才复位），下一个 `play` 命令又来；某个时刻 KataGo 输出 `play X` 行被识别为非 input-command，命中 line 1556 → `isPondering=false`
+
+底栏看到的"暂停按钮"反映的就是 `isPondering` 这个布尔值。
+
+## 排除掉的嫌疑
+
+- **readboard `noponder` 命令**：检查过 readboard `Form1.cs:2560`，`SendNoPonder()` 只在用户手动按某按钮 (`button7_Click_1`) 时发送，自动场景不会发
+- **`isPlayingAgainstLeelaz` 路径**（Leelaz.java:1535/1644 togglePonder）：受 `Lizzie.frame.isPlayingAgainstLeelaz` 守护，野狐 sync 没开这个
+- **`isAnaPlayingAgainstLeelaz` resign 路径**（Leelaz.java:1810/1819）：同上，野狐场景不开
+- **clear/replay 路径**：`Leelaz.clear()`（line 3940）保留 ponder 状态（`if (isPondering) ponder()`），不会主动关
+- **新棋谱触发的 `BoardHistoryNode.sync` 卡死**：那是 EDT 卡死症状，不是这里"按钮翻"
+
+## 修法选项
+
+### A（最简，3 行）
+
+ReadBoard 处理完 `play X Y` 后，无条件 `if (!isPondering()) ponder()`。
+
+副作用：用户手动按"暂停分析"在野狐 sync 期间会失效——下一手到来就被强制恢复。
+
+### A1（折中，~30 行）
+
+加 `userPaused` 标志区分用户主动暂停 vs 系统自动暂停：
+
+1. Leelaz 加 `boolean userPaused`
+2. 包装一个 `userTogglePonder()`：根据当前 isPondering 设 userPaused 为 true（暂停）或 false（恢复）
+3. 把所有用户暂停入口改走 `userTogglePonder()`：
+   - `LizzieFrame.togglePonderMannul()`
+   - `BottomToolbar.java:1701` 暂停按钮
+   - `AnalysisTable.java:64`
+   - `FloatBoard.java:165`
+   - 键盘快捷键
+4. ReadBoard 在 `play` 后强制恢复时多加一个判断：`if (!userPaused && !isPondering()) ponder()`
+
+风险：必须把所有用户能按到的暂停入口都罩住，漏一个那条入口的暂停会被破坏。
+
+### B（根治，风险中等）
+
+直接修 Leelaz.java:1556。比如改成 `if (!isInputCommand && params.length == 2 && Lizzie.frame.isPlayingAgainstLeelaz)`——只在和 KataGo 对弈模式下才停 ponder。
+
+风险：这行原始意图不明，可能有别的代码路径依赖它（比如某种 genmove_analyze 流程）。需要回归测试主菜单的"和 KataGo 对弈" / 各种自对弈 / KataGo 自我对局等。
+
+### D（待调研）
+
+野狐着法有没有可能不走 `Leelaz.playMove`、改走旁路命令避开 line 1556？需要先搜清楚野狐 readboard 的着法到底通过哪个 Leelaz API 喂给 KataGo。
+
+## 推荐顺序
+
+1. 先 A（3 行），放两天看用户是否真的踩到"暂停被打破"
+2. 如果真踩到 → 升 A1
+3. B 等有空 + 有完整测试时再做（风险最高、收益最大）
+
+## 相关代码位置
+
+- `src/main/java/featurecat/lizzie/analysis/Leelaz.java:1495-1562` —— `play` 行解析（含 line 1556 嫌疑代码）
+- `src/main/java/featurecat/lizzie/analysis/ReadBoard.java` —— readboard 命令处理入口
+- `src/main/java/featurecat/lizzie/analysis/Leelaz.java:4151` —— `togglePonder()` 实现
+- `src/main/java/featurecat/lizzie/gui/LizzieFrame.java:10047` —— `togglePonderMannul()` 用户入口
+- `src/main/java/featurecat/lizzie/analysis/Leelaz.java:4220-4225` —— `Pondering()` / `notPondering()` 状态 setter

--- a/src/main/java/featurecat/lizzie/Config.java
+++ b/src/main/java/featurecat/lizzie/Config.java
@@ -1061,6 +1061,7 @@ public class Config {
   public boolean disableMoveRankInOrigin = false;
   public boolean logConsoleToFile = false;
   public boolean logGtpToFile = false;
+  public boolean enableStartupBenchmark = true;
   public boolean readBoardPonder = false;
   public boolean readBoardGetFocus = true;
 
@@ -1846,6 +1847,7 @@ public class Config {
     disableMoveRankInOrigin = uiConfig.optBoolean("disable-move-rank-in-origin", false);
     logConsoleToFile = uiConfig.optBoolean("log-console-to-file", false);
     logGtpToFile = uiConfig.optBoolean("log-gtp-to-file", false);
+    enableStartupBenchmark = uiConfig.optBoolean("enable-startup-benchmark", true);
     readBoardGetFocus = uiConfig.optBoolean("read-board-get-focus", true);
     useScoreLossInMoveRank = uiConfig.optBoolean("use-score-loss-in-move-rank", true);
     useWinLossInMoveRank = uiConfig.optBoolean("use-win-loss-in-move-rank", true);

--- a/src/main/java/featurecat/lizzie/analysis/ReadBoard.java
+++ b/src/main/java/featurecat/lizzie/analysis/ReadBoard.java
@@ -731,7 +731,10 @@ public class ReadBoard {
       Lizzie.gtpConsole.addLineReadBoard(line + (usePipe ? "" : "\n"));
     }
     if (line.startsWith("end")) {
-      if (!isSyncing) syncBoardStones(false);
+      boolean isYikePlatform =
+          pendingRemoteContext != null
+              && pendingRemoteContext.platform == SyncRemoteContext.SyncPlatform.YIKE;
+      if (!isSyncing && !isYikePlatform) syncBoardStones(false);
       clearPendingRemoteContext();
       tempcount = new ArrayList<Integer>();
     }
@@ -1219,9 +1222,10 @@ public class ReadBoard {
   }
 
   private SyncRemoteContext.SyncPlatform parseSyncPlatform(String platformToken) {
-    return "fox".equalsIgnoreCase(platformToken.trim())
-        ? SyncRemoteContext.SyncPlatform.FOX
-        : SyncRemoteContext.SyncPlatform.GENERIC;
+    String t = platformToken.trim();
+    if ("fox".equalsIgnoreCase(t)) return SyncRemoteContext.SyncPlatform.FOX;
+    if ("yike".equalsIgnoreCase(t)) return SyncRemoteContext.SyncPlatform.YIKE;
+    return SyncRemoteContext.SyncPlatform.GENERIC;
   }
 
   private OptionalInt parseOptionalInt(String line, String prefix) {

--- a/src/main/java/featurecat/lizzie/analysis/SyncRemoteContext.java
+++ b/src/main/java/featurecat/lizzie/analysis/SyncRemoteContext.java
@@ -7,6 +7,7 @@ import java.util.OptionalInt;
 final class SyncRemoteContext {
   enum SyncPlatform {
     FOX,
+    YIKE,
     GENERIC
   }
 

--- a/src/main/java/featurecat/lizzie/gui/BrowserFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/BrowserFrame.java
@@ -44,6 +44,10 @@ public class BrowserFrame extends JFrame {
   private final Component browerUI_;
   private volatile boolean browserFocus_ = true;
   private JToolBar toolbar;
+  private String baseTitle = "";
+  private String lastSyncStatus = null;
+  private long pendingYikeRoomId = 0;
+  private int pendingYikeIntervalMs = 1000;
   private boolean isYike;
 
   /**
@@ -58,7 +62,8 @@ public class BrowserFrame extends JFrame {
           InterruptedException {
     // (0) Initialize CEF using the maven loader
     this.isYike = yike;
-    this.setTitle(title);
+    this.baseTitle = title == null ? "" : title;
+    this.setTitle(this.baseTitle);
     try {
       setIconImage(ImageIO.read(getClass().getResourceAsStream("/assets/logo.png")));
     } catch (IOException e) {
@@ -175,6 +180,22 @@ public class BrowserFrame extends JFrame {
 
     client_.addLoadHandler(
         new CefLoadHandlerAdapter() {
+          @Override
+          public void onLoadStart(
+              CefBrowser browser, CefFrame frame, org.cef.network.CefRequest.TransitionType t) {
+            // 在页面 DOM 刚开始构建时就装 hook，赶在弈客网页主动调 game/info 之前
+            if (frame != null && frame.isMain() && pendingYikeRoomId > 0) {
+              installYikeUnitePoller(pendingYikeRoomId, pendingYikeIntervalMs);
+            }
+          }
+
+          @Override
+          public void onLoadEnd(CefBrowser browser, CefFrame frame, int httpStatusCode) {
+            if (frame != null && frame.isMain() && pendingYikeRoomId > 0) {
+              installYikeUnitePoller(pendingYikeRoomId, pendingYikeIntervalMs);
+            }
+          }
+
           @Override
           public void onLoadError(
               CefBrowser browser,
@@ -352,28 +373,28 @@ public class BrowserFrame extends JFrame {
         });
     back.setFocusable(false);
 
-    JButton load = new JButton(Lizzie.resourceBundle.getString("LizzieFrame.onLoad")); // ("加载");
-    load.setFocusable(false);
-    load.addActionListener(
-        new ActionListener() {
+    JLabel load = makeLabelButton(Lizzie.resourceBundle.getString("LizzieFrame.onLoad"));
+    load.addMouseListener(
+        new java.awt.event.MouseAdapter() {
           @Override
-          public void actionPerformed(ActionEvent e) {
-            // TBD未完成
-            browser_.loadURL(address_.getText());
-            if (isYike) Lizzie.frame.syncOnline(address_.getText());
+          public void mouseClicked(java.awt.event.MouseEvent e) {
+            String addr = address_.getText();
+            if (isYike) {
+              Lizzie.frame.syncOnline(addr);
+            }
+            browser_.loadURL(addr);
           }
         });
 
-    JButton stop =
-        new JButton(Lizzie.resourceBundle.getString("LizzieFrame.stopSync")); // ("停止同步");
-    stop.setFocusable(false);
-    stop.addActionListener(
-        new ActionListener() {
+    JLabel stop = makeLabelButton(Lizzie.resourceBundle.getString("LizzieFrame.stopSync"));
+    stop.addMouseListener(
+        new java.awt.event.MouseAdapter() {
           @Override
-          public void actionPerformed(ActionEvent e) {
-            // TBD
+          public void mouseClicked(java.awt.event.MouseEvent e) {
             if (LizzieFrame.onlineDialog != null) {
               LizzieFrame.onlineDialog.stopSync();
+            } else {
+              setSyncStatus("无同步任务");
             }
           }
         });
@@ -469,10 +490,64 @@ public class BrowserFrame extends JFrame {
         new Runnable() {
           public void run() {
             isYike = yike;
-            setTitle(title);
+            baseTitle = title == null ? "" : title;
+            lastSyncStatus = null;
+            if (!yike) pendingYikeRoomId = 0;
+            setTitle(baseTitle);
             setVisible(true);
             toolbar.setVisible(isYike);
             setFrameSize();
+          }
+        });
+  }
+
+  /** 用 JLabel 模拟按钮，完全自绘，绕开 Windows L&F + JToolBar 的 hover/pressed 残影。 */
+  private static JLabel makeLabelButton(String text) {
+    JLabel lbl = new JLabel(text, SwingConstants.CENTER);
+    lbl.setOpaque(true);
+    lbl.setBackground(new Color(0xF0F0F0));
+    lbl.setForeground(Color.BLACK);
+    lbl.setBorder(
+        BorderFactory.createCompoundBorder(
+            BorderFactory.createLineBorder(new Color(0xB0B0B0)),
+            BorderFactory.createEmptyBorder(4, 12, 4, 12)));
+    lbl.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+    lbl.addMouseListener(
+        new java.awt.event.MouseAdapter() {
+          @Override
+          public void mouseEntered(java.awt.event.MouseEvent e) {
+            lbl.setBackground(new Color(0xE0E0E0));
+          }
+
+          @Override
+          public void mouseExited(java.awt.event.MouseEvent e) {
+            lbl.setBackground(new Color(0xF0F0F0));
+          }
+
+          @Override
+          public void mousePressed(java.awt.event.MouseEvent e) {
+            lbl.setBackground(new Color(0xC8C8C8));
+          }
+
+          @Override
+          public void mouseReleased(java.awt.event.MouseEvent e) {
+            lbl.setBackground(
+                lbl.contains(e.getPoint()) ? new Color(0xE0E0E0) : new Color(0xF0F0F0));
+          }
+        });
+    return lbl;
+  }
+
+  public void setSyncStatus(String text) {
+    String normalized = Utils.isBlank(text) ? "" : text;
+    if (java.util.Objects.equals(normalized, lastSyncStatus)) return;
+    lastSyncStatus = normalized;
+    SwingUtilities.invokeLater(
+        () -> {
+          if (normalized.isEmpty()) {
+            setTitle(baseTitle);
+          } else {
+            setTitle(baseTitle + "  —  " + normalized);
           }
         });
   }
@@ -483,6 +558,8 @@ public class BrowserFrame extends JFrame {
    * Java。借用弈客网页自己的鉴权，不用关心 token / CORS。
    */
   public void installYikeUnitePoller(long roomId, int intervalMs) {
+    pendingYikeRoomId = roomId;
+    pendingYikeIntervalMs = intervalMs;
     int periodMs = Math.max(500, intervalMs);
     String js =
         "(function(){"
@@ -584,6 +661,7 @@ public class BrowserFrame extends JFrame {
   }
 
   public void stopYikeUnitePoller() {
+    pendingYikeRoomId = 0;
     String js =
         "if(window.__yikeUnitePoller){clearInterval(window.__yikeUnitePoller);"
             + "window.__yikeUnitePoller=null;}"

--- a/src/main/java/featurecat/lizzie/gui/BrowserFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/BrowserFrame.java
@@ -26,6 +26,10 @@ import org.cef.browser.CefMessageRouter;
 import org.cef.handler.CefDisplayHandlerAdapter;
 import org.cef.handler.CefFocusHandlerAdapter;
 import org.cef.handler.CefLifeSpanHandlerAdapter;
+import org.cef.handler.CefLoadHandler;
+import org.cef.handler.CefLoadHandlerAdapter;
+import org.cef.handler.CefRequestHandler;
+import org.cef.handler.CefRequestHandlerAdapter;
 import org.json.JSONObject;
 import org.json.JSONTokener;
 
@@ -36,7 +40,7 @@ public class BrowserFrame extends JFrame {
   private final CefClient client_;
   private final CefBrowser browser_;
   private final Component browerUI_;
-  private boolean browserFocus_ = true;
+  private volatile boolean browserFocus_ = true;
   private JToolBar toolbar;
   private boolean isYike;
 
@@ -63,6 +67,10 @@ public class BrowserFrame extends JFrame {
     // windowless_rendering_enabled must be set to false if not wanted.
     builder.getCefSettings().windowless_rendering_enabled = false;
     builder.getCefSettings().log_severity = LogSeverity.LOGSEVERITY_DISABLE;
+    File cefCache = new File("jcef-bundle", "cache");
+    if (!cefCache.exists()) cefCache.mkdirs();
+    builder.getCefSettings().root_cache_path = cefCache.getAbsolutePath();
+    builder.getCefSettings().cache_path = cefCache.getAbsolutePath();
     // USE builder.setAppHandler INSTEAD OF CefApp.addAppHandler!
     // Fixes compatibility issues with MacOSX
     builder.setAppHandler(
@@ -135,6 +143,60 @@ public class BrowserFrame extends JFrame {
     CefMessageRouter msgRouter = CefMessageRouter.create();
     client_.addMessageRouter(msgRouter);
 
+    client_.addLoadHandler(
+        new CefLoadHandlerAdapter() {
+          @Override
+          public void onLoadError(
+              CefBrowser browser,
+              CefFrame frame,
+              CefLoadHandler.ErrorCode errorCode,
+              String errorText,
+              String failedUrl) {
+            if (frame.isMain()
+                && errorCode != CefLoadHandler.ErrorCode.ERR_ABORTED
+                && errorCode != CefLoadHandler.ErrorCode.ERR_NONE) {
+              String safeUrl = failedUrl.replace("\\", "\\\\").replace("'", "\\'");
+              String safeError = errorText.replace("\\", "\\\\").replace("'", "\\'");
+              browser.executeJavaScript(
+                  "document.body.textContent='';"
+                      + "var d=document.createElement('div');"
+                      + "d.style.cssText='text-align:center;padding:60px;font-family:sans-serif;color:#333';"
+                      + "d.innerHTML='<h2>\\u52a0\\u8f7d\\u5931\\u8d25</h2>"
+                      + "<p>\\u9519\\u8bef: "
+                      + safeError
+                      + " ("
+                      + errorCode
+                      + ")</p>"
+                      + "<p>URL: "
+                      + safeUrl
+                      + "</p>"
+                      + "<button onclick=\"location.reload()\" style=\"padding:8px 24px;"
+                      + "font-size:14px;cursor:pointer\">\\u91cd\\u8bd5</button>';"
+                      + "document.body.appendChild(d);",
+                  frame.getURL(),
+                  0);
+            }
+          }
+        });
+
+    client_.addRequestHandler(
+        new CefRequestHandlerAdapter() {
+          @Override
+          public void onRenderProcessTerminated(
+              CefBrowser browser,
+              CefRequestHandler.TerminationStatus status,
+              int errorCode,
+              String errorString) {
+            javax.swing.SwingUtilities.invokeLater(
+                () -> {
+                  String url = address_.getText();
+                  if (url != null && !url.isEmpty()) {
+                    browser_.loadURL(url);
+                  }
+                });
+          }
+        });
+
     // (4) One CefBrowser instance is responsible to control what you'll see on
     //     the UI component of the instance. It can be displayed off-screen
     //     rendered or windowed rendered. To get an instance of CefBrowser you
@@ -182,7 +244,7 @@ public class BrowserFrame extends JFrame {
         new CefDisplayHandlerAdapter() {
           @Override
           public void onAddressChange(CefBrowser browser, CefFrame frame, String url) {
-            address_.setText(url);
+            SwingUtilities.invokeLater(() -> address_.setText(url));
           }
         });
 
@@ -205,8 +267,11 @@ public class BrowserFrame extends JFrame {
           public void onGotFocus(CefBrowser browser) {
             if (browserFocus_) return;
             browserFocus_ = true;
-            KeyboardFocusManager.getCurrentKeyboardFocusManager().clearGlobalFocusOwner();
-            browser.setFocus(true);
+            SwingUtilities.invokeLater(
+                () -> {
+                  KeyboardFocusManager.getCurrentKeyboardFocusManager().clearGlobalFocusOwner();
+                  browser.setFocus(true);
+                });
           }
 
           @Override
@@ -222,11 +287,14 @@ public class BrowserFrame extends JFrame {
           @Override
           public boolean onBeforePopup(
               CefBrowser browser, CefFrame frame, String target_url, String target_frame_name) {
-            if (isYike && !browser.getURL().equals(target_url)) {
-              Lizzie.frame.syncOnline(target_url);
-            }
-            browser_.loadURL(target_url);
-            // 返回true表示取消弹出窗口
+            final String currentUrl = browser.getURL();
+            SwingUtilities.invokeLater(
+                () -> {
+                  if (isYike && !currentUrl.equals(target_url)) {
+                    Lizzie.frame.syncOnline(target_url);
+                  }
+                  browser_.loadURL(target_url);
+                });
             return true;
           }
         });

--- a/src/main/java/featurecat/lizzie/gui/BrowserFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/BrowserFrame.java
@@ -23,11 +23,13 @@ import org.cef.CefSettings.LogSeverity;
 import org.cef.browser.CefBrowser;
 import org.cef.browser.CefFrame;
 import org.cef.browser.CefMessageRouter;
+import org.cef.callback.CefQueryCallback;
 import org.cef.handler.CefDisplayHandlerAdapter;
 import org.cef.handler.CefFocusHandlerAdapter;
 import org.cef.handler.CefLifeSpanHandlerAdapter;
 import org.cef.handler.CefLoadHandler;
 import org.cef.handler.CefLoadHandlerAdapter;
+import org.cef.handler.CefMessageRouterHandlerAdapter;
 import org.cef.handler.CefRequestHandler;
 import org.cef.handler.CefRequestHandlerAdapter;
 import org.json.JSONObject;
@@ -140,7 +142,35 @@ public class BrowserFrame extends JFrame {
     client_ = cefApp_.createClient();
 
     // (3) Create a simple message router to receive messages from CEF.
-    CefMessageRouter msgRouter = CefMessageRouter.create();
+    CefMessageRouter msgRouter =
+        CefMessageRouter.create(
+            new CefMessageRouterHandlerAdapter() {
+              @Override
+              public boolean onQuery(
+                  CefBrowser browser,
+                  CefFrame frame,
+                  long queryId,
+                  String request,
+                  boolean persistent,
+                  CefQueryCallback callback) {
+                if (request != null && request.startsWith("yikeUnite:")) {
+                  // 立即回调，绝不在 CEF UI 线程里做解析/Swing/IO，否则消息队列堵了会拖死整个进程
+                  if (callback != null) callback.success("");
+                  final String payload = request.substring("yikeUnite:".length());
+                  YikeQueryWorker.submit(
+                      () -> {
+                        try {
+                          if (LizzieFrame.onlineDialog != null) {
+                            LizzieFrame.onlineDialog.handleYikeUniteSgf(payload);
+                          }
+                        } catch (Throwable ignored) {
+                        }
+                      });
+                  return true;
+                }
+                return false;
+              }
+            });
     client_.addMessageRouter(msgRouter);
 
     client_.addLoadHandler(
@@ -445,5 +475,121 @@ public class BrowserFrame extends JFrame {
             setFrameSize();
           }
         });
+  }
+
+  /**
+   * 在已加载的弈客对弈页面里被动 hook fetch/XHR：第一次抓到 game-server.yikeweiqi.com/game/info 的请求时 完整捕获请求（fetch 路径捕获
+   * Request 对象，XHR 路径捕获 method/url/headers/body），之后每 intervalMs 用 同样方式重发，把响应通过 cefQuery 回传
+   * Java。借用弈客网页自己的鉴权，不用关心 token / CORS。
+   */
+  public void installYikeUnitePoller(long roomId, int intervalMs) {
+    int periodMs = Math.max(500, intervalMs);
+    String js =
+        "(function(){"
+            + "var ROOM='"
+            + roomId
+            + "';"
+            + "var PERIOD="
+            + periodMs
+            + ";"
+            + "var send=function(tag,body){try{window.cefQuery({request:'yikeUnite:'+"
+            + "JSON.stringify({tag:tag,body:body}),persistent:false,"
+            + "onSuccess:function(){},onFailure:function(){}});}catch(e){}};"
+            + "var matchHttp=function(u){return typeof u==='string' && u.indexOf('game-server.yikeweiqi.com/game/info')>=0;};"
+            + "if(window.__yikeUnitePoller){clearInterval(window.__yikeUnitePoller);window.__yikeUnitePoller=null;}"
+            + "var origFetch=window.__yikeUniteOrigFetch||window.fetch;"
+            + "window.__yikeUniteOrigFetch=origFetch;"
+            + "var XO=window.XMLHttpRequest;"
+            + "var origXOpen=window.__yikeUniteOrigXOpen||(XO&&XO.prototype.open);"
+            + "var origXSend=window.__yikeUniteOrigXSend||(XO&&XO.prototype.send);"
+            + "var origXSetHdr=window.__yikeUniteOrigXSetHdr||(XO&&XO.prototype.setRequestHeader);"
+            + "window.__yikeUniteOrigXOpen=origXOpen;window.__yikeUniteOrigXSend=origXSend;"
+            + "window.__yikeUniteOrigXSetHdr=origXSetHdr;"
+            + "var deliverResp=function(url,status,text){"
+            + "send('resp',{url:url,status:status,len:text.length,body:text.substring(0,500000)});};"
+            + "var poll=function(){"
+            + "var saved=window.__yikeUniteSaved;if(!saved)return;"
+            + "if(saved.kind==='fetch'){try{"
+            + "var req=saved.req.clone();"
+            + "origFetch(req).then(function(r){return r.clone().text().then(function(t){"
+            + "deliverResp(saved.url,r.status,t);});}).catch(function(e){send('error','poll fetch: '+e);});"
+            + "}catch(e){send('error','poll fetch throw: '+e);}}"
+            + "else if(saved.kind==='xhr'){try{"
+            + "var x=new XO();"
+            + "origXOpen.call(x,saved.method||'GET',saved.url,true);"
+            + "if(saved.headers){for(var k in saved.headers){try{origXSetHdr.call(x,k,saved.headers[k]);}catch(e){}}}"
+            + "x.addEventListener('load',function(){deliverResp(saved.url,x.status,x.responseText||'');});"
+            + "x.addEventListener('error',function(){send('error','poll xhr: network');});"
+            + "origXSend.call(x,saved.body||null);"
+            + "}catch(e){send('error','poll xhr throw: '+e);}}"
+            + "};"
+            + "var startPolling=function(){"
+            + "if(window.__yikeUnitePoller)return;"
+            + "send('ping','start polling kind='+window.__yikeUniteSaved.kind+' url='+window.__yikeUniteSaved.url+' period='+PERIOD);"
+            + "window.__yikeUnitePoller=setInterval(poll,PERIOD);"
+            + "};"
+            + "if(window.__yikeUniteHookInstalled){"
+            + "send('ping','hook already installed');"
+            + "if(window.__yikeUniteSaved)startPolling();"
+            + "return;}"
+            + "window.__yikeUniteHookInstalled=true;"
+            + "send('ping','installing hook for room='+ROOM);"
+            + "window.fetch=function(input,init){"
+            + "var url=typeof input==='string'?input:(input&&input.url);"
+            + "var p=origFetch.apply(this,arguments);"
+            + "if(matchHttp(url)){"
+            + "p.then(function(r){r.clone().text().then(function(t){"
+            + "deliverResp(url,r.status,t);"
+            + "if(!window.__yikeUniteSaved){"
+            + "try{var req;"
+            + "if(input&&typeof input!=='string'&&typeof input.clone==='function'){req=input.clone();}"
+            + "else if(typeof Request!=='undefined'){req=new Request(url,init||{});}"
+            + "if(req){window.__yikeUniteSaved={kind:'fetch',url:url,req:req};startPolling();}"
+            + "}catch(e){send('error','save fetch: '+e);}"
+            + "}"
+            + "}).catch(function(){});}).catch(function(){});}"
+            + "return p;};"
+            + "if(XO&&XO.prototype){"
+            + "XO.prototype.open=function(m,u){this.__yikeUrl=u;this.__yikeMethod=m;this.__yikeHdrs={};return origXOpen.apply(this,arguments);};"
+            + "XO.prototype.setRequestHeader=function(k,v){try{this.__yikeHdrs=this.__yikeHdrs||{};this.__yikeHdrs[k]=v;}catch(e){}return origXSetHdr.apply(this,arguments);};"
+            + "XO.prototype.send=function(body){var x=this;x.__yikeBody=body;"
+            + "x.addEventListener('load',function(){try{if(matchHttp(x.__yikeUrl)){"
+            + "deliverResp(x.__yikeUrl,x.status,x.responseText||'');"
+            + "if(!window.__yikeUniteSaved){"
+            + "window.__yikeUniteSaved={kind:'xhr',url:x.__yikeUrl,method:x.__yikeMethod||'GET',"
+            + "headers:x.__yikeHdrs||{},body:x.__yikeBody};"
+            + "startPolling();}}}catch(e){}});"
+            + "return origXSend.apply(this,arguments);};}"
+            // -- WebSocket hook: 弈客通过 WS 推送落子，收到任何消息立刻触发一次 fetch
+            + "var WSO=window.__yikeUniteOrigWS||window.WebSocket;"
+            + "window.__yikeUniteOrigWS=WSO;"
+            + "if(WSO && !window.__yikeUniteWSHook){window.__yikeUniteWSHook=true;"
+            + "var WSP=function(url,protocols){"
+            + "var ws=protocols?new WSO(url,protocols):new WSO(url);"
+            + "var u=String(url);"
+            + "if(u.indexOf('yikeweiqi.com')>=0){"
+            + "send('ping','ws-open '+u);"
+            + "ws.addEventListener('message',function(){"
+            + "if(window.__yikeUniteSaved){"
+            + "if(window.__yikeUniteWsDebounce)clearTimeout(window.__yikeUniteWsDebounce);"
+            + "window.__yikeUniteWsDebounce=setTimeout(function(){poll();},80);"
+            + "}});}"
+            + "return ws;};"
+            + "WSP.prototype=WSO.prototype;WSP.CONNECTING=WSO.CONNECTING;WSP.OPEN=WSO.OPEN;"
+            + "WSP.CLOSING=WSO.CLOSING;WSP.CLOSED=WSO.CLOSED;"
+            + "window.WebSocket=WSP;"
+            + "}"
+            + "})();";
+    browser_.executeJavaScript(js, browser_.getURL(), 0);
+  }
+
+  public void stopYikeUnitePoller() {
+    String js =
+        "if(window.__yikeUnitePoller){clearInterval(window.__yikeUnitePoller);"
+            + "window.__yikeUnitePoller=null;}"
+            + "if(window.__yikeUniteWsDebounce){clearTimeout(window.__yikeUniteWsDebounce);"
+            + "window.__yikeUniteWsDebounce=null;}"
+            + "window.__yikeUniteSaved=null;";
+    browser_.executeJavaScript(js, browser_.getURL(), 0);
   }
 }

--- a/src/main/java/featurecat/lizzie/gui/ConfigDialog2.java
+++ b/src/main/java/featurecat/lizzie/gui/ConfigDialog2.java
@@ -281,6 +281,7 @@ public class ConfigDialog2 extends JDialog {
   private JCheckBox chkFastSwtich;
   private JCheckBox chkPonder;
   private JCheckBox chkStopAtEmpty;
+  private JCheckBox chkEnableStartupBenchmark;
 
   private JCheckBox chkUseScoreDiff;
   private JTextField txtPercentScoreDiff;
@@ -291,7 +292,7 @@ public class ConfigDialog2 extends JDialog {
     setModalityType(ModalityType.APPLICATION_MODAL);
     // setType(Type.POPUP);
     // setBounds(100, 100, 890, 834);
-    Lizzie.setFrameSize(this, 890, 855);
+    Lizzie.setFrameSize(this, 890, 885);
     try {
       setIconImage(ImageIO.read(getClass().getResourceAsStream("/assets/logo.png")));
     } catch (IOException e) {
@@ -1924,6 +1925,16 @@ public class ConfigDialog2 extends JDialog {
     chkLogGtpToFile.setToolTipText(
         resourceBundle.getString("LizzieConfig.lblLogGtpToFile.tooltips"));
     chkLogGtpToFile.setSelected(Lizzie.config.logGtpToFile);
+
+    JLabel lblEnableStartupBenchmark =
+        new JLabel(resourceBundle.getString("LizzieConfig.lblEnableStartupBenchmark"));
+    lblEnableStartupBenchmark.setBounds(10, 757, 205, 15);
+    uiTab.add(lblEnableStartupBenchmark);
+
+    chkEnableStartupBenchmark = new JCheckBox();
+    chkEnableStartupBenchmark.setBounds(215, 754, 26, 23);
+    uiTab.add(chkEnableStartupBenchmark);
+    chkEnableStartupBenchmark.setSelected(Lizzie.config.enableStartupBenchmark);
 
     chkPonder = new JCheckBox();
     chkPonder.setBounds(125, 497, 26, 23);
@@ -3763,6 +3774,8 @@ public class ConfigDialog2 extends JDialog {
     Lizzie.config.logGtpToFile = chkLogGtpToFile.isSelected();
     Lizzie.config.uiConfig.put("log-console-to-file", Lizzie.config.logConsoleToFile);
     Lizzie.config.uiConfig.put("log-gtp-to-file", Lizzie.config.logGtpToFile);
+    Lizzie.config.enableStartupBenchmark = chkEnableStartupBenchmark.isSelected();
+    Lizzie.config.uiConfig.put("enable-startup-benchmark", Lizzie.config.enableStartupBenchmark);
     if (rdoLastMark.isSelected()) {
       int lastRankMove = Utils.parseTextToInt(txtLastMark, 1);
       Lizzie.config.moveRankMarkLastMove = lastRankMove;

--- a/src/main/java/featurecat/lizzie/gui/OnlineDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/OnlineDialog.java
@@ -86,6 +86,7 @@ public class OnlineDialog extends JDialog {
   private JTextField txtUrl;
   private String ajaxUrl = "";
   private String lastYikeMainlineSgf = "";
+  private int lastYikeHandsCount = -1;
   private Map queryMap = null;
   private String query = "";
   private String whitePlayer = "";
@@ -474,6 +475,7 @@ public class OnlineDialog extends JDialog {
     done = false;
     history = null;
     lastYikeMainlineSgf = "";
+    lastYikeHandsCount = -1;
     Lizzie.board.clearForOnline();
     switch (type) {
       case 1:
@@ -501,9 +503,7 @@ public class OnlineDialog extends JDialog {
         reqNewYikeRoom(true);
         break;
       case 7:
-        // TODO: 弈客对弈房间（unite/<id>）需要从 JCEF 内嵌浏览器读取 game-server API 的 JWT token
-        // 才能调 https://game-server.yikeweiqi.com/game/info?id=<roomId>。当前未实现。
-        yikeDebugLog("type=7 (UNITE_ROOM) not yet implemented");
+        startYikeUnitePolling();
         break;
       case 2:
         refresh("(?s).*?(\\\"Content\\\":\\\")(.+)(\\\",\\\")(?s).*");
@@ -537,7 +537,7 @@ public class OnlineDialog extends JDialog {
   }
 
   private boolean shouldReplaceYikeMainline() {
-    return type == YikeUrlInfo.TYPE_NEW_LIVE_ROOM;
+    return type == YikeUrlInfo.TYPE_NEW_LIVE_ROOM || type == YikeUrlInfo.TYPE_UNITE_ROOM;
   }
 
   @SuppressWarnings("deprecation")
@@ -2607,9 +2607,11 @@ public class OnlineDialog extends JDialog {
     sendYikeContextToReadBoard();
   }
 
+  private static final boolean YIKE_DEBUG_LOG_ENABLED = false;
   private static final String YIKE_LOG_PATH = "D:/dev/weiqi/lizzieyzy-next/target/yike-debug.log";
 
   private static void yikeDebugLog(String msg) {
+    if (!YIKE_DEBUG_LOG_ENABLED) return;
     try {
       java.io.FileWriter fw = new java.io.FileWriter(YIKE_LOG_PATH, true);
       fw.write(
@@ -2641,6 +2643,90 @@ public class OnlineDialog extends JDialog {
       Lizzie.frame.readBoard.sendCommand(cmd);
     } catch (Exception e) {
       yikeDebugLog("sendYike error: " + e.toString());
+    }
+  }
+
+  private void startYikeUnitePolling() {
+    if (roomId <= 0) {
+      yikeDebugLog("startYikeUnitePolling: roomId<=0");
+      return;
+    }
+    if (Lizzie.frame.browserFrame == null) {
+      yikeDebugLog("startYikeUnitePolling: browserFrame is null");
+      return;
+    }
+    int intervalMs = Math.max(refreshTime, 5) * 1000;
+    yikeDebugLog("startYikeUnitePolling room=" + roomId + " intervalMs=" + intervalMs);
+    Lizzie.frame.browserFrame.installYikeUnitePoller(roomId, intervalMs);
+  }
+
+  /** 由 BrowserFrame 在浏览器内 fetch game-server API 后通过 cefQuery 回传调用。 */
+  public void handleYikeUniteSgf(String envelope) {
+    if (envelope == null || envelope.isEmpty()) return;
+    yikeDebugLog(
+        "handleYikeUniteSgf envelope len="
+            + envelope.length()
+            + " head="
+            + envelope.substring(0, Math.min(envelope.length(), 200)));
+    try {
+      JSONObject env = new JSONObject(envelope);
+      String tag = env.optString("tag");
+      if ("ping".equals(tag)) {
+        yikeDebugLog("yikeUnite ping: " + env.optString("body"));
+        return;
+      }
+      if ("error".equals(tag)) {
+        yikeDebugLog("yikeUnite fetch error: " + env.optString("body"));
+        return;
+      }
+      if (!"resp".equals(tag)) {
+        yikeDebugLog("yikeUnite unknown tag=" + tag);
+        return;
+      }
+      if (isStoped || type != YikeUrlInfo.TYPE_UNITE_ROOM) {
+        yikeDebugLog("yikeUnite resp skipped (isStoped=" + isStoped + " type=" + type + ")");
+        return;
+      }
+      JSONObject body = env.optJSONObject("body");
+      if (body == null) {
+        yikeDebugLog("yikeUnite resp has no body");
+        return;
+      }
+      int status = body.optInt("status", -1);
+      String text = body.optString("body", "");
+      yikeDebugLog("yikeUnite resp status=" + status + " len=" + body.optInt("len"));
+      if (status != 200 || Utils.isBlank(text)) return;
+      JSONObject root = new JSONObject(text);
+      JSONObject data = root.optJSONObject("data");
+      if (data == null) {
+        yikeDebugLog("yikeUnite resp: no data field, root keys=" + root.keySet());
+        return;
+      }
+      String sgf = data.optString("sgf");
+      if (Utils.isBlank(sgf)) {
+        yikeDebugLog("yikeUnite resp: sgf is blank");
+        return;
+      }
+      // 用 hands_count 做主去重：弈客 game/info 里 hands_count 直接给当前手数，比字符串比较快
+      int hands = data.optInt("hands_count", -1);
+      if (hands >= 0 && hands == lastYikeHandsCount) {
+        return; // 没有新走子
+      }
+      String mainlineSgf = YikeSgfMainline.withoutVariations(sgf);
+      boolean hasNewMoves = !mainlineSgf.equals(lastYikeMainlineSgf);
+      if (!hasNewMoves) {
+        if (hands >= 0) lastYikeHandsCount = hands;
+        return;
+      }
+      lastYikeMainlineSgf = mainlineSgf;
+      if (hands >= 0) lastYikeHandsCount = hands;
+      JSONObject wrapper = new JSONObject();
+      wrapper.put("result", data);
+      parseSgf(wrapper.toString(), "", 0, false, firstTime);
+    } catch (JSONException e) {
+      yikeDebugLog("handleYikeUniteSgf JSON error: " + e.toString());
+    } catch (RuntimeException e) {
+      yikeDebugLog("handleYikeUniteSgf error: " + e.toString());
     }
   }
 
@@ -2877,6 +2963,12 @@ public class OnlineDialog extends JDialog {
     isStoped = true;
     if (schedule != null && !schedule.isCancelled() && !schedule.isDone()) {
       schedule.cancel(false);
+    }
+    if (Lizzie.frame.browserFrame != null) {
+      try {
+        Lizzie.frame.browserFrame.stopYikeUnitePoller();
+      } catch (Exception ignored) {
+      }
     }
     //    if (client != null && client.isOpen()) {
     //      client.close();

--- a/src/main/java/featurecat/lizzie/gui/OnlineDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/OnlineDialog.java
@@ -697,6 +697,13 @@ public class OnlineDialog extends JDialog {
       ;
     while (liveNode.next(true).isPresent())
       ;
+    if (type == YikeUrlInfo.TYPE_UNITE_ROOM) {
+      if (isUserExploringVariation()) {
+        appendNewMainlineMovesPreservingHead(liveNode);
+        return;
+      }
+      preserveUserBranchesOnto(liveNode);
+    }
     Lizzie.board.setHistory(liveNode);
     Lizzie.board.getHistory().getGameInfo().setPlayerBlack(blackPlayer);
     Lizzie.board.getHistory().getGameInfo().setPlayerWhite(whitePlayer);
@@ -726,6 +733,68 @@ public class OnlineDialog extends JDialog {
     firstTime = false;
     Lizzie.frame.refresh();
     sendYikeContextToReadBoard(liveNode != null ? liveNode.getMoveNumber() : 0);
+  }
+
+  /** 把用户在主线节点上摆出的"变化分支"按手数搬到新 liveNode 主线对应节点上，避免每次同步丢失复盘分支。 */
+  private void preserveUserBranchesOnto(BoardHistoryList liveNode) {
+    BoardHistoryList current = Lizzie.board.getHistory();
+    if (current == null || liveNode == null) return;
+    BoardHistoryNode curHead = current.getCurrentHistoryNode();
+    if (curHead == null) return;
+    while (curHead.previous().isPresent()) curHead = curHead.previous().get();
+    BoardHistoryNode liveHead = liveNode.getCurrentHistoryNode();
+    if (liveHead == null) return;
+    while (liveHead.previous().isPresent()) liveHead = liveHead.previous().get();
+
+    Map<Integer, BoardHistoryNode> liveByMove = new HashMap<>();
+    for (BoardHistoryNode n = liveHead; n != null; n = n.next(true).orElse(null)) {
+      liveByMove.put(n.getData().moveNumber, n);
+    }
+
+    for (BoardHistoryNode old = curHead; old != null; old = old.next(true).orElse(null)) {
+      if (old.numberOfChildren() <= 1) continue;
+      BoardHistoryNode liveAtSameMove = liveByMove.get(old.getData().moveNumber);
+      if (liveAtSameMove == null) continue;
+      for (int i = 1; i < old.numberOfChildren(); i++) {
+        BoardHistoryNode branch = old.getVariation(i).orElse(null);
+        if (branch != null) branch.reparentAsLastVariationOf(liveAtSameMove);
+      }
+    }
+  }
+
+  /** 用户当前是否在试下变化：head 不在主线，或在主线但已往前翻过棋。试下时直接 setHistory 会拉走视图，所以走 append 路径。 */
+  private boolean isUserExploringVariation() {
+    BoardHistoryList current = Lizzie.board.getHistory();
+    if (current == null) return false;
+    BoardHistoryNode head = current.getCurrentHistoryNode();
+    if (head == null) return false;
+    if (!head.isMainTrunk()) return true;
+    return head.next(true).isPresent();
+  }
+
+  /** 试下时不动 head，只把 liveNode 主线上多出的手数克隆挂到现有主线末尾，用户回到末尾就能看到新走子。 */
+  private void appendNewMainlineMovesPreservingHead(BoardHistoryList liveNode) {
+    BoardHistoryList current = Lizzie.board.getHistory();
+    if (current == null || liveNode == null) return;
+    BoardHistoryNode curHead = current.getCurrentHistoryNode();
+    if (curHead == null) return;
+    BoardHistoryNode tail = curHead.getLast();
+    int existingTailMove = tail.getData().moveNumber;
+    BoardHistoryNode liveTail = liveNode.getCurrentHistoryNode();
+    while (liveTail != null && liveTail.getData().moveNumber > existingTailMove + 1) {
+      liveTail = liveTail.previous().orElse(null);
+    }
+    java.util.Deque<BoardHistoryNode> toAppend = new java.util.ArrayDeque<>();
+    for (BoardHistoryNode c = liveTail;
+        c != null && c.getData().moveNumber > existingTailMove;
+        c = c.previous().orElse(null)) {
+      toAppend.push(c);
+    }
+    for (BoardHistoryNode src : toAppend) {
+      BoardHistoryNode newNode = new BoardHistoryNode(src.getData().clone());
+      newNode.reparentAsFirstVariationOf(tail);
+      tail = newNode;
+    }
   }
 
   public void get() throws IOException {
@@ -2629,6 +2698,12 @@ public class OnlineDialog extends JDialog {
     sendYikeContextToReadBoard(history != null ? history.getMoveNumber() : 0);
   }
 
+  private void reportSyncStatus(String text) {
+    if (Lizzie.frame != null && Lizzie.frame.browserFrame != null) {
+      Lizzie.frame.browserFrame.setSyncStatus(text);
+    }
+  }
+
   private void sendYikeContextToReadBoard(int moveNumber) {
     try {
       if (Lizzie.frame == null || Lizzie.frame.readBoard == null) {
@@ -2677,6 +2752,7 @@ public class OnlineDialog extends JDialog {
       }
       if ("error".equals(tag)) {
         yikeDebugLog("yikeUnite fetch error: " + env.optString("body"));
+        reportSyncStatus("拉取异常: " + env.optString("body"));
         return;
       }
       if (!"resp".equals(tag)) {
@@ -2695,7 +2771,11 @@ public class OnlineDialog extends JDialog {
       int status = body.optInt("status", -1);
       String text = body.optString("body", "");
       yikeDebugLog("yikeUnite resp status=" + status + " len=" + body.optInt("len"));
-      if (status != 200 || Utils.isBlank(text)) return;
+      if (status != 200) {
+        reportSyncStatus("game-server 响应 HTTP " + status);
+        return;
+      }
+      if (Utils.isBlank(text)) return;
       JSONObject root = new JSONObject(text);
       JSONObject data = root.optJSONObject("data");
       if (data == null) {
@@ -2723,10 +2803,13 @@ public class OnlineDialog extends JDialog {
       JSONObject wrapper = new JSONObject();
       wrapper.put("result", data);
       parseSgf(wrapper.toString(), "", 0, false, firstTime);
+      reportSyncStatus(syncStatusPrefix() + "第 " + (hands >= 0 ? hands : "?") + " 手");
     } catch (JSONException e) {
       yikeDebugLog("handleYikeUniteSgf JSON error: " + e.toString());
+      reportSyncStatus("解析响应失败: " + e.getMessage());
     } catch (RuntimeException e) {
       yikeDebugLog("handleYikeUniteSgf error: " + e.toString());
+      reportSyncStatus("处理响应异常: " + e.getMessage());
     }
   }
 
@@ -2990,6 +3073,7 @@ public class OnlineDialog extends JDialog {
       sio.close();
     }
     setVisible(false);
+    reportSyncStatus("已停止同步");
     //  Lizzie.frame.onlineDialog.dispose();
   }
 
@@ -3009,11 +3093,35 @@ public class OnlineDialog extends JDialog {
       try {
         Lizzie.frame.setResult("");
         proc();
+        reportSyncStatus(syncStatusPrefix() + "已启动");
       } catch (IOException | URISyntaxException e) {
         e.printStackTrace();
+        reportSyncStatus("同步启动失败: " + e.getMessage());
       }
     } else {
-      // error(true);
+      reportSyncStatus("URL 无法识别");
     }
+  }
+
+  private String syncStatusPrefix() {
+    String label;
+    switch (type) {
+      case YikeUrlInfo.TYPE_UNITE_ROOM:
+        label = "弈客对弈";
+        break;
+      case YikeUrlInfo.TYPE_NEW_LIVE_ROOM:
+        label = "弈客直播(新)";
+        break;
+      case YikeUrlInfo.TYPE_OLD_LIVE_ROOM:
+      case YikeUrlInfo.TYPE_OLD_LIVE_BOARD:
+        label = "弈客直播";
+        break;
+      case YikeUrlInfo.TYPE_GAME_ROOM:
+        label = "弈客对局";
+        break;
+      default:
+        label = "同步";
+    }
+    return roomId > 0 ? label + " 房间 " + roomId + " " : label + " ";
   }
 }

--- a/src/main/java/featurecat/lizzie/gui/OnlineDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/OnlineDialog.java
@@ -136,6 +136,7 @@ public class OnlineDialog extends JDialog {
 
   public OnlineDialog(Window owner) {
     super(owner);
+    yikeDebugLog("OnlineDialog created");
     setTitle(resourceBundle.getString("OnlineDialog.title.config"));
     setModalityType(ModalityType.APPLICATION_MODAL);
     setAlwaysOnTop(Lizzie.frame.isAlwaysOnTop());
@@ -346,7 +347,8 @@ public class OnlineDialog extends JDialog {
     return type == YikeUrlInfo.TYPE_OLD_LIVE_ROOM
         || type == YikeUrlInfo.TYPE_OLD_LIVE_BOARD
         || type == YikeUrlInfo.TYPE_GAME_ROOM
-        || type == YikeUrlInfo.TYPE_NEW_LIVE_ROOM;
+        || type == YikeUrlInfo.TYPE_NEW_LIVE_ROOM
+        || type == YikeUrlInfo.TYPE_UNITE_ROOM;
   }
 
   private String currentYikeSourceUrl() {
@@ -498,6 +500,11 @@ public class OnlineDialog extends JDialog {
       case 6:
         reqNewYikeRoom(true);
         break;
+      case 7:
+        // TODO: 弈客对弈房间（unite/<id>）需要从 JCEF 内嵌浏览器读取 game-server API 的 JWT token
+        // 才能调 https://game-server.yikeweiqi.com/game/info?id=<roomId>。当前未实现。
+        yikeDebugLog("type=7 (UNITE_ROOM) not yet implemented");
+        break;
       case 2:
         refresh("(?s).*?(\\\"Content\\\":\\\")(.+)(\\\",\\\")(?s).*");
         break;
@@ -525,7 +532,8 @@ public class OnlineDialog extends JDialog {
     return type == YikeUrlInfo.TYPE_OLD_LIVE_ROOM
         || type == YikeUrlInfo.TYPE_OLD_LIVE_BOARD
         || type == YikeUrlInfo.TYPE_GAME_ROOM
-        || type == YikeUrlInfo.TYPE_NEW_LIVE_ROOM;
+        || type == YikeUrlInfo.TYPE_NEW_LIVE_ROOM
+        || type == YikeUrlInfo.TYPE_UNITE_ROOM;
   }
 
   private boolean shouldReplaceYikeMainline() {
@@ -617,6 +625,7 @@ public class OnlineDialog extends JDialog {
           return;
         }
         int diffMove = Lizzie.board.getHistory().sync(liveNode);
+        sendYikeContextToReadBoard(liveNode != null ? liveNode.getMoveNumber() : 0);
         if (diffMove >= 0) {
           //     Lizzie.board.goToMoveNumberBeyondBranch(diffMove > 0 ? diffMove - 1 : 0);
           //    while (Lizzie.board.nextMove()) ;
@@ -716,6 +725,7 @@ public class OnlineDialog extends JDialog {
     }
     firstTime = false;
     Lizzie.frame.refresh();
+    sendYikeContextToReadBoard(liveNode != null ? liveNode.getMoveNumber() : 0);
   }
 
   public void get() throws IOException {
@@ -2224,19 +2234,21 @@ public class OnlineDialog extends JDialog {
   }
 
   public void req2(boolean clear) throws URISyntaxException {
+    yikeDebugLog("req2 start, clear=" + clear);
     if (clear) Lizzie.board.clearForOnline();
     if (sio != null) {
       sio.close();
     }
     seqs = 0;
     URI uri = new URI(new String(c1));
+    yikeDebugLog("req2 uri=" + uri);
     sio = IO.socket(uri);
     sio.on(
             Socket.EVENT_CONNECT,
             new Emitter.Listener() {
               @Override
               public void call(Object... args) {
-                // System.out.println("io:connect");
+                yikeDebugLog("Socket.IO connected");
                 login();
               }
             })
@@ -2285,7 +2297,9 @@ public class OnlineDialog extends JDialog {
             new Emitter.Listener() {
               @Override
               public void call(Object... args) {
-                // System.out.println("io:EVENT_CONNECT_ERROR");
+                yikeDebugLog(
+                    "Socket.IO connect error: "
+                        + (args == null || args.length == 0 ? "?" : String.valueOf(args[0])));
               }
             })
         .on(
@@ -2293,7 +2307,7 @@ public class OnlineDialog extends JDialog {
             new Emitter.Listener() {
               @Override
               public void call(Object... args) {
-                // System.out.println("io:EVENT_CONNECT_TIMEOUT");
+                yikeDebugLog("Socket.IO connect timeout");
               }
             })
         .on(
@@ -2375,7 +2389,8 @@ public class OnlineDialog extends JDialog {
             new Emitter.Listener() {
               @Override
               public void call(Object... args) {
-                // System.out.println("io:init:" + strJson(args));
+                yikeDebugLog(
+                    "Socket.IO init event received, args=" + (args == null ? "null" : args.length));
                 initData(args == null || args.length < 1 ? null : ((JSONObject) args[0]));
               }
             })
@@ -2469,6 +2484,7 @@ public class OnlineDialog extends JDialog {
   }
 
   private void initData(JSONObject data) {
+    yikeDebugLog("initData called, data=" + (data == null ? "null" : "present"));
     if (data == null) return;
     JSONObject info = data.optJSONObject("game_info");
     int size = info.optInt("boardSize", 19);
@@ -2492,6 +2508,7 @@ public class OnlineDialog extends JDialog {
       }
       Lizzie.board.getHistory().getGameInfo().setHandicap(handicap);
       int diffMove = Lizzie.board.getHistory().sync(history);
+      sendYikeContextToReadBoard();
       if (diffMove >= 0) {
         //      Lizzie.board.goToMoveNumberBeyondBranch(diffMove > 0 ? diffMove - 1 : 0);
         //      while (Lizzie.board.nextMove()) ;
@@ -2512,7 +2529,7 @@ public class OnlineDialog extends JDialog {
     if (history == null) {
       //      error(true);
       sio.close();
-      if (isEnd && type == 1) {
+      if (isEnd && (type == 1 || type == 5)) {
         try {
           refresh("(?s).*?(\\\"Content\\\":\\\")(.+)(\\\",\\\")(?s).*", 2, false, false);
         } catch (IOException e) {
@@ -2583,9 +2600,48 @@ public class OnlineDialog extends JDialog {
   }
 
   void sync() {
+    if (history == null) return;
     while (history.previous().isPresent())
       ;
     Lizzie.board.getHistory().sync(history);
+    sendYikeContextToReadBoard();
+  }
+
+  private static final String YIKE_LOG_PATH = "D:/dev/weiqi/lizzieyzy-next/target/yike-debug.log";
+
+  private static void yikeDebugLog(String msg) {
+    try {
+      java.io.FileWriter fw = new java.io.FileWriter(YIKE_LOG_PATH, true);
+      fw.write(
+          "["
+              + new java.text.SimpleDateFormat("HH:mm:ss.SSS").format(new java.util.Date())
+              + "] "
+              + msg
+              + "\n");
+      fw.close();
+    } catch (Exception ignored) {
+    }
+  }
+
+  private void sendYikeContextToReadBoard() {
+    sendYikeContextToReadBoard(history != null ? history.getMoveNumber() : 0);
+  }
+
+  private void sendYikeContextToReadBoard(int moveNumber) {
+    try {
+      if (Lizzie.frame == null || Lizzie.frame.readBoard == null) {
+        yikeDebugLog("sendYike: readBoard is null");
+        return;
+      }
+      StringBuilder sb = new StringBuilder("yike");
+      if (roomId > 0) sb.append(" room=").append(roomId);
+      if (moveNumber > 0) sb.append(" move=").append(moveNumber);
+      String cmd = sb.toString();
+      yikeDebugLog("sendYike: " + cmd);
+      Lizzie.frame.readBoard.sendCommand(cmd);
+    } catch (Exception e) {
+      yikeDebugLog("sendYike error: " + e.toString());
+    }
   }
 
   private void procComments(JSONObject cb) {
@@ -2676,7 +2732,7 @@ public class OnlineDialog extends JDialog {
   }
 
   private void move(JSONObject d) {
-    if (d == null || d.opt("move") == null) return;
+    if (d == null || d.opt("move") == null || history == null) return;
     JSONObject m = (JSONObject) d.get("move");
     int move = m.optInt("mcnt");
     if (move > 0) {
@@ -2846,12 +2902,14 @@ public class OnlineDialog extends JDialog {
   }
 
   public void applyChangeWeb(String url) {
+    yikeDebugLog("applyChangeWeb url=" + url);
     //
     isStoped = false;
     fromBrowser = true;
     firstTime = true;
     txtUrl.setText(url);
     type = checkUrl();
+    yikeDebugLog("applyChangeWeb type=" + type);
     LizzieFrame.urlSgf = true;
     Lizzie.frame.setCommentPaneOrArea(false);
     if (type > 0) {

--- a/src/main/java/featurecat/lizzie/gui/YikeQueryWorker.java
+++ b/src/main/java/featurecat/lizzie/gui/YikeQueryWorker.java
@@ -1,0 +1,42 @@
+package featurecat.lizzie.gui;
+
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * 单线程后台 worker，专门跑从 CEF onQuery 派发过来的弈客消息处理。
+ *
+ * <p>用 LinkedBlockingDeque + 限长 + 抛弃最旧策略，避免下游慢时无限堆积拖死 EDT。
+ */
+final class YikeQueryWorker {
+  private static final int CAPACITY = 64;
+
+  private static final ThreadPoolExecutor EXEC =
+      new ThreadPoolExecutor(
+          1,
+          1,
+          0L,
+          TimeUnit.MILLISECONDS,
+          new LinkedBlockingDeque<>(CAPACITY),
+          r -> {
+            Thread t = new Thread(r, "yike-query-worker");
+            t.setDaemon(true);
+            return t;
+          },
+          (r, ex) -> {
+            // 队列满：丢掉最旧的一个，再塞新的
+            LinkedBlockingDeque<Runnable> q = (LinkedBlockingDeque<Runnable>) ex.getQueue();
+            q.pollFirst();
+            q.offer(r);
+          });
+
+  static void submit(Runnable r) {
+    try {
+      EXEC.execute(r);
+    } catch (Throwable ignored) {
+    }
+  }
+
+  private YikeQueryWorker() {}
+}

--- a/src/main/java/featurecat/lizzie/gui/YikeUrlInfo.java
+++ b/src/main/java/featurecat/lizzie/gui/YikeUrlInfo.java
@@ -5,6 +5,7 @@ public class YikeUrlInfo {
   public static final int TYPE_OLD_LIVE_BOARD = 2;
   public static final int TYPE_GAME_ROOM = 5;
   public static final int TYPE_NEW_LIVE_ROOM = 6;
+  public static final int TYPE_UNITE_ROOM = 7;
 
   private final int type;
   private final String id;

--- a/src/main/java/featurecat/lizzie/gui/YikeUrlParser.java
+++ b/src/main/java/featurecat/lizzie/gui/YikeUrlParser.java
@@ -21,6 +21,8 @@ public class YikeUrlParser {
           "https*://(?s).*?([^\\./]+\\.[^\\./]+)/(?s).*?(game/[a-zA-Z]+/)[0-9]+/([^/\\s]+)");
   private static final Pattern HALL_ROOM =
       Pattern.compile("https*://(?s).*?([^\\./]+\\.[^\\./]+)/(?s).*?(room=)([0-9]+)(&hall)(?s).*?");
+  private static final Pattern UNITE_ROOM =
+      Pattern.compile("https*://(?s).*?([^\\./]+\\.[^\\./]+)/(?s).*?(unite/)([0-9]+)(?s).*?");
 
   public static Optional<YikeUrlInfo> parse(String rawUrl) {
     if (Utils.isBlank(rawUrl)) return Optional.empty();
@@ -106,6 +108,21 @@ public class YikeUrlParser {
                 matcher.group(3),
                 roomId,
                 "https://api." + matcher.group(1) + "/golive/dtl?id=" + roomId));
+      }
+    }
+
+    matcher = UNITE_ROOM.matcher(url);
+    if (matcher.matches() && matcher.groupCount() >= 3) {
+      long roomId = parseLongOrDefault(matcher.group(3), 0);
+      if (roomId > 0) {
+        return Optional.of(
+            new YikeUrlInfo(
+                YikeUrlInfo.TYPE_UNITE_ROOM,
+                matcher.group(3),
+                roomId,
+                "https://game-server.yikeweiqi.com/game/info?id="
+                    + roomId
+                    + "&sgf_option=true&players_option=true&setting_option=true&clock_option=true&is_void=true"));
       }
     }
 

--- a/src/main/java/featurecat/lizzie/rules/BoardHistoryNode.java
+++ b/src/main/java/featurecat/lizzie/rules/BoardHistoryNode.java
@@ -256,6 +256,18 @@ public class BoardHistoryNode {
     return previous;
   }
 
+  /** 把已有节点重挂到新父节点末尾，维持父链一致。仅用于跨树搬运现成节点的特殊场景。 */
+  public void reparentAsLastVariationOf(BoardHistoryNode newParent) {
+    this.previous = Optional.of(newParent);
+    newParent.variations.add(this);
+  }
+
+  /** 把已有节点重挂为新父节点的主线（variations[0]），其它分支顺延。 */
+  public void reparentAsFirstVariationOf(BoardHistoryNode newParent) {
+    this.previous = Optional.of(newParent);
+    newParent.variations.add(0, this);
+  }
+
   public Optional<BoardHistoryNode> next() {
     return next(false);
   }

--- a/src/main/java/featurecat/lizzie/util/KataGoRuntimeHelper.java
+++ b/src/main/java/featurecat/lizzie/util/KataGoRuntimeHelper.java
@@ -1353,6 +1353,7 @@ public final class KataGoRuntimeHelper {
   public static void startFirstRunBenchmarkAsync() {
     if (Lizzie.config == null || Lizzie.config.uiConfig == null) return;
     if (isAppleSiliconHost()) return;
+    if (!Lizzie.config.enableStartupBenchmark) return;
     if (getStoredBenchmarkResult() != null) return;
 
     Thread worker =

--- a/src/main/resources/l10n/DisplayStrings.properties
+++ b/src/main/resources/l10n/DisplayStrings.properties
@@ -1122,6 +1122,7 @@ LizzieConfig.about.lblOriginTitle=<html><b>Project background</b></html>
 LizzieConfig.about.lblOriginLizzieInfo1=<html>LizzieYzy Next continues the Lizzie -> LizzieYzy line and keeps the project available for current users.<br /><br /><table><tr><td>Build ID:</td><td>
 LizzieConfig.about.lblOriginLizzieInfo2=</td></tr><tr><td>Maintainer:</td><td><a href=\"https://github.com/wimi321\">wimi321</a></td></tr><tr><td>Maintained fork:</td><td><a href=\"https://github.com/wimi321/lizzieyzy-next\">wimi321/lizzieyzy-next</a></td></tr><tr><td>Previous fork:</td><td><a href=\"https://github.com/yzyray/lizzieyzy\">yzyray/lizzieyzy</a></td></tr><tr><td>Original project:</td><td><a href=\"https://github.com/featurecat/lizzie\">featurecat/lizzie</a></td></tr><tr><td>License:</td><td><a href=\"https://github.com/wimi321/lizzieyzy-next/blob/main/LICENSE.txt\">GPL-3.0</a></td></tr></table></html>
 LizzieConfig.lblLogGtpToFile=Log GTP To File
+LizzieConfig.lblEnableStartupBenchmark=Enable Startup Benchmark
 LizzieConfig.lblLogGtpToFile.tooltips=Need restart,Log file is 'LastGtpLogs.txt' in Lizzie's folder.
 LizzieConfig.lblLogConsoleToFile=Log Console To Files
 LizzieConfig.lblLogConsoleToFile.tooltips=Need restart,Log files is 'LastConsoleLogs.txt' and 'LastErrorLogs.txt' in Lizzie's folder.

--- a/src/main/resources/l10n/DisplayStrings_en_US.properties
+++ b/src/main/resources/l10n/DisplayStrings_en_US.properties
@@ -1112,6 +1112,7 @@ LizzieConfig.about.lblOriginTitle=<html><b>Project background</b></html>
 LizzieConfig.about.lblOriginLizzieInfo1=<html>LizzieYzy Next continues the Lizzie -> LizzieYzy line and keeps the project available for current users.<br /><br /><table><tr><td>Build ID:</td><td>
 LizzieConfig.about.lblOriginLizzieInfo2=</td></tr><tr><td>Maintainer:</td><td><a href=\"https://github.com/wimi321\">wimi321</a></td></tr><tr><td>Maintained fork:</td><td><a href=\"https://github.com/wimi321/lizzieyzy-next\">wimi321/lizzieyzy-next</a></td></tr><tr><td>Previous fork:</td><td><a href=\"https://github.com/yzyray/lizzieyzy\">yzyray/lizzieyzy</a></td></tr><tr><td>Original project:</td><td><a href=\"https://github.com/featurecat/lizzie\">featurecat/lizzie</a></td></tr><tr><td>License:</td><td><a href=\"https://github.com/wimi321/lizzieyzy-next/blob/main/LICENSE.txt\">GPL-3.0</a></td></tr></table></html>
 LizzieConfig.lblLogGtpToFile=Log GTP To File
+LizzieConfig.lblEnableStartupBenchmark=Enable Startup Benchmark
 LizzieConfig.lblLogGtpToFile.tooltips=Need restart,Log file is 'LastGtpLogs.txt' in Lizzie's folder.
 LizzieConfig.lblLogConsoleToFile=Log Console To Files
 LizzieConfig.lblLogConsoleToFile.tooltips=Need restart,Log files is 'LastConsoleLogs.txt' and 'LastErrorLogs.txt' in Lizzie's folder.

--- a/src/main/resources/l10n/DisplayStrings_ja_JP.properties
+++ b/src/main/resources/l10n/DisplayStrings_ja_JP.properties
@@ -1398,6 +1398,7 @@ LizzieConfig.rdoShowMoveRect=\u8868\u793A
 LizzieConfig.rdoShowMoveRectOnPlay=\u5BFE\u5C40\u6642\u306E\u307F
 LizzieConfig.lblAlwaysLogGtpInfo=GTP\u60C5\u5831\u306E\u5370\u5B57
 LizzieConfig.lblLogGtpToFile=GTP\u60C5\u5831\u3092\u4FDD\u5B58
+LizzieConfig.lblEnableStartupBenchmark=\u8D77\u52D5\u6642\u306B\u81EA\u52D5\u30D9\u30F3\u30C1\u30DE\u30FC\u30AF
 LizzieConfig.showNameInboard=\u7881\u76E4\u306E\u4E0B\u90E8\u306B\u5BFE\u5C40\u8005\u540D\u3092\u8868\u793A
 LizzieConfig.lblLogGtpToFile.tooltips=\u8981\u518D\u8D77\u52D5\u3002\uFF9B\uFF78\uFF9E\uFF8C\uFF67\uFF72\uFF99\u306FLizzieyzy\uFF8C\uFF6B\uFF99\uFF80\uFF9E\u306E\u300CLastGtpLogs.txt\u300D\u3067\u3059\u3002
 LizzieConfig.lblLogConsoleToFile.tooltips=\u8981\u518D\u8D77\u52D5\u3002\uFF9B\uFF78\uFF9E\uFF8C\uFF67\uFF72\uFF99\u306FLizzieyzy\uFF8C\uFF6B\uFF99\uFF80\uFF9E\u306E\u300CLastConsoleLogs.txt\u300D\u3068\u300CLastErrorLogs.txt\u300D\u3067\u3059\u3002

--- a/src/main/resources/l10n/DisplayStrings_ko.properties
+++ b/src/main/resources/l10n/DisplayStrings_ko.properties
@@ -1005,6 +1005,7 @@ LizzieConfig.about.lblOriginTitle=<html><b>프로젝트 배경</b></html>
 LizzieConfig.about.lblOriginLizzieInfo1=<html>LizzieYzy Next는 Lizzie -> LizzieYzy 계보를 이어 받아 지금 사용자에게 필요한 기능, 배포판, 사용 경험을 계속 유지보수합니다.<br /><br /><table><tr><td>빌드 ID:</td><td>
 LizzieConfig.about.lblOriginLizzieInfo2=</td></tr><tr><td>유지관리자:</td><td><a href=\"https://github.com/wimi321\">wimi321</a></td></tr><tr><td>현재 저장소:</td><td><a href=\"https://github.com/wimi321/lizzieyzy-next\">wimi321/lizzieyzy-next</a></td></tr><tr><td>이전 포크:</td><td><a href=\"https://github.com/yzyray/lizzieyzy\">yzyray/lizzieyzy</a></td></tr><tr><td>원본 프로젝트:</td><td><a href=\"https://github.com/featurecat/lizzie\">featurecat/lizzie</a></td></tr><tr><td>라이선스:</td><td><a href=\"https://github.com/wimi321/lizzieyzy-next/blob/main/LICENSE.txt\">GPL-3.0</a></td></tr></table></html>
 LizzieConfig.lblLogGtpToFile=GTP \uB85C\uADF8\uD30C\uC77C \uC800\uC7A5
+LizzieConfig.lblEnableStartupBenchmark=\uC2DC\uC791 \uC2DC \uBCA4\uCE58\uB9C8\uD06C
 LizzieConfig.lblLogGtpToFile.tooltips=Need restart,Log file is 'LastGtpLogs.txt' in Lizzie's folder.
 LizzieConfig.lblLogConsoleToFile=\uCF58\uC194 \uB85C\uADF8\uD30C\uC77C \uC800\uC7A5
 LizzieConfig.lblLogConsoleToFile.tooltips=Need restart,Log files is 'LastConsoleLogs.txt' and 'LastErrorLogs.txt' in Lizzie's folder.

--- a/src/main/resources/l10n/DisplayStrings_zh_CN.properties
+++ b/src/main/resources/l10n/DisplayStrings_zh_CN.properties
@@ -888,6 +888,7 @@ LizzieFrame.waitEngineLoadingHint=\u8BF7\u7B49\u5F85\u5F15\u64CE\u52A0\u8F7D\u5B
 LizzieFrame.engineGameStopFirstHint=\u8BF7\u7B49\u5F85\u5F53\u524D\u5F15\u64CE\u5BF9\u6218\u7ED3\u675F,\u6216\u624B\u52A8\u7EC8\u6B62\u5BF9\u5C40
 LizzieConfig.lblStopAtEmpty=\u7A7A\u68CB\u76D8\u505C\u6B62\u8BA1\u7B97
 LizzieConfig.lblLogGtpToFile=\u8BB0\u5F55GTP\u65E5\u5FD7\u5230\u6587\u4EF6
+LizzieConfig.lblEnableStartupBenchmark=\u542F\u52A8\u65F6\u81EA\u52A8\u6D4B\u901F
 LizzieConfig.lblLogConsoleToFile=\u8BB0\u5F55\u63A7\u5236\u53F0\u65E5\u5FD7\u5230\u6587\u4EF6
 LizzieConfig.lblLogGtpToFile.tooltips=\u9700\u91CD\u542FLizzie,\u8BB0\u5F55\u5728Lizzie\u76EE\u5F55\u4E0B\u7684'LastGtpLogs.txt'\u6587\u4EF6
 LizzieConfig.lblLogConsoleToFile.tooltips=\u9700\u91CD\u542FLizzie,\u8BB0\u5F55\u5728Lizzie\u76EE\u5F55\u4E0B\u7684'LastConsoleLogs.txt'\u548C'LastErrorLogs.txt'\u6587\u4EF6

--- a/src/main/resources/l10n/DisplayStrings_zh_HK.properties
+++ b/src/main/resources/l10n/DisplayStrings_zh_HK.properties
@@ -806,6 +806,7 @@ LizzieFrame.waitEngineLoadingHint=\u8BF7\u7B49\u5F85\u5F15\u64CE\u52A0\u8F7D\u5B
 LizzieFrame.engineGameStopFirstHint=\u8BF7\u7B49\u5F85\u5F53\u524D\u5F15\u64CE\u5BF9\u6218\u7ED3\u675F,\u6216\u624B\u52A8\u7EC8\u6B62\u5BF9\u5C40
 LizzieConfig.lblStopAtEmpty=\u7A7A\u68CB\u76D8\u505C\u6B62\u8BA1\u7B97
 LizzieConfig.lblLogGtpToFile=\u8BB0\u5F55GTP\u65E5\u5FD7\u5230\u6587\u4EF6
+LizzieConfig.lblEnableStartupBenchmark=\u555F\u52D5\u6642\u81EA\u52D5\u6E2C\u901F
 LizzieConfig.lblLogConsoleToFile=\u8BB0\u5F55\u63A7\u5236\u53F0\u65E5\u5FD7\u5230\u6587\u4EF6
 LizzieConfig.lblLogGtpToFile.tooltips=\u9700\u91CD\u542FLizzie,\u8BB0\u5F55\u5728Lizzie\u76EE\u5F55\u4E0B\u7684'LastGtpLogs.txt'\u6587\u4EF6
 LizzieConfig.lblLogConsoleToFile.tooltips=\u9700\u91CD\u542FLizzie,\u8BB0\u5F55\u5728Lizzie\u76EE\u5F55\u4E0B\u7684'LastConsoleLogs.txt'\u548C'LastErrorLogs.txt'\u6587\u4EF6

--- a/src/main/resources/l10n/DisplayStrings_zh_TW.properties
+++ b/src/main/resources/l10n/DisplayStrings_zh_TW.properties
@@ -806,6 +806,7 @@ LizzieFrame.waitEngineLoadingHint=\u8BF7\u7B49\u5F85\u5F15\u64CE\u52A0\u8F7D\u5B
 LizzieFrame.engineGameStopFirstHint=\u8BF7\u7B49\u5F85\u5F53\u524D\u5F15\u64CE\u5BF9\u6218\u7ED3\u675F,\u6216\u624B\u52A8\u7EC8\u6B62\u5BF9\u5C40
 LizzieConfig.lblStopAtEmpty=\u7A7A\u68CB\u76D8\u505C\u6B62\u8BA1\u7B97
 LizzieConfig.lblLogGtpToFile=\u8BB0\u5F55GTP\u65E5\u5FD7\u5230\u6587\u4EF6
+LizzieConfig.lblEnableStartupBenchmark=\u555F\u52D5\u6642\u81EA\u52D5\u6E2C\u901F
 LizzieConfig.lblLogConsoleToFile=\u8BB0\u5F55\u63A7\u5236\u53F0\u65E5\u5FD7\u5230\u6587\u4EF6
 LizzieConfig.lblLogGtpToFile.tooltips=\u9700\u91CD\u542FLizzie,\u8BB0\u5F55\u5728Lizzie\u76EE\u5F55\u4E0B\u7684'LastGtpLogs.txt'\u6587\u4EF6
 LizzieConfig.lblLogConsoleToFile.tooltips=\u9700\u91CD\u542FLizzie,\u8BB0\u5F55\u5728Lizzie\u76EE\u5F55\u4E0B\u7684'LastConsoleLogs.txt'\u548C'LastErrorLogs.txt'\u6587\u4EF6

--- a/src/test/java/featurecat/lizzie/gui/SnapshotNodeRenderGateTest.java
+++ b/src/test/java/featurecat/lizzie/gui/SnapshotNodeRenderGateTest.java
@@ -203,17 +203,7 @@ class SnapshotNodeRenderGateTest {
     moveNumberList[Board.getIndex(0, 0)] = 1;
     moveNumberList[Board.getIndex(1, 0)] = 2;
     return BoardData.move(
-        stones,
-        new int[] {1, 0},
-        Stone.WHITE,
-        true,
-        new Zobrist(),
-        2,
-        moveNumberList,
-        0,
-        0,
-        50,
-        0);
+        stones, new int[] {1, 0}, Stone.WHITE, true, new Zobrist(), 2, moveNumberList, 0, 0, 50, 0);
   }
 
   private static Board boardWithRoot(BoardData root) throws Exception {


### PR DESCRIPTION
## 背景

lizzieyzy-next 内嵌的 JCEF 浏览器已支持弈客平台部分房间类型的棋谱同步，但弈客对弈房间（`#/unite/<roomId>`）一直没接入。本 PR 在不动其他平台同步路径的前提下，新增对弈房间同步、修复同步过程中暴露出的若干稳定性问题，并改善了同步状态的可观测性。

## 主要改动

### 弈客对弈房间同步（type=7, TYPE_UNITE_ROOM）
- `BrowserFrame`：注册 `CefMessageRouter` handler，在弈客网页内 hook `fetch` / `XMLHttpRequest`，第一次抓到 `game-server.yikeweiqi.com/game/info` 请求时完整捕获 Request/headers，之后定时复用相同请求重发，借用弈客网页自身的 JWT 鉴权，绕开跨域 CORS 与 token 提取问题。
- 同时 hook 弈客的 WebSocket：服务器推送落子时立刻触发一次额外 fetch，降低首手延迟。
- `OnlineDialog`：新增 `handleYikeUniteSgf`，把响应包成 `{result:data}` 喂进现有 `parseSgf` 链路；用 `hands_count` 字段做主去重避免重复 sync。
- `YikeUrlParser` / `YikeUrlInfo`：识别 `unite/<roomId>` URL，新增 `TYPE_UNITE_ROOM = 7`。

### 修复 EDT 卡死
长棋谱下 `BoardHistoryNode.sync` ↔ `syncVariationsFrom` 的递归比较会把 EDT 吃满。让 unite 房间走 `replaceYikeMainline` 路径，绕开递归 sync 算法。

### 保留用户复盘分支
- `BoardHistoryNode`：新增 `reparentAsLastVariationOf` / `reparentAsFirstVariationOf` 封装跨树重挂操作。
- `OnlineDialog.preserveUserBranchesOnto`：每次同步前把用户摆出的变化分支按手数搬到新 liveNode 主线节点上，避免被 setHistory 清掉。
- `OnlineDialog.appendNewMainlineMovesPreservingHead`：用户在试下（head 不在主线，或在主线但已往前翻过棋）时不动 head，只把新主线手数追加到末尾，避免把用户视图拉走。

### 同步状态实时反馈
- `BrowserFrame.setSyncStatus`：dedup 同样文本，把状态写到弈客浏览器窗口标题栏。
- `OnlineDialog`：在启动 / 已停止 / 拉取异常 / HTTP 错误 / 手数推进等关键节点上报状态。

### 防止误注入与稳定性
- `BrowserFrame`：`onLoadStart` + `onLoadEnd` 双事件自动重装 fetch hook（页面 reload 时 hook 会丢失）。
- 切换到非 yike URL 时清 `pendingYikeRoomId`，防止 hook JS 注入到非 yike 页面。
- `onQuery` 立即 success 返回，payload 处理派发给 `YikeQueryWorker` 单线程后台执行，避免 CEF UI 线程阻塞拖死 AWT。

### 弈客对弈房间相关 bug 修复
- 修复对弈房间（type=5）的 NullPointerException：`sync` / `move` 加 `history` 非空检查；`initData` fallback 重试覆盖 type=5。

### UI 细节
- 浏览器 toolbar 加载/停止按钮换成 JLabel 自绘，绕开 Windows L&F + JToolBar 在 hover/pressed 时不重绘按钮背景导致的字符串重影残留。

### 文档
- `docs/FOX_READBOARD_AUTOPAUSE_BUG.md`：记录野狐 readboard 同步期间分析自动暂停的根因诊断与修法选项（本 PR 不修，留给后续）。

## 不影响

- 野狐截图同步 / 弈城 / 新浪 / 弈客直播（type=1/2/5/6）等其他平台路径未改动
- `BoardHistoryNode.sync` 递归算法本身未改动，仅 unite 房间绕开
- 抓取野狐棋谱（按野狐昵称）的 `GetFoxRequest` / `GIBParser` 完全未触

## 测试

手工测试：
- 进入弈客对弈房间（`unite/<id>`），可正常同步 SGF、棋盘随对局推进
- 手动停止 / 重新加载，能恢复同步，标题显示当前手数
- 在 lizzieyzy-next 端摆变化分支或往前翻棋时，弈客实际落子继续记录到主线，不打断试下视图
- 长棋谱（200+ 手）下不再发生 EDT 卡死（jstack 验证 `BoardHistoryNode.sync` 不在调用栈）