### PR TITLE
[codex] Split oversized Windows release assets

### DIFF
--- a/.github/workflows/build-windows-release.yml
+++ b/.github/workflows/build-windows-release.yml
@@ -273,7 +273,7 @@ jobs:
         run: |
           gh release upload "${{ inputs.release_tag }}" \
             dist/release/*windows64*.installer.exe \
-            dist/release/*windows64*.portable.zip \
+            dist/release/*windows64*.portable.zip* \
             --repo "${{ github.repository }}" \
             --clobber
 

--- a/scripts/generate_release_notes.py
+++ b/scripts/generate_release_notes.py
@@ -22,7 +22,8 @@ ASSET_SPECS = [
     ('windows_nvidia_portable', 'windows64.nvidia.portable.zip', 'Windows 64 位，英伟达显卡，免安装', 'Windows x64, NVIDIA GPU, no installer'),
     ('windows_nvidia50_cuda_installer', 'windows64.nvidia50.cuda.installer.exe', 'Windows 64 位，RTX 50 CUDA 版', 'Windows x64, RTX 50 CUDA'),
     ('windows_nvidia50_cuda_portable', 'windows64.nvidia50.cuda.portable.zip', 'Windows 64 位，RTX 50 CUDA 版，免安装', 'Windows x64, RTX 50 CUDA, no installer'),
-    ('windows_nvidia50_trt_portable', 'windows64.nvidia50.trt.portable.zip', 'Windows 64 位，RTX 50 TensorRT 试验版，免安装', 'Windows x64, RTX 50 TensorRT experimental, no installer'),
+    ('windows_nvidia50_trt_part01', 'windows64.nvidia50.trt.portable.zip.part01', 'Windows 64 位，RTX 50 TensorRT 试验版，免安装，第 1 部分', 'Windows x64, RTX 50 TensorRT experimental, no installer, part 1'),
+    ('windows_nvidia50_trt_part02', 'windows64.nvidia50.trt.portable.zip.part02', 'Windows 64 位，RTX 50 TensorRT 试验版，免安装，第 2 部分', 'Windows x64, RTX 50 TensorRT experimental, no installer, part 2'),
     ('windows_no_engine_installer', 'windows64.without.engine.installer.exe', 'Windows 64 位，想自己配引擎，也想安装器', 'Windows x64, your own engine with installer'),
     ('windows_no_engine_portable', 'windows64.without.engine.portable.zip', 'Windows 64 位，想自己配引擎', 'Windows x64, your own engine'),
     ('mac_arm64', 'mac-apple-silicon.with-katago.dmg', 'macOS Apple Silicon', 'macOS Apple Silicon'),
@@ -270,32 +271,38 @@ def add_nvidia50_download_rows(
         '中文': (
             'Windows 64 位，RTX 50 CUDA 版，5070/5080/5090 优先，免安装',
             'Windows 64 位，RTX 50 CUDA 版，5070/5080/5090 优先，想安装',
-            'Windows 64 位，RTX 50 TensorRT 试验版，免安装',
+            'Windows 64 位，RTX 50 TensorRT 试验版，免安装，第 1 部分',
+            'Windows 64 位，RTX 50 TensorRT 试验版，免安装，第 2 部分',
         ),
         '繁體中文': (
             'Windows 64 位，RTX 50 CUDA 版，5070/5080/5090 優先，免安裝',
             'Windows 64 位，RTX 50 CUDA 版，5070/5080/5090 優先，想安裝',
-            'Windows 64 位，RTX 50 TensorRT 試驗版，免安裝',
+            'Windows 64 位，RTX 50 TensorRT 試驗版，免安裝，第 1 部分',
+            'Windows 64 位，RTX 50 TensorRT 試驗版，免安裝，第 2 部分',
         ),
         'English': (
             'Windows 64-bit, RTX 50 CUDA, recommended for 5070/5080/5090, no install',
             'Windows 64-bit, RTX 50 CUDA, recommended for 5070/5080/5090, installer',
-            'Windows 64-bit, RTX 50 TensorRT experimental, no install',
+            'Windows 64-bit, RTX 50 TensorRT experimental, no install, part 1',
+            'Windows 64-bit, RTX 50 TensorRT experimental, no install, part 2',
         ),
         '日本語': (
             'Windows 64-bit、RTX 50 CUDA、5070/5080/5090 推奨、インストール不要',
             'Windows 64-bit、RTX 50 CUDA、5070/5080/5090 推奨、インストーラ',
-            'Windows 64-bit、RTX 50 TensorRT 試験版、インストール不要',
+            'Windows 64-bit、RTX 50 TensorRT 試験版、インストール不要、part 1',
+            'Windows 64-bit、RTX 50 TensorRT 試験版、インストール不要、part 2',
         ),
         '한국어': (
             'Windows 64-bit, RTX 50 CUDA, 5070/5080/5090 권장, 무설치',
             'Windows 64-bit, RTX 50 CUDA, 5070/5080/5090 권장, 설치형',
-            'Windows 64-bit, RTX 50 TensorRT 실험판, 무설치',
+            'Windows 64-bit, RTX 50 TensorRT 실험판, 무설치, part 1',
+            'Windows 64-bit, RTX 50 TensorRT 실험판, 무설치, part 2',
         ),
         'ภาษาไทย': (
             'Windows 64-bit, RTX 50 CUDA, แนะนำสำหรับ 5070/5080/5090, ไม่ต้องติดตั้ง',
             'Windows 64-bit, RTX 50 CUDA, แนะนำสำหรับ 5070/5080/5090, แบบติดตั้ง',
-            'Windows 64-bit, RTX 50 TensorRT รุ่นทดลอง, ไม่ต้องติดตั้ง',
+            'Windows 64-bit, RTX 50 TensorRT รุ่นทดลอง, ไม่ต้องติดตั้ง, part 1',
+            'Windows 64-bit, RTX 50 TensorRT รุ่นทดลอง, ไม่ต้องติดตั้ง, part 2',
         ),
     }
     before_note_by_language = {
@@ -319,7 +326,8 @@ def add_nvidia50_download_rows(
         additions = [
             (labels[0], localized_assets['windows_nvidia50_cuda_portable']),
             (labels[1], localized_assets['windows_nvidia50_cuda_installer']),
-            (labels[2], localized_assets['windows_nvidia50_trt_portable']),
+            (labels[2], localized_assets['windows_nvidia50_trt_part01']),
+            (labels[3], localized_assets['windows_nvidia50_trt_part02']),
         ]
         insert_at = min(6, len(rows))
         for index, row in enumerate(rows):

--- a/scripts/package_windows_exe.sh
+++ b/scripts/package_windows_exe.sh
@@ -45,6 +45,9 @@ NVIDIA_ARCH_TAG="${ARCH_TAG}.nvidia"
 NVIDIA50_CUDA_ARCH_TAG="${ARCH_TAG}.nvidia50.cuda"
 NVIDIA50_TRT_ARCH_TAG="${ARCH_TAG}.nvidia50.trt"
 BUILD_NVIDIA50_TRT_INSTALLER="${WINDOWS_BUILD_NVIDIA50_TRT_INSTALLER:-false}"
+SPLIT_LARGE_RELEASE_ASSETS="${WINDOWS_SPLIT_LARGE_RELEASE_ASSETS:-true}"
+MAX_RELEASE_ASSET_BYTES="${WINDOWS_RELEASE_ASSET_MAX_BYTES:-2000000000}"
+RELEASE_SPLIT_SIZE="${WINDOWS_RELEASE_SPLIT_SIZE:-1900M}"
 DIST_DIR="$ROOT_DIR/dist/windows"
 RELEASE_DIR="$ROOT_DIR/dist/release"
 META_DIR="$ROOT_DIR/dist/release-meta"
@@ -579,10 +582,18 @@ EOF
   fi
 
   if [[ "$has_nvidia50_trt_katago" == "true" ]]; then
-    cat >>"$note_file" <<EOF
+    if [[ "$SPLIT_LARGE_RELEASE_ASSETS" == "true" ]]; then
+      cat >>"$note_file" <<EOF
+- ${DATE_TAG}-${NVIDIA50_TRT_ARCH_TAG}.portable.zip.part01 / part02
+  Experimental RTX 50 TensorRT portable build split into parts for GitHub's release asset size limit. Download every part, then recombine with:
+  copy /b ${DATE_TAG}-${NVIDIA50_TRT_ARCH_TAG}.portable.zip.part01+${DATE_TAG}-${NVIDIA50_TRT_ARCH_TAG}.portable.zip.part02 ${DATE_TAG}-${NVIDIA50_TRT_ARCH_TAG}.portable.zip
+EOF
+    else
+      cat >>"$note_file" <<EOF
 - ${DATE_TAG}-${NVIDIA50_TRT_ARCH_TAG}.portable.zip
   Experimental RTX 50 TensorRT portable build. Unzip it and open ${NVIDIA50_TRT_APP_NAME}.exe.
 EOF
+    fi
     if [[ "$BUILD_NVIDIA50_TRT_INSTALLER" == "true" ]]; then
       cat >>"$note_file" <<EOF
 - ${DATE_TAG}-${NVIDIA50_TRT_ARCH_TAG}.installer.exe
@@ -614,10 +625,10 @@ Download verification:
 
 What is bundled:
 - Windows release assets include a packaged Java runtime via jpackage.
-- Native Windows readboard is included in `readboard/`.
+- Native Windows readboard is included in 'readboard/'.
 - Native Windows readboard is pinned to qiyi71w/readboard ${READBOARD_RELEASE_TAG} (${READBOARD_ASSET_NAME}, SHA256 ${READBOARD_ASSET_SHA256}).
-- The built-in Java readboard helper is also included in `readboard_java/` for the explicit Java sync entry.
-- The JCEF browser runtime for Yike web page and Yike hall is included in `jcef-bundle/` (${JCEF_RELEASE_TAG}, SHA256 ${JCEF_ASSET_SHA256}), so these entries do not download browser components on first use.
+- The built-in Java readboard helper is also included in 'readboard_java/' for the explicit Java sync entry.
+- The JCEF browser runtime for Yike web page and Yike hall is included in 'jcef-bundle/' (${JCEF_RELEASE_TAG}, SHA256 ${JCEF_ASSET_SHA256}), so these entries do not download browser components on first use.
 EOF
 
   if [[ "$has_with_katago" == "true" ]]; then
@@ -690,6 +701,48 @@ create_portable_zip() {
   powershell.exe -NoProfile -Command \
     "Compress-Archive -Path '$native_root' -DestinationPath '$native_zip' -Force"
   log_step "Finished Windows portable zip: $(basename "$portable_zip")"
+}
+
+split_large_release_artifacts() {
+  if [[ "$SPLIT_LARGE_RELEASE_ASSETS" != "true" ]]; then
+    return 0
+  fi
+
+  local next_artifacts=()
+  local artifact
+  for artifact in "${artifacts[@]}"; do
+    if [[ ! -f "$artifact" ]]; then
+      next_artifacts+=("$artifact")
+      continue
+    fi
+
+    local size
+    size="$(stat -c '%s' "$artifact")"
+    if (( size <= MAX_RELEASE_ASSET_BYTES )); then
+      next_artifacts+=("$artifact")
+      continue
+    fi
+
+    log_step "Splitting oversized release asset: $(basename "$artifact") (${size} bytes)"
+    rm -f "$artifact".part[0-9][0-9]
+    split -b "$RELEASE_SPLIT_SIZE" -d -a 2 --numeric-suffixes=1 "$artifact" "$artifact.part"
+    rm -f "$artifact"
+
+    shopt -s nullglob
+    local parts=("$artifact".part[0-9][0-9])
+    shopt -u nullglob
+    if (( ${#parts[@]} < 2 )); then
+      echo "Expected multiple split parts for oversized asset: $artifact" >&2
+      return 1
+    fi
+
+    local part
+    for part in "${parts[@]}"; do
+      next_artifacts+=("$part")
+    done
+  done
+
+  artifacts=("${next_artifacts[@]}")
 }
 
 build_release_variant() {
@@ -853,6 +906,8 @@ build_release_variant \
   "" \
   "${ARCH_TAG}.without.engine" \
   "$WINDOWS_UPGRADE_UUID"
+
+split_large_release_artifacts
 
 install_note="$META_DIR/${DATE_TAG}-${ARCH_TAG}-install.txt"
 checksum_file="$META_DIR/${DATE_TAG}-${ARCH_TAG}-sha256.txt"

--- a/scripts/validate_release_assets.sh
+++ b/scripts/validate_release_assets.sh
@@ -25,7 +25,6 @@ case "$PLATFORM" in
       "${DATE_TAG}-windows64.nvidia.portable.zip"
       "${DATE_TAG}-windows64.nvidia50.cuda.installer.exe"
       "${DATE_TAG}-windows64.nvidia50.cuda.portable.zip"
-      "${DATE_TAG}-windows64.nvidia50.trt.portable.zip"
       "${DATE_TAG}-windows64.with-katago.installer.exe"
       "${DATE_TAG}-windows64.with-katago.portable.zip"
       "${DATE_TAG}-windows64.without.engine.installer.exe"
@@ -58,6 +57,21 @@ for path in "$RELEASE_DIR"/*; do
   actual+=("$(basename "$path")")
 done
 shopt -u nullglob
+
+if [[ "$PLATFORM" == "windows" ]]; then
+  trt_parts=()
+  shopt -s nullglob
+  for path in "$RELEASE_DIR/${DATE_TAG}-windows64.nvidia50.trt.portable.zip.part"[0-9][0-9]; do
+    [[ -f "$path" ]] || continue
+    trt_parts+=("$(basename "$path")")
+  done
+  shopt -u nullglob
+  if [[ "${#trt_parts[@]}" -lt 2 ]]; then
+    echo "Missing split RTX 50 TensorRT portable assets"
+    exit 1
+  fi
+  expected+=("${trt_parts[@]}")
+fi
 
 if [[ "${#actual[@]}" -eq 0 ]]; then
   echo "No release assets found in $RELEASE_DIR"


### PR DESCRIPTION
## Summary

- Split oversized Windows release assets into `.part01/.part02` files before upload.
- Upload `*.portable.zip*` so split TensorRT assets are included in GitHub Releases.
- Update Windows asset validation and generated release-note asset tables for split RTX 50 TensorRT portable packages.
- Clean up Windows install-note text that accidentally triggered shell command substitution for backtick paths.

## Why

GitHub Releases reject individual assets larger than 2,147,483,648 bytes. The RTX 50 TensorRT portable package is about 3.4 GB, so the Windows workflow passed build, validation, and smoke testing, then failed while uploading `windows64.nvidia50.trt.portable.zip`.

## Validation

- `bash -n scripts/package_windows_exe.sh`
- `bash -n scripts/validate_release_assets.sh`
- `python -m py_compile scripts/generate_release_notes.py`
- Windows asset validator passed with split TensorRT assets: `windows64.nvidia50.trt.portable.zip.part01` and `.part02`
- Release-note generator produced links for both TensorRT split parts
