### PR TITLE
fix: 仅在引擎正在 ponder 时才切换 ponder 状态

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/ReadBoard.java
+++ b/src/main/java/featurecat/lizzie/analysis/ReadBoard.java
@@ -909,7 +909,9 @@ public class ReadBoard {
       if (Lizzie.frame.isAnaPlayingAgainstLeelaz) {
         Lizzie.frame.stopAiPlayingAndPolicy();
       }
-      Lizzie.leelaz.togglePonder();
+      if (Lizzie.leelaz.isPondering()) {
+        Lizzie.leelaz.togglePonder();
+      }
     }
     if (line.startsWith("noinboard")) {
       if (Lizzie.frame.floatBoard != null && Lizzie.frame.floatBoard.isVisible()) {


### PR DESCRIPTION
## Summary
- 在 `ReadBoard` 收到对应信号触发 `togglePonder()` 之前，先判断 `Lizzie.leelaz.isPondering()`，避免在引擎已停止时被误启动。

## Test plan
- [x] 手动验证：引擎已停止时触发 readboard 信号，引擎不应被自动恢复 ponder
- [x] 手动验证：引擎正在 ponder 时仍能正常被切换停止