### PR TITLE
[codex] Fix RTX 50 TensorRT release packaging

### DIFF
--- a/scripts/generate_release_notes.py
+++ b/scripts/generate_release_notes.py
@@ -22,7 +22,6 @@ ASSET_SPECS = [
     ('windows_nvidia_portable', 'windows64.nvidia.portable.zip', 'Windows 64 位，英伟达显卡，免安装', 'Windows x64, NVIDIA GPU, no installer'),
     ('windows_nvidia50_cuda_installer', 'windows64.nvidia50.cuda.installer.exe', 'Windows 64 位，RTX 50 CUDA 版', 'Windows x64, RTX 50 CUDA'),
     ('windows_nvidia50_cuda_portable', 'windows64.nvidia50.cuda.portable.zip', 'Windows 64 位，RTX 50 CUDA 版，免安装', 'Windows x64, RTX 50 CUDA, no installer'),
-    ('windows_nvidia50_trt_installer', 'windows64.nvidia50.trt.installer.exe', 'Windows 64 位，RTX 50 TensorRT 试验版', 'Windows x64, RTX 50 TensorRT experimental'),
     ('windows_nvidia50_trt_portable', 'windows64.nvidia50.trt.portable.zip', 'Windows 64 位，RTX 50 TensorRT 试验版，免安装', 'Windows x64, RTX 50 TensorRT experimental, no installer'),
     ('windows_no_engine_installer', 'windows64.without.engine.installer.exe', 'Windows 64 位，想自己配引擎，也想安装器', 'Windows x64, your own engine with installer'),
     ('windows_no_engine_portable', 'windows64.without.engine.portable.zip', 'Windows 64 位，想自己配引擎', 'Windows x64, your own engine'),
@@ -272,37 +271,31 @@ def add_nvidia50_download_rows(
             'Windows 64 位，RTX 50 CUDA 版，5070/5080/5090 优先，免安装',
             'Windows 64 位，RTX 50 CUDA 版，5070/5080/5090 优先，想安装',
             'Windows 64 位，RTX 50 TensorRT 试验版，免安装',
-            'Windows 64 位，RTX 50 TensorRT 试验版，想安装',
         ),
         '繁體中文': (
             'Windows 64 位，RTX 50 CUDA 版，5070/5080/5090 優先，免安裝',
             'Windows 64 位，RTX 50 CUDA 版，5070/5080/5090 優先，想安裝',
             'Windows 64 位，RTX 50 TensorRT 試驗版，免安裝',
-            'Windows 64 位，RTX 50 TensorRT 試驗版，想安裝',
         ),
         'English': (
             'Windows 64-bit, RTX 50 CUDA, recommended for 5070/5080/5090, no install',
             'Windows 64-bit, RTX 50 CUDA, recommended for 5070/5080/5090, installer',
             'Windows 64-bit, RTX 50 TensorRT experimental, no install',
-            'Windows 64-bit, RTX 50 TensorRT experimental, installer',
         ),
         '日本語': (
             'Windows 64-bit、RTX 50 CUDA、5070/5080/5090 推奨、インストール不要',
             'Windows 64-bit、RTX 50 CUDA、5070/5080/5090 推奨、インストーラ',
             'Windows 64-bit、RTX 50 TensorRT 試験版、インストール不要',
-            'Windows 64-bit、RTX 50 TensorRT 試験版、インストーラ',
         ),
         '한국어': (
             'Windows 64-bit, RTX 50 CUDA, 5070/5080/5090 권장, 무설치',
             'Windows 64-bit, RTX 50 CUDA, 5070/5080/5090 권장, 설치형',
             'Windows 64-bit, RTX 50 TensorRT 실험판, 무설치',
-            'Windows 64-bit, RTX 50 TensorRT 실험판, 설치형',
         ),
         'ภาษาไทย': (
             'Windows 64-bit, RTX 50 CUDA, แนะนำสำหรับ 5070/5080/5090, ไม่ต้องติดตั้ง',
             'Windows 64-bit, RTX 50 CUDA, แนะนำสำหรับ 5070/5080/5090, แบบติดตั้ง',
             'Windows 64-bit, RTX 50 TensorRT รุ่นทดลอง, ไม่ต้องติดตั้ง',
-            'Windows 64-bit, RTX 50 TensorRT รุ่นทดลอง, แบบติดตั้ง',
         ),
     }
     before_note_by_language = {
@@ -327,7 +320,6 @@ def add_nvidia50_download_rows(
             (labels[0], localized_assets['windows_nvidia50_cuda_portable']),
             (labels[1], localized_assets['windows_nvidia50_cuda_installer']),
             (labels[2], localized_assets['windows_nvidia50_trt_portable']),
-            (labels[3], localized_assets['windows_nvidia50_trt_installer']),
         ]
         insert_at = min(6, len(rows))
         for index, row in enumerate(rows):

--- a/scripts/package_windows_exe.sh
+++ b/scripts/package_windows_exe.sh
@@ -44,6 +44,7 @@ OPENCL_ARCH_TAG="${ARCH_TAG}.opencl"
 NVIDIA_ARCH_TAG="${ARCH_TAG}.nvidia"
 NVIDIA50_CUDA_ARCH_TAG="${ARCH_TAG}.nvidia50.cuda"
 NVIDIA50_TRT_ARCH_TAG="${ARCH_TAG}.nvidia50.trt"
+BUILD_NVIDIA50_TRT_INSTALLER="${WINDOWS_BUILD_NVIDIA50_TRT_INSTALLER:-false}"
 DIST_DIR="$ROOT_DIR/dist/windows"
 RELEASE_DIR="$ROOT_DIR/dist/release"
 META_DIR="$ROOT_DIR/dist/release-meta"
@@ -579,11 +580,15 @@ EOF
 
   if [[ "$has_nvidia50_trt_katago" == "true" ]]; then
     cat >>"$note_file" <<EOF
-- ${DATE_TAG}-${NVIDIA50_TRT_ARCH_TAG}.installer.exe
-  Experimental RTX 50 TensorRT package for users willing to test higher peak performance.
 - ${DATE_TAG}-${NVIDIA50_TRT_ARCH_TAG}.portable.zip
   Experimental RTX 50 TensorRT portable build. Unzip it and open ${NVIDIA50_TRT_APP_NAME}.exe.
 EOF
+    if [[ "$BUILD_NVIDIA50_TRT_INSTALLER" == "true" ]]; then
+      cat >>"$note_file" <<EOF
+- ${DATE_TAG}-${NVIDIA50_TRT_ARCH_TAG}.installer.exe
+  Experimental RTX 50 TensorRT installer. This is disabled by default because the TensorRT runtime makes the MSI/EXE build very large.
+EOF
+    fi
   fi
 
   cat >>"$note_file" <<EOF
@@ -698,6 +703,7 @@ build_release_variant() {
   local release_basename="$8"
   local upgrade_uuid="$9"
   local runtime_stage_dir="${10:-}"
+  local build_installer_asset="${11:-true}"
 
   local app_root
   local installer_path
@@ -714,19 +720,28 @@ build_release_variant() {
     "$engine_backend" \
     "$runtime_stage_dir")"
   create_portable_zip "$release_basename" "$app_root"
-  installer_path="$(build_installer \
-    "$flavor" \
-    "$include_katago" \
-    "$app_name" \
-    "$app_description" \
-    "$engine_source_dir" \
-    "$engine_target_dir" \
-    "$engine_backend" \
-    "$runtime_stage_dir" \
-    "$upgrade_uuid")"
-  final_installer="$RELEASE_DIR/${DATE_TAG}-${release_basename}.installer.exe"
-  cp "$installer_path" "$final_installer"
-  artifacts+=("$final_installer" "$RELEASE_DIR/${DATE_TAG}-${release_basename}.portable.zip")
+  artifacts+=("$RELEASE_DIR/${DATE_TAG}-${release_basename}.portable.zip")
+  if [[ "$build_installer_asset" == "true" ]]; then
+    installer_path="$(build_installer \
+      "$flavor" \
+      "$include_katago" \
+      "$app_name" \
+      "$app_description" \
+      "$engine_source_dir" \
+      "$engine_target_dir" \
+      "$engine_backend" \
+      "$runtime_stage_dir" \
+      "$upgrade_uuid")"
+    if [[ -z "$installer_path" || ! -f "$installer_path" ]]; then
+      echo "Windows installer was not produced for $release_basename" >&2
+      return 1
+    fi
+    final_installer="$RELEASE_DIR/${DATE_TAG}-${release_basename}.installer.exe"
+    cp "$installer_path" "$final_installer"
+    artifacts+=("$final_installer")
+  else
+    log_step "Skipping Windows installer for $release_basename"
+  fi
   log_step "Finished Windows release variant: $release_basename"
 }
 
@@ -822,7 +837,8 @@ if has_bundled_katago "$NVIDIA50_TRT_ENGINE_PLATFORM_DIR"; then
     "nvidia50-trt" \
     "$NVIDIA50_TRT_ARCH_TAG" \
     "$WINDOWS_UPGRADE_UUID_NVIDIA50_TRT" \
-    "$NVIDIA50_TRT_RUNTIME_STAGE_DIR"
+    "$NVIDIA50_TRT_RUNTIME_STAGE_DIR" \
+    "$BUILD_NVIDIA50_TRT_INSTALLER"
 else
   has_nvidia50_trt_katago_assets="false"
 fi

--- a/scripts/validate_release_assets.sh
+++ b/scripts/validate_release_assets.sh
@@ -25,7 +25,6 @@ case "$PLATFORM" in
       "${DATE_TAG}-windows64.nvidia.portable.zip"
       "${DATE_TAG}-windows64.nvidia50.cuda.installer.exe"
       "${DATE_TAG}-windows64.nvidia50.cuda.portable.zip"
-      "${DATE_TAG}-windows64.nvidia50.trt.installer.exe"
       "${DATE_TAG}-windows64.nvidia50.trt.portable.zip"
       "${DATE_TAG}-windows64.with-katago.installer.exe"
       "${DATE_TAG}-windows64.with-katago.portable.zip"


### PR DESCRIPTION
## Summary

- Make the experimental RTX 50 TensorRT Windows package portable-only by default.
- Keep RTX 50 CUDA as installer + portable, while avoiding the huge TensorRT WiX/jpackage installer failure that blocked all release asset uploads.
- Update Windows release asset validation and release-note asset tables to match the real public package set.

## Why

The `next-2026-05-10.1` Windows release workflow successfully built the TensorRT portable zip, but failed while building the very large TensorRT MSI/EXE installer through WiX `light.exe`. Because the script expected that installer unconditionally, the whole workflow failed before uploading any assets.

## Validation

- `bash -n scripts/package_windows_exe.sh`
- `bash -n scripts/validate_release_assets.sh`
- `python -m py_compile scripts/generate_release_notes.py`
- Windows asset validator passed against the expected 11 Windows assets, with `windows64.nvidia50.trt.portable.zip` and no TensorRT installer.
