### PR TITLE
修复 ReadBoard 落子失败/错点后本地与远端不同步

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -1379,6 +1379,10 @@ public class Leelaz {
         }
       }
     }
+    boolean handledInfoLine = false;
+    boolean notifyAutoPKAfterInfo = false;
+    boolean notifyAutoPlayAfterInfo = false;
+    int autoAnalyzeAfterInfo = 0;
     synchronized (this) {
       if (line.startsWith("info")) {
         boolean upToDate = isResponseUpToDate();
@@ -1428,15 +1432,15 @@ public class Leelaz {
             YikeSyncDebugLog.log("Leelaz parseLine bestMoves size=" + this.bestMoves.size());
           }
           if (!this.bestMoves.isEmpty()) {
-            notifyAutoPK(false);
-            notifyAutoPlay(false);
+            notifyAutoPKAfterInfo = true;
+            notifyAutoPlayAfterInfo = true;
             if (Lizzie.config.isAutoAna) {
               if (Lizzie.frame.isAutoAnalyzingDiffNode) {
-                nofityDiffAna();
+                autoAnalyzeAfterInfo = 1;
               } else if (Lizzie.config.analyzeAllBranch) {
-                notifyAutoAnaAllBranch();
+                autoAnalyzeAfterInfo = 2;
               } else {
-                notifyAutoAna();
+                autoAnalyzeAfterInfo = 3;
               }
             }
           }
@@ -1477,7 +1481,7 @@ public class Leelaz {
           if (Lizzie.config.isAutoAna)
             Lizzie.board.getHistory().getCurrentHistoryNode().getData().tryToClearBestMoves();
         }
-        return;
+        handledInfoLine = true;
       } else {
         if (Lizzie.gtpConsole.isVisible() || Lizzie.config.alwaysGtp || !this.isLoaded)
           Lizzie.gtpConsole.addLine(line + "\n");
@@ -1766,6 +1770,26 @@ public class Leelaz {
         }
       }
       parseHeatMap(line);
+    }
+    if (handledInfoLine) {
+      runPostInfoActions(notifyAutoPKAfterInfo, notifyAutoPlayAfterInfo, autoAnalyzeAfterInfo);
+    }
+  }
+
+  private void runPostInfoActions(
+      boolean notifyAutoPKAfterInfo, boolean notifyAutoPlayAfterInfo, int autoAnalyzeAfterInfo) {
+    if (notifyAutoPKAfterInfo) {
+      notifyAutoPK(false);
+    }
+    if (notifyAutoPlayAfterInfo) {
+      notifyAutoPlay(false);
+    }
+    if (autoAnalyzeAfterInfo == 1) {
+      nofityDiffAna();
+    } else if (autoAnalyzeAfterInfo == 2) {
+      notifyAutoAnaAllBranch();
+    } else if (autoAnalyzeAfterInfo == 3) {
+      notifyAutoAna();
     }
   }
 

--- a/src/main/java/featurecat/lizzie/analysis/ReadBoard.java
+++ b/src/main/java/featurecat/lizzie/analysis/ReadBoard.java
@@ -11,6 +11,7 @@ import featurecat.lizzie.rules.BoardHistoryList;
 import featurecat.lizzie.rules.BoardHistoryNode;
 import featurecat.lizzie.rules.ExtraStones;
 import featurecat.lizzie.rules.Movelist;
+import featurecat.lizzie.rules.SnapshotEngineRestore;
 import featurecat.lizzie.rules.Stone;
 import featurecat.lizzie.rules.Zobrist;
 import featurecat.lizzie.util.Utils;
@@ -18,6 +19,7 @@ import featurecat.lizzie.util.YikeSyncDebugLog;
 import java.io.BufferedOutputStream;
 import java.io.Closeable;
 import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
@@ -26,7 +28,9 @@ import java.net.Socket;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
@@ -49,6 +53,19 @@ public class ReadBoard {
   };
   private static final int SYNC_ANALYSIS_RESUME_DELAY_MS = 200;
   private static final int STARTUP_OUTPUT_LOG_LIMIT = 8;
+  private static final String READBOARD_PLACEMENT_FAILED = "error place failed";
+  private static final int LOCAL_MOVE_PLACE_RETRY_LIMIT = 0;
+  private static final long LOCAL_MOVE_PLACE_RETRY_INTERVAL_MS = 350L;
+  private static final long PENDING_LOCAL_MOVE_ACK_TIMEOUT_MS = 3000L;
+  private static final long FAILED_LOCAL_MOVE_OBSERVATION_GRACE_MS = 1000L;
+  private static final boolean LOCAL_MOVE_SYNC_LOG_ENABLED =
+      Boolean.parseBoolean(
+          System.getProperty(
+              "lizzie.localMoveSyncLog.enabled",
+              System.getProperty("surefire.test.class.path") == null ? "true" : "false"));
+  private static final String LOCAL_MOVE_SYNC_LOG_PATH =
+      System.getProperty("lizzie.localMoveSyncLog", "runtime/readboard-local-move-debug.log");
+  private static final long LOCAL_MOVE_SYNC_LOG_MAX_BYTES = 2_000_000L;
   private static final String READBOARD_UPDATE_SUPPORTED_COMMAND = "readboardUpdateSupported";
   private static final String YIKE_SYNC_START_COMMAND = "yikeSyncStart";
   private static final String YIKE_SYNC_STOP_COMMAND = "yikeSyncStop";
@@ -73,6 +90,44 @@ public class ReadBoard {
     return isExactReadBoardCommand(line, YIKE_SYNC_START_COMMAND);
   }
 
+  public static void localMoveSyncDebug(String message) {
+    if (!LOCAL_MOVE_SYNC_LOG_ENABLED) {
+      return;
+    }
+    synchronized (ReadBoard.class) {
+      try {
+        File file = new File(LOCAL_MOVE_SYNC_LOG_PATH);
+        File parent = file.getParentFile();
+        if (parent != null && !parent.exists()) {
+          parent.mkdirs();
+        }
+        rotateLocalMoveSyncLogIfNeeded(file);
+        try (FileWriter writer = new FileWriter(file, true)) {
+          writer.write(
+              "["
+                  + new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS").format(new Date())
+                  + "] "
+                  + Thread.currentThread().getName()
+                  + " "
+                  + message
+                  + System.lineSeparator());
+        }
+      } catch (IOException ignored) {
+      }
+    }
+  }
+
+  private static void rotateLocalMoveSyncLogIfNeeded(File file) {
+    if (!file.exists() || file.length() <= LOCAL_MOVE_SYNC_LOG_MAX_BYTES) {
+      return;
+    }
+    File rotated = new File(file.getParentFile(), file.getName() + ".1");
+    if (rotated.exists()) {
+      rotated.delete();
+    }
+    file.renameTo(rotated);
+  }
+
   static boolean isYikeSyncStopCommand(String line) {
     return isExactReadBoardCommand(line, YIKE_SYNC_STOP_COMMAND);
   }
@@ -85,6 +140,7 @@ public class ReadBoard {
   private InputStreamReader inputStream;
   private BufferedOutputStream outputStream;
   private ScheduledExecutorService executor;
+  private ScheduledExecutorService pendingLocalMoveTimeoutExecutor;
   ArrayList<Integer> tempcount = new ArrayList<Integer>();
   // private long startSyncTime = 0;
 
@@ -110,10 +166,43 @@ public class ReadBoard {
   public boolean lastMovePlayByLizzie = false;
   private SyncRemoteContext pendingRemoteContext = SyncRemoteContext.generic(false);
   private boolean waitingForReadBoardLocalMoveAck = false;
+  private boolean pendingLocalMoveClickCompleted = false;
+  private int pendingLocalMoveRetryCount = 0;
+  private long lastPendingLocalMoveRetryTimeMs = 0L;
+  private BoardHistoryNode pendingLocalMoveNode = null;
+  private int pendingLocalMoveX = -1;
+  private int pendingLocalMoveY = -1;
+  private Stone pendingLocalMoveColor = Stone.EMPTY;
+  private String pendingLocalMoveBaselineKey = "";
+  private long pendingLocalMoveAckGeneration = 0L;
+  // Readboard placeComplete has no request id, so a late success from the previous command must
+  // never be allowed to confirm the next pending move. Explicit failures still release the current
+  // pending move; otherwise a missed click can wait forever with no follow-up snapshot.
+  private boolean ignoreReadBoardPlaceResultsForCurrentPending = false;
+  private boolean ignoreReadBoardPlaceResultsForNextPending = false;
+  private boolean failedLocalMoveSuppressionActive = false;
+  private int failedLocalMoveSuppressionX = -1;
+  private int failedLocalMoveSuppressionY = -1;
+  private Stone failedLocalMoveSuppressionColor = Stone.EMPTY;
+  private String failedLocalMoveSuppressionSnapshotKey = "";
+  private boolean failedLocalMoveRecoveryActive = false;
+  private int failedLocalMoveRecoveryX = -1;
+  private int failedLocalMoveRecoveryY = -1;
+  private Stone failedLocalMoveRecoveryColor = Stone.EMPTY;
+  private boolean failedLocalMoveAwaitingRemoteObservation = false;
+  private boolean failedLocalMoveWaitingForOurTurnAfterRemoteChange = false;
+  private long failedLocalMoveObservationDeadlineMs = 0L;
+  private boolean confirmedLocalMoveActive = false;
+  private BoardHistoryNode confirmedLocalMoveNode = null;
+  private int confirmedLocalMoveX = -1;
+  private int confirmedLocalMoveY = -1;
+  private Stone confirmedLocalMoveColor = Stone.EMPTY;
+  private String confirmedLocalMoveBaselineKey = "";
   private boolean hideFloadBoardBeforePlace = false;
   private boolean hideFromPlace = false;
   public boolean editMode = false;
   private int startupOutputLineCount = 0;
+  private volatile boolean shutdownStarted = false;
   private final SyncConflictTracker conflictTracker = new SyncConflictTracker();
   private final SyncHistoryJumpTracker historyJumpTracker = new SyncHistoryJumpTracker();
   private final SyncLocalNavigationTracker localNavigationTracker =
@@ -455,7 +544,9 @@ public class ReadBoard {
       commands.add(Lizzie.resourceBundle.getString("ReadBoard.language"));
       if (usePipe) commands.add("-1");
       else commands.add(String.valueOf(port));
-      ProcessBuilder processBuilder = buildLegacyNativeReadBoardProcessBuilder(usePipe, commands);
+      File nativeReadBoardDirectory = legacyNativeReadBoardDirectory();
+      ProcessBuilder processBuilder =
+          buildLegacyNativeReadBoardProcessBuilder(nativeReadBoardDirectory, usePipe, commands);
       logNativeReadBoardLaunch(processBuilder);
       try {
         process = processBuilder.start();
@@ -649,15 +740,16 @@ public class ReadBoard {
       }
       System.out.println("Board synchronization tool process ended.");
       logReadBoardExit();
-      if (!javaReadBoard && !isLoaded) {
-        shutdown();
-      } else shutdown();
+      shutdownAfterProcessEnd();
       // Do no exit for switching weights
       // System.exit(-1);
     } catch (IOException e) {
       e.printStackTrace();
-      Lizzie.frame.bothSync = false;
-      Lizzie.frame.syncBoard = false;
+      if (Lizzie.frame != null) {
+        Lizzie.frame.bothSync = false;
+        Lizzie.frame.syncBoard = false;
+      }
+      shutdownAfterProcessEnd();
       // System.exit(-1);
     }
   }
@@ -764,6 +856,9 @@ public class ReadBoard {
         msg.setMessage(Lizzie.resourceBundle.getString("ReadBoard.versionCheckFaied"), 2);
       }
     }
+    if (isPlacementFailedLine(line)) {
+      handleLocalMovePlacementFailed(line);
+    }
     if (line.startsWith("error")) {
       Lizzie.gtpConsole.addLineReadBoard(line + (usePipe ? "" : "\n"));
     }
@@ -776,7 +871,7 @@ public class ReadBoard {
       tempcount = new ArrayList<Integer>();
     }
     if (line.startsWith("clear")) {
-      resetActiveSyncState();
+      resetActiveSyncStateForReadBoardControlLine();
       clearPendingRemoteContext();
       tempcount = new ArrayList<Integer>();
     }
@@ -791,15 +886,21 @@ public class ReadBoard {
           clearResumeState();
           Lizzie.board.reopen(boardWidth, boardHeight);
         } else {
-          resetActiveSyncState();
+          resetActiveSyncStateForReadBoardControlLine();
         }
       } else {
-        resetActiveSyncState();
+        resetActiveSyncStateForReadBoardControlLine();
       }
       tempcount = new ArrayList<Integer>();
     }
     if (line.trim().equals("sync")) {
       Lizzie.frame.syncBoard = true;
+      if (isFailedLocalMoveAwaitingRemoteObservation()) {
+        localMoveSyncDebug(
+            "sync line resumes analysis while failed-place guard only blocks placement "
+                + pendingLocalMoveState());
+        releaseFailedLocalMoveObservationIfTimedOut("sync-line");
+      }
       if (isReadBoardAnalysisEngineAvailable() && !Lizzie.leelaz.isPondering()) {
         Lizzie.leelaz.togglePonder();
       }
@@ -820,7 +921,7 @@ public class ReadBoard {
     }
     if (line.startsWith("endsync")) {
       noMsg = true;
-      resetActiveSyncState();
+      resetActiveSyncStateForReadBoardControlLine();
       clearPendingRemoteContext();
       tempcount = new ArrayList<Integer>();
       Lizzie.frame.syncBoard = false;
@@ -833,7 +934,7 @@ public class ReadBoard {
       }
     }
     if (line.startsWith("stopsync")) {
-      resetActiveSyncState();
+      resetActiveSyncStateForReadBoardControlLine();
       clearPendingRemoteContext();
       tempcount = new ArrayList<Integer>();
       Lizzie.frame.syncBoard = false;
@@ -848,6 +949,18 @@ public class ReadBoard {
     }
     if (line.startsWith("play")) {
       String[] params = line.trim().split(">");
+      Stone autoPlayColor = autoPlayColorFromPlayParams(params);
+      clearFailedLocalMoveStateIfAutoPlaySideChanged(autoPlayColor);
+      if (hasFailedLocalMoveStateToPreserve()) {
+        localMoveSyncDebug(
+            "play line preserves failed local move state autoPlayColor="
+                + autoPlayColor
+                + " "
+                + pendingLocalMoveState());
+      } else {
+        clearFailedLocalMoveSuppression();
+        clearFailedLocalMoveRecovery();
+      }
       if (params.length == 3) {
         String[] playParams = params[2].trim().split(" ");
         int playouts = Integer.parseInt(playParams[1]);
@@ -1009,10 +1122,160 @@ public class ReadBoard {
       hideFloadBoardBeforePlace = false;
     }
     if (line.startsWith("placeComplete")) {
+      localMoveSyncDebug("readboard line placeComplete before " + pendingLocalMoveState());
       markLocalMoveCommandCompleted();
-      if (hideFloadBoardBeforePlace && hideFromPlace) {
-        hideFromPlace = false;
-        if (Lizzie.frame.floatBoard != null) Lizzie.frame.floatBoard.setVisible(true);
+      restoreFloatBoardAfterPlaceResult();
+      localMoveSyncDebug("readboard line placeComplete after " + pendingLocalMoveState());
+    }
+  }
+
+  private static boolean isPlacementFailedLine(String line) {
+    return line != null && line.trim().startsWith(READBOARD_PLACEMENT_FAILED);
+  }
+
+  private void handleLocalMovePlacementFailed(String line) {
+    String reason = "readboard line placement failed line=" + line;
+    if (ignoreReadBoardPlaceResultsForCurrentPending) {
+      localMoveSyncDebug(
+          "pending local move placement failure bypasses stale placeComplete quarantine reason="
+              + reason
+              + " "
+              + pendingLocalMoveState());
+    }
+    handlePendingLocalMovePlacementFailure(reason);
+  }
+
+  private boolean handlePendingLocalMovePlacementFailure(String reason) {
+    localMoveSyncDebug(
+        "pending local move placement failure reason="
+            + reason
+            + " before "
+            + pendingLocalMoveState());
+    restoreFloatBoardAfterPlaceResult();
+    if (isPendingLocalMoveAwaitingReadBoard()) {
+      clearConfirmedLocalMove();
+      rememberFailedLocalMoveSuppression();
+      Optional<BoardHistoryNode> rollbackNode = discardFailedLocalMoveFromMainEnd();
+      clearPendingLocalMoveTracking();
+      if (failedLocalMoveRecoveryActive) {
+        beginFailedLocalMoveObservationGuard();
+      }
+      if (rollbackNode.isPresent()) {
+        bindFailedLocalMoveSuppressionBaseline(rollbackNode.get());
+        syncEngineToRebuiltSnapshot(rollbackNode.get());
+        localMoveSyncDebug(
+            "placement failed rolled back; resume analysis with placement guard baseline="
+                + historyNodeSummary(rollbackNode.get())
+                + " "
+                + pendingLocalMoveState());
+        continueGameAfterSyncIfNeeded("placeFailed", rollbackNode.get());
+      } else if (failedLocalMoveRecoveryActive) {
+        localMoveSyncDebug(
+            "placement failed keeps placement guard without rollback " + pendingLocalMoveState());
+      }
+    } else {
+      localMoveSyncDebug(
+          "pending local move placement failure ignored no pending reason="
+              + reason
+              + " "
+              + pendingLocalMoveState());
+    }
+    localMoveSyncDebug(
+        "pending local move placement failure after reason="
+            + reason
+            + " "
+            + pendingLocalMoveState());
+    return true;
+  }
+
+  private Optional<BoardHistoryNode> discardFailedLocalMoveFromMainEnd() {
+    if (!failedLocalMoveRecoveryActive
+        || Lizzie.board == null
+        || Lizzie.board.getHistory() == null) {
+      localMoveSyncDebug(
+          "discard failed local move skip missing recovery " + pendingLocalMoveState());
+      return Optional.empty();
+    }
+    BoardHistoryList history = Lizzie.board.getHistory();
+    BoardHistoryNode failedNode = history.getMainEnd();
+    if (pendingLocalMoveNode != null && failedNode != pendingLocalMoveNode) {
+      localMoveSyncDebug(
+          "discard failed local move skip main end moved away from pending node mainEnd="
+              + historyNodeSummary(failedNode)
+              + " pendingNode="
+              + historyNodeSummary(pendingLocalMoveNode)
+              + " "
+              + pendingLocalMoveState());
+      return Optional.empty();
+    }
+    if (failedNode == null || !matchesFailedLocalMove(failedNode)) {
+      localMoveSyncDebug(
+          "discard failed local move skip no matching main end node="
+              + historyNodeSummary(failedNode)
+              + " "
+              + pendingLocalMoveState());
+      return Optional.empty();
+    }
+    Optional<BoardHistoryNode> previous = failedNode.previous();
+    if (!previous.isPresent()) {
+      localMoveSyncDebug(
+          "discard failed local move skip no previous node="
+              + historyNodeSummary(failedNode)
+              + " "
+              + pendingLocalMoveState());
+      return Optional.empty();
+    }
+    BoardHistoryNode rollbackNode = previous.get();
+    int childIndex = rollbackNode.indexOfNode(failedNode);
+    if (childIndex < 0) {
+      localMoveSyncDebug(
+          "discard failed local move skip child not linked failed="
+              + historyNodeSummary(failedNode)
+              + " rollback="
+              + historyNodeSummary(rollbackNode)
+              + " "
+              + pendingLocalMoveState());
+      return Optional.empty();
+    }
+    moveToAnyPositionWithoutTracking(rollbackNode);
+    rollbackNode.deleteChild(childIndex);
+    historyJumpTracker.clear();
+    localMoveSyncDebug(
+        "discard failed local move rollback="
+            + historyNodeSummary(rollbackNode)
+            + " removed="
+            + historyNodeSummary(failedNode)
+            + " childIndex="
+            + childIndex
+            + " "
+            + pendingLocalMoveState());
+    if (Lizzie.frame != null) {
+      Lizzie.frame.redrawTree = true;
+      Lizzie.frame.renderVarTree(0, 0, false, false);
+      Lizzie.frame.refresh();
+    }
+    return Optional.of(rollbackNode);
+  }
+
+  private boolean matchesFailedLocalMove(BoardHistoryNode node) {
+    if (node == null || node.getData() == null) {
+      return false;
+    }
+    BoardData data = node.getData();
+    if (!data.isMoveNode() || !data.lastMove.isPresent()) {
+      return false;
+    }
+    int[] coords = data.lastMove.get();
+    return coords[0] == failedLocalMoveRecoveryX
+        && coords[1] == failedLocalMoveRecoveryY
+        && data.lastMoveColor == failedLocalMoveRecoveryColor;
+  }
+
+  private void restoreFloatBoardAfterPlaceResult() {
+    if (hideFloadBoardBeforePlace && hideFromPlace) {
+      hideFromPlace = false;
+      if (Lizzie.frame != null && Lizzie.frame.floatBoard != null) {
+        Lizzie.frame.floatBoard.setVisible(true);
       }
     }
   }
@@ -1093,9 +1356,49 @@ public class ReadBoard {
       SyncSnapshotClassifier.SnapshotDelta snapshotDelta =
           classifier.summarizeDelta(syncStartStones, currentSnapshotCodes);
       if (!snapshotDiffChecker().isComparable(currentSnapshotCodes, stones)) {
+        if (lastMovePlayByLizzie || failedLocalMoveSuppressionActive) {
+          localMoveSyncDebug(
+              "syncBoardStones not-comparable isSecondTime="
+                  + isSecondTime
+                  + " snapshot="
+                  + snapshotSummary(currentSnapshotCodes)
+                  + " "
+                  + pendingLocalMoveState());
+        }
         return;
       }
-      acknowledgeLocalMoveIfSnapshotCaughtUp(stones, currentSnapshotCodes);
+      boolean diffWithoutIgnore =
+          snapshotDiffChecker().hasDiff(currentSnapshotCodes, stones, false, Optional.empty());
+      if (lastMovePlayByLizzie || failedLocalMoveSuppressionActive || diffWithoutIgnore) {
+        localMoveSyncDebug(
+            "syncBoardStones start isSecondTime="
+                + isSecondTime
+                + " diffWithoutIgnore="
+                + diffWithoutIgnore
+                + " allowsIncremental="
+                + allowsIncrementalSync(snapshotDelta, node2, currentRemoteContext)
+                + " snapshot="
+                + snapshotSummary(currentSnapshotCodes)
+                + " "
+                + pendingLocalMoveState());
+      }
+      updateFailedLocalMoveSuppressionForSnapshot(currentSnapshotCodes);
+      if (acknowledgeLocalMoveIfSnapshotCaughtUp(stones, currentSnapshotCodes)) {
+        finishSyncAfterAcknowledgedLocalMoveSnapshot();
+        return;
+      }
+      updateConfirmedLocalMoveForSnapshot(currentSnapshotCodes);
+      if (shouldHoldSyncForConfirmedLocalMove(currentSnapshotCodes)) {
+        localMoveSyncDebug(
+            "syncBoardStones hold stale snapshot before confirmed local move snapshot="
+                + snapshotSummary(currentSnapshotCodes)
+                + " "
+                + pendingLocalMoveState());
+        return;
+      }
+      if (retryPendingLocalMoveIfSnapshotStillMissing(currentSnapshotCodes)) {
+        return;
+      }
 
       boolean needRefresh = false;
       if (allowsIncrementalSync(snapshotDelta, node2, currentRemoteContext)) {
@@ -1206,9 +1509,22 @@ public class ReadBoard {
             resolveCompleteSnapshotRecovery(
                 node2, node, syncStartStones, currentSnapshotCodes, snapshotDelta);
         if (recovery.outcome == CompleteSnapshotRecoveryOutcome.HOLD) {
+          if (lastMovePlayByLizzie || failedLocalMoveSuppressionActive || diffWithoutIgnore) {
+            localMoveSyncDebug(
+                "syncBoardStones recovery HOLD snapshot="
+                    + snapshotSummary(currentSnapshotCodes)
+                    + " "
+                    + pendingLocalMoveState());
+          }
+          resumeFailedLocalMoveAfterRecoveryHoldIfNeeded(played || needRefresh);
           return;
         }
         if (recovery.outcome == CompleteSnapshotRecoveryOutcome.FORCE_REBUILD) {
+          localMoveSyncDebug(
+              "syncBoardStones recovery FORCE_REBUILD snapshot="
+                  + snapshotSummary(currentSnapshotCodes)
+                  + " "
+                  + pendingLocalMoveState());
           rebuildFromSnapshot(node2, currentSnapshotCodes, snapshotDelta, currentFoxMoveNumber);
           return;
         }
@@ -1272,15 +1588,7 @@ public class ReadBoard {
           }
         }.start();
       }
-      if (Lizzie.frame.isPlayingAgainstLeelaz && needGenmove) {
-        if (!Lizzie.board.getHistory().isBlacksTurn() && Lizzie.frame.playerIsBlack) {
-          Lizzie.leelaz.genmove("W");
-          needGenmove = false;
-        } else if (!Lizzie.frame.playerIsBlack) {
-          Lizzie.leelaz.genmove("B");
-          needGenmove = false;
-        }
-      }
+      continueGameAfterSyncIfNeeded("sync", Lizzie.board.getHistory().getCurrentHistoryNode());
     } finally {
       localNavigationTracker.clear();
       isSyncing = false;
@@ -1290,6 +1598,36 @@ public class ReadBoard {
     //	      Lizzie.board.goToMoveNumberBeyondBranch(moveNumber);
     //	      Lizzie.frame.refresh();
     //	    }
+  }
+
+  private void resumeFailedLocalMoveAfterRecoveryHoldIfNeeded(boolean needRefresh) {
+    if (!failedLocalMoveRecoveryActive
+        || Lizzie.board == null
+        || Lizzie.board.getHistory() == null) {
+      return;
+    }
+    BoardHistoryNode heldMainEnd = Lizzie.board.getHistory().getMainEnd();
+    localMoveSyncDebug(
+        "syncBoardStones recovery HOLD checks failed local move target="
+            + historyNodeSummary(heldMainEnd)
+            + " "
+            + pendingLocalMoveState());
+    if (failedLocalMoveAwaitingRemoteObservation) {
+      localMoveSyncDebug(
+          "syncBoardStones recovery HOLD keeps failed-place guard but lets analysis continue "
+              + pendingLocalMoveState());
+      if (continueGameAfterSyncIfNeeded("sync-hold-observation", heldMainEnd)
+          && needRefresh
+          && Lizzie.frame != null) {
+        Lizzie.frame.refresh();
+      }
+      return;
+    }
+    if (resumeFailedLocalMoveAfterSyncIfNeeded("sync-hold", heldMainEnd)
+        && needRefresh
+        && Lizzie.frame != null) {
+      Lizzie.frame.refresh();
+    }
   }
 
   private int[] getSnapshotCodes() {
@@ -1416,6 +1754,14 @@ public class ReadBoard {
     if (shouldForceRebuildOnResumeConflict(remoteContext)) {
       return CompleteSnapshotRecoveryDecision.forceRebuild();
     }
+    if (shouldHoldCompleteSnapshotRecoveryForPendingLocalMove(snapshotCodes)) {
+      localMoveSyncDebug(
+          "resolveCompleteSnapshotRecovery hold pending local move snapshot="
+              + snapshotSummary(snapshotCodes)
+              + " "
+              + pendingLocalMoveState());
+      return CompleteSnapshotRecoveryDecision.hold();
+    }
 
     Optional<BoardHistoryNode> matchingNode =
         remoteContext != null && remoteContext.supportsFoxRecovery()
@@ -1449,6 +1795,13 @@ public class ReadBoard {
       return CompleteSnapshotRecoveryDecision.hold();
     }
     return CompleteSnapshotRecoveryDecision.forceRebuild();
+  }
+
+  private boolean shouldHoldCompleteSnapshotRecoveryForPendingLocalMove(int[] snapshotCodes) {
+    // Callers must run snapshot ack and pending-place timeout handling before this stale-snapshot
+    // guard.
+    return isPendingLocalMoveAwaitingReadBoard()
+        && currentPendingLocalMoveCoordinates().isPresent();
   }
 
   private boolean shouldForceRebuildWithoutWaiting(
@@ -1493,7 +1846,22 @@ public class ReadBoard {
       OptionalInt foxMoveNumber) {
     SyncRemoteContext resolvedRemoteContext = currentPendingRemoteContext().withoutForceRebuild();
     boolean analysisEngineAvailable = isReadBoardAnalysisEngineAvailable();
-    resetActiveSyncState();
+    localMoveSyncDebug(
+        "rebuildFromSnapshot start engineAvailable="
+            + analysisEngineAvailable
+            + " syncStart="
+            + historyNodeSummary(syncStartNode)
+            + " snapshot="
+            + snapshotSummary(snapshotCodes)
+            + " foxMoveNumber="
+            + (foxMoveNumber.isPresent() ? foxMoveNumber.getAsInt() : "empty")
+            + " "
+            + pendingLocalMoveState());
+    if (failedLocalMoveRecoveryActive) {
+      resetActiveSyncState(true, failedLocalMoveSuppressionActive);
+    } else {
+      resetActiveSyncState(true);
+    }
     BoardHistoryList previousHistory = Lizzie.board.getHistory();
     RootStartSetupState preservedRootStartSetup = captureRootStartSetupState();
     BoardHistoryList rebuiltHistory =
@@ -1506,16 +1874,29 @@ public class ReadBoard {
     Lizzie.board.startStonelist = new ArrayList<>();
     setHistoryWithoutInvalidatingResumeState(rebuiltHistory);
     restoreRootStartSetupIfNoOrRootSnapshotAnchor(syncStartNode, preservedRootStartSetup);
+    BoardHistoryNode rebuiltNode = rebuiltHistory.getCurrentHistoryNode();
     if (analysisEngineAvailable) {
-      syncEngineToRebuiltSnapshot(rebuiltHistory.getCurrentHistoryNode());
+      try {
+        syncEngineToRebuiltSnapshot(rebuiltNode);
+      } catch (RuntimeException ex) {
+        localMoveSyncDebug(
+            "rebuildFromSnapshot syncEngine failed node="
+                + historyNodeSummary(rebuiltNode)
+                + " error="
+                + ex.getClass().getSimpleName()
+                + ": "
+                + ex.getMessage());
+        throw ex;
+      }
     }
-    rememberResolvedSnapshotNode(rebuiltHistory.getCurrentHistoryNode(), resolvedRemoteContext);
-    if (analysisEngineAvailable) {
-      scheduleResumeAnalysisAfterSync(rebuiltHistory.getCurrentHistoryNode());
+    rememberResolvedSnapshotNode(rebuiltNode, resolvedRemoteContext);
+    if (analysisEngineAvailable && !continueGameAfterSyncIfNeeded("rebuild", rebuiltNode)) {
+      scheduleResumeAnalysisAfterSync(rebuiltNode);
     }
     Lizzie.frame.renderVarTree(0, 0, false, false);
     Lizzie.frame.refresh();
     firstSync = false;
+    localMoveSyncDebug("rebuildFromSnapshot done rebuilt=" + historyNodeSummary(rebuiltNode));
   }
 
   private BoardHistoryList buildSnapshotHistory(
@@ -1885,13 +2266,29 @@ public class ReadBoard {
 
   private void syncEngineToRebuiltSnapshot(BoardHistoryNode rebuiltNode) {
     if (!isReadBoardAnalysisEngineAvailable()) {
+      localMoveSyncDebug(
+          "syncEngineToRebuiltSnapshot skip engine unavailable node="
+              + historyNodeSummary(rebuiltNode));
       return;
     }
     BoardData data = rebuiltNode.getData();
-    Lizzie.leelaz.clear();
-    if (!ExactSnapshotEngineRestore.restoreIfNeeded(Lizzie.leelaz, data)) {
-      throw new IllegalStateException("Snapshot rebuild must sync through snapshot data.");
+    BoardData restoreData =
+        data.isSnapshotNode() ? data : SnapshotEngineRestore.snapshotFromCurrentBoard(data);
+    boolean wasPondering = Lizzie.leelaz.isPondering();
+    localMoveSyncDebug(
+        "syncEngineToRebuiltSnapshot begin node="
+            + historyNodeSummary(rebuiltNode)
+            + " restoreNodeType="
+            + (data.isSnapshotNode() ? "snapshot" : "move")
+            + " enginePondering="
+            + wasPondering);
+    Lizzie.leelaz.clearWithoutPonder();
+    localMoveSyncDebug("syncEngineToRebuiltSnapshot clearWithoutPonder sent");
+    if (!ExactSnapshotEngineRestore.restoreIfNeeded(Lizzie.leelaz, restoreData)) {
+      throw new IllegalStateException("Engine restore must sync through snapshot data.");
     }
+    localMoveSyncDebug(
+        "syncEngineToRebuiltSnapshot loadsgf completed node=" + historyNodeSummary(rebuiltNode));
   }
 
   private static final class SnapshotCaptures {
@@ -1935,9 +2332,73 @@ public class ReadBoard {
   }
 
   private void resetActiveSyncState() {
+    resetActiveSyncState(false, false, false);
+  }
+
+  private void resetActiveSyncState(boolean preserveFailedLocalMoveRecovery) {
+    resetActiveSyncState(preserveFailedLocalMoveRecovery, false, false);
+  }
+
+  private void resetActiveSyncStateForReadBoardControlLine() {
+    boolean preserveFailedLocalMoveState = hasFailedLocalMoveStateToPreserve();
+    boolean preservePendingLocalMove = isPendingLocalMoveAwaitingReadBoard();
+    boolean preserveConfirmedLocalMove = confirmedLocalMoveActive;
+    resetActiveSyncState(
+        preserveFailedLocalMoveState,
+        preserveFailedLocalMoveState,
+        preservePendingLocalMove,
+        preserveConfirmedLocalMove);
+  }
+
+  private void resetActiveSyncState(
+      boolean preserveFailedLocalMoveRecovery, boolean preserveFailedLocalMoveSuppression) {
+    resetActiveSyncState(
+        preserveFailedLocalMoveRecovery, preserveFailedLocalMoveSuppression, false);
+  }
+
+  private void resetActiveSyncState(
+      boolean preserveFailedLocalMoveRecovery,
+      boolean preserveFailedLocalMoveSuppression,
+      boolean preservePendingLocalMoveTracking) {
+    resetActiveSyncState(
+        preserveFailedLocalMoveRecovery,
+        preserveFailedLocalMoveSuppression,
+        preservePendingLocalMoveTracking,
+        false);
+  }
+
+  private void resetActiveSyncState(
+      boolean preserveFailedLocalMoveRecovery,
+      boolean preserveFailedLocalMoveSuppression,
+      boolean preservePendingLocalMoveTracking,
+      boolean preserveConfirmedLocalMove) {
     conflictTracker.clear();
     historyJumpTracker.clear();
-    waitingForReadBoardLocalMoveAck = false;
+    if (preservePendingLocalMoveTracking && isPendingLocalMoveAwaitingReadBoard()) {
+      localMoveSyncDebug(
+          "preserve pending local move across active sync reset " + pendingLocalMoveState());
+    } else {
+      clearPendingLocalMoveTracking();
+    }
+    if (preserveFailedLocalMoveSuppression && failedLocalMoveSuppressionActive) {
+      localMoveSyncDebug(
+          "preserve suppression across active sync reset " + pendingLocalMoveState());
+    } else {
+      clearFailedLocalMoveSuppression();
+    }
+    if (!preserveFailedLocalMoveRecovery) {
+      clearFailedLocalMoveRecovery();
+    } else if (failedLocalMoveRecoveryActive) {
+      localMoveSyncDebug(
+          "preserve failed local move recovery across active sync reset "
+              + pendingLocalMoveState());
+    }
+    if (preserveConfirmedLocalMove && confirmedLocalMoveActive) {
+      localMoveSyncDebug(
+          "preserve confirmed local move across active sync reset " + pendingLocalMoveState());
+    } else {
+      clearConfirmedLocalMove();
+    }
     pendingRemoteContext = SyncRemoteContext.generic(false);
     awaitingFirstSyncFrame = true;
     invalidatePendingSyncAnalysisResume();
@@ -1947,6 +2408,7 @@ public class ReadBoard {
     invalidatePendingSyncAnalysisResume();
     resumeState = null;
     lastResolvedSnapshotNode = null;
+    clearConfirmedLocalMove();
   }
 
   private synchronized void runWithSuppressedHistoryOverwriteInvalidation(Runnable action) {
@@ -2016,26 +2478,182 @@ public class ReadBoard {
             currentPendingLocalMove);
   }
 
-  private void acknowledgeLocalMoveIfSnapshotCaughtUp(Stone[] stones, int[] snapshotCodes) {
+  private boolean acknowledgeLocalMoveIfSnapshotCaughtUp(Stone[] stones, int[] snapshotCodes) {
     if (!Lizzie.frame.bothSync || !lastMovePlayByLizzie) {
-      return;
+      return false;
     }
     if (!currentPendingLocalMoveCoordinates().isPresent()) {
+      localMoveSyncDebug("ack skip no pending coordinates " + pendingLocalMoveState());
+      return false;
+    }
+    boolean pendingPresent = isCurrentPendingLocalMovePresentInSnapshot(snapshotCodes);
+    boolean noDiff = !snapshotDiffChecker().hasDiff(snapshotCodes, stones, false, Optional.empty());
+    localMoveSyncDebug(
+        "ack check pendingPresent="
+            + pendingPresent
+            + " noDiffWithoutIgnore="
+            + noDiff
+            + " snapshot="
+            + snapshotSummary(snapshotCodes)
+            + " "
+            + pendingLocalMoveState());
+    if (pendingPresent) {
+      localMoveSyncDebug("ack clear pending " + pendingLocalMoveState());
+      clearPendingLocalMoveTracking();
+      return true;
+    } else if (noDiff) {
+      localMoveSyncDebug(
+          "ack keeps pending despite noDiff because pending move is not visible "
+              + pendingLocalMoveState());
+    }
+    return false;
+  }
+
+  private void finishSyncAfterAcknowledgedLocalMoveSnapshot() {
+    BoardHistoryNode acknowledgedNode = Lizzie.board.getHistory().getMainEnd();
+    clearConfirmedLocalMove();
+    rememberResolvedSnapshotNode(acknowledgedNode);
+    conflictTracker.clear();
+    historyJumpTracker.clear();
+    awaitingFirstSyncFrame = false;
+    invalidatePendingSyncAnalysisResume();
+    localMoveSyncDebug(
+        "syncBoardStones ack caught up; skip stale recovery target="
+            + historyNodeSummary(acknowledgedNode)
+            + " "
+            + pendingLocalMoveState());
+    if (!continueGameAfterSyncIfNeeded("ack", acknowledgedNode)) {
+      scheduleResumeAnalysisAfterSync(acknowledgedNode);
+    }
+  }
+
+  private void finishSyncAfterConfirmedLocalMoveCommand(BoardHistoryNode confirmedNode) {
+    if (confirmedNode == null) {
       return;
     }
-    if (!snapshotDiffChecker().hasDiff(snapshotCodes, stones, false, Optional.empty())) {
-      lastMovePlayByLizzie = false;
-      waitingForReadBoardLocalMoveAck = false;
+    rememberResolvedSnapshotNode(confirmedNode);
+    conflictTracker.clear();
+    historyJumpTracker.clear();
+    awaitingFirstSyncFrame = false;
+    invalidatePendingSyncAnalysisResume();
+    localMoveSyncDebug(
+        "placeComplete confirmed local move; protect against stale recovery target="
+            + historyNodeSummary(confirmedNode)
+            + " "
+            + pendingLocalMoveState());
+    if (!continueGameAfterSyncIfNeeded("placeComplete", confirmedNode)) {
+      scheduleResumeAnalysisAfterSync(confirmedNode);
     }
   }
 
   private void startTrackingLocalMoveFromLizzie() {
+    clearConfirmedLocalMove();
+    capturePendingLocalMoveRecord(currentMainEndNode());
     lastMovePlayByLizzie = true;
     waitingForReadBoardLocalMoveAck = true;
+    pendingLocalMoveClickCompleted = false;
+    pendingLocalMoveRetryCount = 0;
+    ignoreReadBoardPlaceResultsForCurrentPending = ignoreReadBoardPlaceResultsForNextPending;
+    ignoreReadBoardPlaceResultsForNextPending = false;
+    lastPendingLocalMoveRetryTimeMs = System.currentTimeMillis();
+    pendingLocalMoveAckGeneration++;
+    localMoveSyncDebug("startTrackingLocalMoveFromLizzie " + pendingLocalMoveState());
+    schedulePendingLocalMoveAckTimeout();
+  }
+
+  private void schedulePendingLocalMoveAckTimeout() {
+    ScheduledExecutorService timeoutExecutor = ensurePendingLocalMoveTimeoutExecutor();
+    if (timeoutExecutor == null || timeoutExecutor.isShutdown()) {
+      return;
+    }
+    final long generation = pendingLocalMoveAckGeneration;
+    final BoardHistoryNode node = pendingLocalMoveNode;
+    final int x = pendingLocalMoveX;
+    final int y = pendingLocalMoveY;
+    final Stone color = pendingLocalMoveColor;
+    timeoutExecutor.schedule(
+        () -> failPendingLocalMoveIfAckTimedOutWithoutSnapshot(generation, node, x, y, color),
+        PENDING_LOCAL_MOVE_ACK_TIMEOUT_MS,
+        TimeUnit.MILLISECONDS);
+  }
+
+  private ScheduledExecutorService ensurePendingLocalMoveTimeoutExecutor() {
+    if (shutdownStarted || System.getProperty("surefire.test.class.path") != null) {
+      return null;
+    }
+    if (pendingLocalMoveTimeoutExecutor == null || pendingLocalMoveTimeoutExecutor.isShutdown()) {
+      pendingLocalMoveTimeoutExecutor =
+          Executors.newSingleThreadScheduledExecutor(
+              runnable -> {
+                Thread thread = new Thread(runnable, "readboard-local-move-timeout");
+                thread.setDaemon(true);
+                return thread;
+              });
+    }
+    return pendingLocalMoveTimeoutExecutor;
   }
 
   private void markLocalMoveCommandCompleted() {
+    if (!isPendingLocalMoveAwaitingReadBoard()) {
+      pendingLocalMoveClickCompleted = false;
+      localMoveSyncDebug(
+          "markLocalMoveCommandCompleted ignored no pending " + pendingLocalMoveState());
+      return;
+    }
+    if (ignoreReadBoardPlaceResultsForCurrentPending) {
+      localMoveSyncDebug(
+          "markLocalMoveCommandCompleted ignored by stale-result quarantine "
+              + pendingLocalMoveState());
+      return;
+    }
+    pendingLocalMoveClickCompleted = true;
+    localMoveSyncDebug("markLocalMoveCommandCompleted " + pendingLocalMoveState());
+    localMoveSyncDebug(
+        "placeComplete noted pending local move; waiting for remote snapshot "
+            + pendingLocalMoveState());
+  }
+
+  private void clearFailedLocalMoveStateIfCurrentMoveConfirmed() {
+    if (!hasFailedLocalMoveStateToPreserve()
+        || Lizzie.board == null
+        || Lizzie.board.getHistory() == null) {
+      return;
+    }
+    BoardHistoryNode mainEnd = Lizzie.board.getHistory().getMainEnd();
+    if (matchesFailedLocalMove(mainEnd)) {
+      localMoveSyncDebug(
+          "placeComplete clears failed local move state node="
+              + historyNodeSummary(mainEnd)
+              + " "
+              + pendingLocalMoveState());
+      clearFailedLocalMoveSuppression();
+      clearFailedLocalMoveRecovery();
+    }
+  }
+
+  private void clearPendingLocalMoveTracking() {
+    localMoveSyncDebug("clearPendingLocalMoveTracking before " + pendingLocalMoveState());
+    boolean wasPending = isPendingLocalMoveAwaitingReadBoard();
+    lastMovePlayByLizzie = false;
     waitingForReadBoardLocalMoveAck = false;
+    pendingLocalMoveClickCompleted = false;
+    pendingLocalMoveRetryCount = 0;
+    lastPendingLocalMoveRetryTimeMs = 0L;
+    pendingLocalMoveNode = null;
+    pendingLocalMoveX = -1;
+    pendingLocalMoveY = -1;
+    pendingLocalMoveColor = Stone.EMPTY;
+    pendingLocalMoveBaselineKey = "";
+    ignoreReadBoardPlaceResultsForCurrentPending = false;
+    if (wasPending) {
+      pendingLocalMoveAckGeneration++;
+      ignoreReadBoardPlaceResultsForNextPending = true;
+    }
+    localMoveSyncDebug("clearPendingLocalMoveTracking after " + pendingLocalMoveState());
+  }
+
+  public boolean isPendingLocalMoveAwaitingReadBoard() {
+    return lastMovePlayByLizzie && waitingForReadBoardLocalMoveAck;
   }
 
   private boolean shouldIgnoreCurrentLastLocalMove() {
@@ -2046,12 +2664,867 @@ public class ReadBoard {
     return shouldIgnoreCurrentLastLocalMove() && currentPendingLocalMove.isPresent();
   }
 
+  private void capturePendingLocalMoveRecord(BoardHistoryNode node) {
+    pendingLocalMoveNode = null;
+    pendingLocalMoveX = -1;
+    pendingLocalMoveY = -1;
+    pendingLocalMoveColor = Stone.EMPTY;
+    pendingLocalMoveBaselineKey = "";
+    if (node == null || node.getData() == null) {
+      localMoveSyncDebug("capture pending local move skipped missing node");
+      return;
+    }
+    BoardData data = node.getData();
+    if (!data.isMoveNode()
+        || !data.lastMove.isPresent()
+        || data.lastMoveColor == null
+        || data.lastMoveColor.isEmpty()) {
+      localMoveSyncDebug(
+          "capture pending local move skipped non-move node=" + historyNodeSummary(node));
+      return;
+    }
+    int[] coords = data.lastMove.get();
+    pendingLocalMoveNode = node;
+    pendingLocalMoveX = coords[0];
+    pendingLocalMoveY = coords[1];
+    pendingLocalMoveColor = data.lastMoveColor;
+    Optional<BoardHistoryNode> previousNode = node.previous();
+    pendingLocalMoveBaselineKey =
+        previousNode.isPresent()
+            ? snapshotPositionKey(snapshotCodesForNode(previousNode.get()))
+            : "";
+    localMoveSyncDebug(
+        "capture pending local move coords="
+            + coordsText(coords)
+            + " color="
+            + pendingLocalMoveColor
+            + " baselineKey="
+            + pendingLocalMoveBaselineKey
+            + " node="
+            + historyNodeSummary(node));
+  }
+
+  private boolean hasPendingLocalMoveRecord() {
+    return pendingLocalMoveNode != null
+        && pendingLocalMoveX >= 0
+        && pendingLocalMoveY >= 0
+        && pendingLocalMoveColor != null
+        && !pendingLocalMoveColor.isEmpty();
+  }
+
   private Optional<int[]> currentPendingLocalMoveCoordinates() {
-    BoardData mainEndData = Lizzie.board.getHistory().getMainEnd().getData();
-    if (!mainEndData.isMoveNode()) {
+    if (!hasPendingLocalMoveRecord()) {
       return Optional.empty();
     }
-    return mainEndData.lastMove;
+    return Optional.of(new int[] {pendingLocalMoveX, pendingLocalMoveY});
+  }
+
+  private BoardHistoryNode currentMainEndNode() {
+    if (Lizzie.board == null || Lizzie.board.getHistory() == null) {
+      return null;
+    }
+    return Lizzie.board.getHistory().getMainEnd();
+  }
+
+  private boolean isCurrentPendingLocalMovePresentInSnapshot(int[] snapshotCodes) {
+    Optional<int[]> currentPendingLocalMove = currentPendingLocalMoveCoordinates();
+    if (!currentPendingLocalMove.isPresent()) {
+      return false;
+    }
+    return snapshotContainsMove(
+        snapshotCodes, currentPendingLocalMove.get(), pendingLocalMoveColor);
+  }
+
+  private boolean snapshotContainsMove(int[] snapshotCodes, int[] coords, Stone color) {
+    if (coords == null || coords.length < 2 || color == null || color.isEmpty()) {
+      return false;
+    }
+    int index = coords[1] * Board.boardWidth + coords[0];
+    if (index < 0 || index >= snapshotCodes.length) {
+      return false;
+    }
+    int code = snapshotCodes[index];
+    return color.isBlack() ? code == 1 || code == 3 : code == 2 || code == 4;
+  }
+
+  private void rememberConfirmedLocalMove(BoardHistoryNode node) {
+    if (node == null || node.getData() == null) {
+      clearConfirmedLocalMove();
+      return;
+    }
+    BoardData data = node.getData();
+    if (!data.isMoveNode()
+        || !data.lastMove.isPresent()
+        || data.lastMoveColor == null
+        || data.lastMoveColor.isEmpty()) {
+      clearConfirmedLocalMove();
+      return;
+    }
+    int[] coords = data.lastMove.get();
+    confirmedLocalMoveActive = true;
+    confirmedLocalMoveNode = node;
+    confirmedLocalMoveX = coords[0];
+    confirmedLocalMoveY = coords[1];
+    confirmedLocalMoveColor = data.lastMoveColor;
+    Optional<BoardHistoryNode> previousNode = node.previous();
+    confirmedLocalMoveBaselineKey =
+        previousNode.isPresent()
+            ? snapshotPositionKey(snapshotCodesForNode(previousNode.get()))
+            : "";
+    localMoveSyncDebug(
+        "remember confirmed local move coords="
+            + coordsText(coords)
+            + " color="
+            + confirmedLocalMoveColor
+            + " baselineKey="
+            + confirmedLocalMoveBaselineKey
+            + " node="
+            + historyNodeSummary(node));
+  }
+
+  private void clearConfirmedLocalMove() {
+    if (confirmedLocalMoveActive) {
+      localMoveSyncDebug("clear confirmed local move before " + pendingLocalMoveState());
+    }
+    confirmedLocalMoveActive = false;
+    confirmedLocalMoveNode = null;
+    confirmedLocalMoveX = -1;
+    confirmedLocalMoveY = -1;
+    confirmedLocalMoveColor = Stone.EMPTY;
+    confirmedLocalMoveBaselineKey = "";
+  }
+
+  private void updateConfirmedLocalMoveForSnapshot(int[] snapshotCodes) {
+    if (!confirmedLocalMoveActive) {
+      return;
+    }
+    if (snapshotContainsConfirmedLocalMove(snapshotCodes)) {
+      localMoveSyncDebug(
+          "confirmed local move reached remote snapshot snapshot="
+              + snapshotSummary(snapshotCodes)
+              + " "
+              + pendingLocalMoveState());
+      clearConfirmedLocalMove();
+      return;
+    }
+    if (!isConfirmedLocalMoveBaselineSnapshot(snapshotCodes)) {
+      localMoveSyncDebug(
+          "confirmed local move snapshot advanced without target; releasing stale guard snapshot="
+              + snapshotSummary(snapshotCodes)
+              + " "
+              + pendingLocalMoveState());
+      clearConfirmedLocalMove();
+    }
+  }
+
+  private boolean shouldHoldSyncForConfirmedLocalMove(int[] snapshotCodes) {
+    return confirmedLocalMoveActive
+        && !snapshotContainsConfirmedLocalMove(snapshotCodes)
+        && isConfirmedLocalMoveBaselineSnapshot(snapshotCodes);
+  }
+
+  private boolean snapshotContainsConfirmedLocalMove(int[] snapshotCodes) {
+    return snapshotContainsMove(
+        snapshotCodes,
+        new int[] {confirmedLocalMoveX, confirmedLocalMoveY},
+        confirmedLocalMoveColor);
+  }
+
+  private boolean isConfirmedLocalMoveBaselineSnapshot(int[] snapshotCodes) {
+    return confirmedLocalMoveBaselineKey != null
+        && !confirmedLocalMoveBaselineKey.isEmpty()
+        && confirmedLocalMoveBaselineKey.equals(snapshotPositionKey(snapshotCodes));
+  }
+
+  private boolean retryPendingLocalMoveIfSnapshotStillMissing(int[] snapshotCodes) {
+    if (!Lizzie.frame.bothSync || !lastMovePlayByLizzie) {
+      return false;
+    }
+    if (!waitingForReadBoardLocalMoveAck) {
+      localMoveSyncDebug("retry skip not waiting " + pendingLocalMoveState());
+      return false;
+    }
+    boolean pendingPresent = isCurrentPendingLocalMovePresentInSnapshot(snapshotCodes);
+    if (failPendingLocalMoveIfRemoteChangedWithoutTarget(snapshotCodes, pendingPresent)) {
+      return true;
+    }
+    if (failPendingLocalMoveIfAckTimedOut(snapshotCodes, pendingPresent)) {
+      return true;
+    }
+    if (pendingLocalMoveRetryCount >= LOCAL_MOVE_PLACE_RETRY_LIMIT || pendingPresent) {
+      localMoveSyncDebug(
+          "retry skip limit-or-present pendingPresent="
+              + pendingPresent
+              + " snapshot="
+              + snapshotSummary(snapshotCodes)
+              + " "
+              + pendingLocalMoveState());
+      return false;
+    }
+    Optional<int[]> currentPendingLocalMove = currentPendingLocalMoveCoordinates();
+    if (!currentPendingLocalMove.isPresent()) {
+      localMoveSyncDebug("retry skip no pending coordinates " + pendingLocalMoveState());
+      return false;
+    }
+    long now = System.currentTimeMillis();
+    if (!pendingLocalMoveClickCompleted
+        && now - lastPendingLocalMoveRetryTimeMs < LOCAL_MOVE_PLACE_RETRY_INTERVAL_MS) {
+      localMoveSyncDebug(
+          "retry wait no placeComplete elapsedMs="
+              + (now - lastPendingLocalMoveRetryTimeMs)
+              + " "
+              + pendingLocalMoveState());
+      return false;
+    }
+    if (now - lastPendingLocalMoveRetryTimeMs < LOCAL_MOVE_PLACE_RETRY_INTERVAL_MS) {
+      localMoveSyncDebug(
+          "retry wait interval elapsedMs="
+              + (now - lastPendingLocalMoveRetryTimeMs)
+              + " "
+              + pendingLocalMoveState());
+      return false;
+    }
+    int[] coords = currentPendingLocalMove.get();
+    pendingLocalMoveRetryCount++;
+    pendingLocalMoveClickCompleted = false;
+    lastPendingLocalMoveRetryTimeMs = now;
+    localMoveSyncDebug(
+        "retry sending place coords="
+            + coordsText(coords)
+            + " snapshot="
+            + snapshotSummary(snapshotCodes)
+            + " "
+            + pendingLocalMoveState());
+    sendPlaceCommandWithoutRestartingTracking(coords[0], coords[1]);
+    return false;
+  }
+
+  private boolean failPendingLocalMoveIfRemoteChangedWithoutTarget(
+      int[] snapshotCodes, boolean pendingPresent) {
+    if (pendingPresent || !isPendingLocalMoveAwaitingReadBoard()) {
+      return false;
+    }
+    if (pendingLocalMoveBaselineKey == null || pendingLocalMoveBaselineKey.isEmpty()) {
+      return false;
+    }
+    String snapshotKey = snapshotPositionKey(snapshotCodes);
+    if (snapshotKey.isEmpty() || pendingLocalMoveBaselineKey.equals(snapshotKey)) {
+      return false;
+    }
+    localMoveSyncDebug(
+        "pending local move remote changed without target; treating as misplaced/failed move snapshot="
+            + snapshotSummary(snapshotCodes)
+            + " "
+            + pendingLocalMoveState());
+    return handlePendingLocalMovePlacementFailure(
+        "pending local move remote changed without target");
+  }
+
+  private boolean failPendingLocalMoveIfAckTimedOut(int[] snapshotCodes, boolean pendingPresent) {
+    if (pendingPresent || !isPendingLocalMoveAwaitingReadBoard()) {
+      return false;
+    }
+    Optional<int[]> currentPendingLocalMove = currentPendingLocalMoveCoordinates();
+    if (!currentPendingLocalMove.isPresent()) {
+      localMoveSyncDebug(
+          "pending local move ack timeout skip no coordinates " + pendingLocalMoveState());
+      return false;
+    }
+    long now = System.currentTimeMillis();
+    long elapsedMs =
+        lastPendingLocalMoveRetryTimeMs == 0L ? 0L : now - lastPendingLocalMoveRetryTimeMs;
+    if (lastPendingLocalMoveRetryTimeMs == 0L || elapsedMs < PENDING_LOCAL_MOVE_ACK_TIMEOUT_MS) {
+      localMoveSyncDebug(
+          "pending local move waits for place result elapsedMs="
+              + elapsedMs
+              + " timeoutMs="
+              + PENDING_LOCAL_MOVE_ACK_TIMEOUT_MS
+              + " snapshot="
+              + snapshotSummary(snapshotCodes)
+              + " "
+              + pendingLocalMoveState());
+      return false;
+    }
+    localMoveSyncDebug(
+        "pending local move timed out without place result elapsedMs="
+            + elapsedMs
+            + " timeoutMs="
+            + PENDING_LOCAL_MOVE_ACK_TIMEOUT_MS
+            + " snapshot="
+            + snapshotSummary(snapshotCodes)
+            + " "
+            + pendingLocalMoveState());
+    return handlePendingLocalMovePlacementFailure(
+        "pending local move timed out without place result elapsedMs=" + elapsedMs);
+  }
+
+  private boolean failPendingLocalMoveIfAckTimedOutWithoutSnapshot() {
+    return failPendingLocalMoveIfAckTimedOutWithoutSnapshot(
+        pendingLocalMoveAckGeneration,
+        pendingLocalMoveNode,
+        pendingLocalMoveX,
+        pendingLocalMoveY,
+        pendingLocalMoveColor);
+  }
+
+  private boolean failPendingLocalMoveIfAckTimedOutWithoutSnapshot(
+      long generation, BoardHistoryNode node, int x, int y, Stone color) {
+    if (!isPendingLocalMoveAwaitingReadBoard()
+        || generation != pendingLocalMoveAckGeneration
+        || !samePendingLocalMove(node, x, y, color)) {
+      localMoveSyncDebug(
+          "pending local move timer skip stale generation="
+              + generation
+              + " currentGeneration="
+              + pendingLocalMoveAckGeneration
+              + " "
+              + pendingLocalMoveState());
+      return false;
+    }
+    long now = System.currentTimeMillis();
+    long elapsedMs =
+        lastPendingLocalMoveRetryTimeMs == 0L ? 0L : now - lastPendingLocalMoveRetryTimeMs;
+    if (lastPendingLocalMoveRetryTimeMs == 0L || elapsedMs < PENDING_LOCAL_MOVE_ACK_TIMEOUT_MS) {
+      localMoveSyncDebug(
+          "pending local move timer skip before timeout elapsedMs="
+              + elapsedMs
+              + " timeoutMs="
+              + PENDING_LOCAL_MOVE_ACK_TIMEOUT_MS
+              + " "
+              + pendingLocalMoveState());
+      return false;
+    }
+    localMoveSyncDebug(
+        "pending local move timer timed out without sync frame elapsedMs="
+            + elapsedMs
+            + " timeoutMs="
+            + PENDING_LOCAL_MOVE_ACK_TIMEOUT_MS
+            + " "
+            + pendingLocalMoveState());
+    return handlePendingLocalMovePlacementFailure(
+        "pending local move timed out without sync frame elapsedMs=" + elapsedMs);
+  }
+
+  private boolean samePendingLocalMove(BoardHistoryNode node, int x, int y, Stone color) {
+    return pendingLocalMoveNode == node
+        && pendingLocalMoveX == x
+        && pendingLocalMoveY == y
+        && pendingLocalMoveColor == color;
+  }
+
+  public boolean shouldSuppressLocalPlaceAfterFailedSync(int x, int y, Stone color) {
+    if (!failedLocalMoveSuppressionActive || color == null) {
+      return false;
+    }
+    if (failedLocalMoveAwaitingRemoteObservation) {
+      if (releaseFailedLocalMoveObservationIfTimedOut("local-place")) {
+        return false;
+      }
+      YikeSyncDebugLog.log(
+          "ReadBoard suppress local place while awaiting failed-place observation x="
+              + x
+              + " y="
+              + y
+              + " color="
+              + color);
+      localMoveSyncDebug(
+          "suppress local place while awaiting failed-place observation x="
+              + x
+              + " y="
+              + y
+              + " color="
+              + color
+              + " "
+              + pendingLocalMoveState());
+      return true;
+    }
+    if (failedLocalMoveWaitingForOurTurnAfterRemoteChange) {
+      YikeSyncDebugLog.log(
+          "ReadBoard suppress local place while waiting for failed-place side turn x="
+              + x
+              + " y="
+              + y
+              + " color="
+              + color);
+      localMoveSyncDebug(
+          "suppress local place while waiting for failed-place side turn x="
+              + x
+              + " y="
+              + y
+              + " color="
+              + color
+              + " "
+              + pendingLocalMoveState());
+      return true;
+    }
+    boolean sameFailedMove =
+        x == failedLocalMoveSuppressionX
+            && y == failedLocalMoveSuppressionY
+            && color == failedLocalMoveSuppressionColor;
+    if (!sameFailedMove) {
+      localMoveSyncDebug(
+          "clear failed local move state because engine selected a different move x="
+              + x
+              + " y="
+              + y
+              + " color="
+              + color
+              + " "
+              + pendingLocalMoveState());
+      clearFailedLocalMoveSuppression();
+      clearFailedLocalMoveRecovery();
+      return false;
+    }
+    YikeSyncDebugLog.log(
+        "ReadBoard suppress repeated failed local place x=" + x + " y=" + y + " color=" + color);
+    localMoveSyncDebug(
+        "suppress repeated failed local place x="
+            + x
+            + " y="
+            + y
+            + " color="
+            + color
+            + " "
+            + pendingLocalMoveState());
+    return true;
+  }
+
+  private void rememberFailedLocalMoveSuppression() {
+    rememberFailedLocalMoveSuppression(null);
+  }
+
+  private void rememberFailedLocalMoveSuppression(int[] snapshotCodes) {
+    Optional<int[]> currentPendingLocalMove = currentPendingLocalMoveCoordinates();
+    if (!currentPendingLocalMove.isPresent()) {
+      clearFailedLocalMoveSuppression();
+      clearFailedLocalMoveRecovery();
+      return;
+    }
+    Stone color = pendingLocalMoveColor;
+    if (color == null || color.isEmpty()) {
+      clearFailedLocalMoveSuppression();
+      clearFailedLocalMoveRecovery();
+      return;
+    }
+    int[] coords = currentPendingLocalMove.get();
+    failedLocalMoveSuppressionActive = true;
+    failedLocalMoveSuppressionX = coords[0];
+    failedLocalMoveSuppressionY = coords[1];
+    failedLocalMoveSuppressionColor = color;
+    failedLocalMoveSuppressionSnapshotKey = snapshotPositionKey(snapshotCodes);
+    rememberFailedLocalMoveRecovery(coords, color);
+    localMoveSyncDebug(
+        "remember suppression coords="
+            + coordsText(coords)
+            + " color="
+            + color
+            + " snapshot="
+            + snapshotSummary(snapshotCodes));
+  }
+
+  private void bindFailedLocalMoveSuppressionBaseline(BoardHistoryNode baselineNode) {
+    if (!failedLocalMoveSuppressionActive
+        || baselineNode == null
+        || baselineNode.getData() == null) {
+      return;
+    }
+    int[] baselineSnapshotCodes = snapshotCodesForNode(baselineNode);
+    failedLocalMoveSuppressionSnapshotKey = snapshotPositionKey(baselineSnapshotCodes);
+    localMoveSyncDebug(
+        "bind suppression rollback baseline="
+            + snapshotSummary(baselineSnapshotCodes)
+            + " "
+            + pendingLocalMoveState());
+  }
+
+  private void updateFailedLocalMoveSuppressionForSnapshot(int[] snapshotCodes) {
+    if (!failedLocalMoveSuppressionActive || snapshotCodes == null || snapshotCodes.length == 0) {
+      return;
+    }
+    int[] coords = new int[] {failedLocalMoveSuppressionX, failedLocalMoveSuppressionY};
+    String snapshotKey = snapshotPositionKey(snapshotCodes);
+    if (failedLocalMoveAwaitingRemoteObservation) {
+      observeFailedLocalMoveSnapshot(snapshotCodes, coords, snapshotKey);
+      return;
+    }
+    if (failedLocalMoveWaitingForOurTurnAfterRemoteChange) {
+      localMoveSyncDebug(
+          "failed-place waiting for our turn keeps suppression snapshot="
+              + snapshotSummary(snapshotCodes)
+              + " "
+              + pendingLocalMoveState());
+      return;
+    }
+    if (snapshotContainsMove(snapshotCodes, coords, failedLocalMoveSuppressionColor)) {
+      localMoveSyncDebug(
+          "clear suppression because failed move is now visible snapshot="
+              + snapshotSummary(snapshotCodes)
+              + " "
+              + pendingLocalMoveState());
+      clearFailedLocalMoveSuppression();
+      clearFailedLocalMoveRecovery();
+      return;
+    }
+    if (failedLocalMoveSuppressionSnapshotKey.isEmpty()) {
+      failedLocalMoveSuppressionSnapshotKey = snapshotKey;
+      localMoveSyncDebug(
+          "bind suppression snapshot="
+              + snapshotSummary(snapshotCodes)
+              + " "
+              + pendingLocalMoveState());
+      return;
+    }
+    if (!failedLocalMoveSuppressionSnapshotKey.equals(snapshotKey)) {
+      localMoveSyncDebug(
+          "clear suppression due snapshot change snapshot="
+              + snapshotSummary(snapshotCodes)
+              + " "
+              + pendingLocalMoveState());
+      clearFailedLocalMoveSuppression();
+      clearFailedLocalMoveRecovery();
+    }
+  }
+
+  private void observeFailedLocalMoveSnapshot(
+      int[] snapshotCodes, int[] failedCoords, String snapshotKey) {
+    if (snapshotContainsMove(snapshotCodes, failedCoords, failedLocalMoveSuppressionColor)) {
+      localMoveSyncDebug(
+          "failed-place observation sees intended move visible; treating failure as stale snapshot="
+              + snapshotSummary(snapshotCodes)
+              + " "
+              + pendingLocalMoveState());
+      clearFailedLocalMoveSuppression();
+      clearFailedLocalMoveRecovery();
+      return;
+    }
+    if (failedLocalMoveSuppressionSnapshotKey.isEmpty()) {
+      failedLocalMoveSuppressionSnapshotKey = snapshotKey;
+      localMoveSyncDebug(
+          "failed-place observation binds first snapshot="
+              + snapshotSummary(snapshotCodes)
+              + " "
+              + pendingLocalMoveState());
+      return;
+    }
+    if (failedLocalMoveSuppressionSnapshotKey.equals(snapshotKey)) {
+      localMoveSyncDebug(
+          "failed-place observation sees no remote board change; releasing failed move for fresh analysis snapshot="
+              + snapshotSummary(snapshotCodes)
+              + " "
+              + pendingLocalMoveState());
+      clearFailedLocalMoveSuppression();
+      clearFailedLocalMoveRecovery();
+      return;
+    }
+    failedLocalMoveAwaitingRemoteObservation = false;
+    failedLocalMoveWaitingForOurTurnAfterRemoteChange = true;
+    failedLocalMoveObservationDeadlineMs = 0L;
+    localMoveSyncDebug(
+        "failed-place observation sees remote board changed; resolving turn from sync snapshot="
+            + snapshotSummary(snapshotCodes)
+            + " "
+            + pendingLocalMoveState());
+  }
+
+  private void clearFailedLocalMoveSuppression() {
+    if (failedLocalMoveSuppressionActive) {
+      localMoveSyncDebug("clear suppression before " + pendingLocalMoveState());
+    }
+    failedLocalMoveSuppressionActive = false;
+    failedLocalMoveSuppressionX = -1;
+    failedLocalMoveSuppressionY = -1;
+    failedLocalMoveSuppressionColor = Stone.EMPTY;
+    failedLocalMoveSuppressionSnapshotKey = "";
+  }
+
+  private void rememberFailedLocalMoveRecovery(int[] coords, Stone color) {
+    failedLocalMoveRecoveryActive = true;
+    failedLocalMoveRecoveryX = coords[0];
+    failedLocalMoveRecoveryY = coords[1];
+    failedLocalMoveRecoveryColor = color;
+    failedLocalMoveAwaitingRemoteObservation = false;
+    failedLocalMoveWaitingForOurTurnAfterRemoteChange = false;
+    failedLocalMoveObservationDeadlineMs = 0L;
+    localMoveSyncDebug(
+        "remember failed local move recovery coords="
+            + coordsText(coords)
+            + " color="
+            + color
+            + " "
+            + pendingLocalMoveState());
+  }
+
+  private void beginFailedLocalMoveObservationGuard() {
+    failedLocalMoveAwaitingRemoteObservation = true;
+    failedLocalMoveWaitingForOurTurnAfterRemoteChange = false;
+    failedLocalMoveObservationDeadlineMs =
+        System.currentTimeMillis() + FAILED_LOCAL_MOVE_OBSERVATION_GRACE_MS;
+    localMoveSyncDebug(
+        "begin failed-place observation guard graceMs="
+            + FAILED_LOCAL_MOVE_OBSERVATION_GRACE_MS
+            + " "
+            + pendingLocalMoveState());
+  }
+
+  private boolean releaseFailedLocalMoveObservationIfTimedOut(String reason) {
+    if (!failedLocalMoveAwaitingRemoteObservation) {
+      return false;
+    }
+    long deadlineMs = failedLocalMoveObservationDeadlineMs;
+    if (deadlineMs > 0L && System.currentTimeMillis() < deadlineMs) {
+      return false;
+    }
+    localMoveSyncDebug(
+        "failed-place observation guard elapsed; release for fresh analysis reason="
+            + reason
+            + " "
+            + pendingLocalMoveState());
+    clearFailedLocalMoveSuppression();
+    clearFailedLocalMoveRecovery();
+    return true;
+  }
+
+  private void clearFailedLocalMoveRecovery() {
+    if (failedLocalMoveRecoveryActive) {
+      localMoveSyncDebug("clear failed local move recovery before " + pendingLocalMoveState());
+    }
+    failedLocalMoveRecoveryActive = false;
+    failedLocalMoveRecoveryX = -1;
+    failedLocalMoveRecoveryY = -1;
+    failedLocalMoveRecoveryColor = Stone.EMPTY;
+    failedLocalMoveAwaitingRemoteObservation = false;
+    failedLocalMoveWaitingForOurTurnAfterRemoteChange = false;
+    failedLocalMoveObservationDeadlineMs = 0L;
+  }
+
+  private boolean hasFailedLocalMoveStateToPreserve() {
+    return failedLocalMoveRecoveryActive;
+  }
+
+  private Stone autoPlayColorFromPlayParams(String[] params) {
+    if (params == null || params.length < 2) {
+      return Stone.EMPTY;
+    }
+    String color = params[1].trim();
+    if ("black".equals(color)) {
+      return Stone.BLACK;
+    }
+    if ("white".equals(color)) {
+      return Stone.WHITE;
+    }
+    return Stone.EMPTY;
+  }
+
+  private void clearFailedLocalMoveStateIfAutoPlaySideChanged(Stone autoPlayColor) {
+    if (autoPlayColor == null || autoPlayColor.isEmpty() || !hasFailedLocalMoveStateToPreserve()) {
+      return;
+    }
+    Stone failedColor = failedLocalMoveRecoveryColor;
+    if (failedColor == null || failedColor.isEmpty()) {
+      failedColor = failedLocalMoveSuppressionColor;
+    }
+    if (failedColor == null || failedColor.isEmpty() || failedColor == autoPlayColor) {
+      return;
+    }
+    localMoveSyncDebug(
+        "clear failed local move state because auto-play side changed failedColor="
+            + failedColor
+            + " autoPlayColor="
+            + autoPlayColor
+            + " "
+            + pendingLocalMoveState());
+    clearFailedLocalMoveSuppression();
+    clearFailedLocalMoveRecovery();
+  }
+
+  private boolean isFailedLocalMoveAwaitingRemoteObservation() {
+    return hasFailedLocalMoveStateToPreserve() && failedLocalMoveAwaitingRemoteObservation;
+  }
+
+  private String pendingLocalMoveState() {
+    long retryAgeMs =
+        lastPendingLocalMoveRetryTimeMs == 0L
+            ? -1L
+            : System.currentTimeMillis() - lastPendingLocalMoveRetryTimeMs;
+    long observationMsLeft =
+        failedLocalMoveObservationDeadlineMs == 0L
+            ? -1L
+            : failedLocalMoveObservationDeadlineMs - System.currentTimeMillis();
+    return "pendingState{lastMovePlayByLizzie="
+        + lastMovePlayByLizzie
+        + ",waiting="
+        + waitingForReadBoardLocalMoveAck
+        + ",clickCompleted="
+        + pendingLocalMoveClickCompleted
+        + ",retryCount="
+        + pendingLocalMoveRetryCount
+        + ",retryAgeMs="
+        + retryAgeMs
+        + ",pendingMove="
+        + safePendingMoveText()
+        + ",ackGeneration="
+        + pendingLocalMoveAckGeneration
+        + ",ignoreResult="
+        + ignoreReadBoardPlaceResultsForCurrentPending
+        + ",suppression="
+        + failedLocalMoveSuppressionActive
+        + "/"
+        + failedLocalMoveSuppressionX
+        + ","
+        + failedLocalMoveSuppressionY
+        + ","
+        + failedLocalMoveSuppressionColor
+        + ",recovery="
+        + failedLocalMoveRecoveryActive
+        + "/"
+        + failedLocalMoveRecoveryX
+        + ","
+        + failedLocalMoveRecoveryY
+        + ","
+        + failedLocalMoveRecoveryColor
+        + ",awaitRemoteObservation="
+        + failedLocalMoveAwaitingRemoteObservation
+        + ",observationMsLeft="
+        + observationMsLeft
+        + ",waitingOurTurnAfterRemoteChange="
+        + failedLocalMoveWaitingForOurTurnAfterRemoteChange
+        + ",confirmed="
+        + confirmedLocalMoveActive
+        + "/"
+        + confirmedLocalMoveX
+        + ","
+        + confirmedLocalMoveY
+        + ","
+        + confirmedLocalMoveColor
+        + ",baseline="
+        + (confirmedLocalMoveBaselineKey != null && !confirmedLocalMoveBaselineKey.isEmpty())
+        + "}";
+  }
+
+  private String safePendingMoveText() {
+    try {
+      if (hasPendingLocalMoveRecord()) {
+        BoardData pendingData = pendingLocalMoveNode.getData();
+        return pendingData.moveNumber
+            + ":"
+            + pendingLocalMoveColor
+            + "@"
+            + coordsText(new int[] {pendingLocalMoveX, pendingLocalMoveY})
+            + ":fixed=true";
+      }
+      BoardData mainEndData = Lizzie.board.getHistory().getMainEnd().getData();
+      return mainEndData.moveNumber
+          + ":"
+          + mainEndData.lastMoveColor
+          + "@"
+          + (mainEndData.lastMove.isPresent() ? coordsText(mainEndData.lastMove.get()) : "none")
+          + ":isMoveNode="
+          + mainEndData.isMoveNode();
+    } catch (Exception ex) {
+      return "unavailable:" + ex.getClass().getSimpleName();
+    }
+  }
+
+  private String coordsText(int[] coords) {
+    if (coords == null || coords.length < 2) {
+      return "none";
+    }
+    return coords[0] + "," + coords[1];
+  }
+
+  private String snapshotSummary(int[] snapshotCodes) {
+    if (snapshotCodes == null) {
+      return "null";
+    }
+    return "len=" + snapshotCodes.length + ",key=" + snapshotKey(snapshotCodes);
+  }
+
+  private int[] snapshotCodesForNode(BoardHistoryNode node) {
+    if (node == null || node.getData() == null) {
+      return new int[0];
+    }
+    BoardData data = node.getData();
+    int[] snapshotCodes = new int[Board.boardWidth * Board.boardHeight];
+    for (int y = 0; y < Board.boardHeight; y++) {
+      for (int x = 0; x < Board.boardWidth; x++) {
+        snapshotCodes[y * Board.boardWidth + x] =
+            snapshotCodeForStone(data.stones[Board.getIndex(x, y)]);
+      }
+    }
+    if (data.lastMove.isPresent() && data.lastMoveColor != null && !data.lastMoveColor.isEmpty()) {
+      int[] coords = data.lastMove.get();
+      int snapshotIndex = coords[1] * Board.boardWidth + coords[0];
+      if (snapshotIndex >= 0 && snapshotIndex < snapshotCodes.length) {
+        snapshotCodes[snapshotIndex] = data.lastMoveColor.isBlack() ? 3 : 4;
+      }
+    }
+    return snapshotCodes;
+  }
+
+  private int snapshotCodeForStone(Stone stone) {
+    if (stone == null || stone.isEmpty()) {
+      return 0;
+    }
+    return stone.isBlack() ? 1 : 2;
+  }
+
+  private String snapshotPositionKey(int[] snapshotCodes) {
+    if (snapshotCodes == null || snapshotCodes.length == 0) {
+      return "";
+    }
+    StringBuilder builder = new StringBuilder(snapshotCodes.length);
+    for (int code : snapshotCodes) {
+      builder.append((char) ('0' + normalizeSnapshotPositionCode(code)));
+    }
+    return builder.toString();
+  }
+
+  private int normalizeSnapshotPositionCode(int code) {
+    if (code == 3) {
+      return 1;
+    }
+    if (code == 4) {
+      return 2;
+    }
+    return code;
+  }
+
+  private String snapshotKey(int[] snapshotCodes) {
+    if (snapshotCodes == null || snapshotCodes.length == 0) {
+      return "";
+    }
+    StringBuilder builder = new StringBuilder(snapshotCodes.length);
+    for (int code : snapshotCodes) {
+      builder.append((char) ('0' + code));
+    }
+    return builder.toString();
+  }
+
+  private void sendPlaceCommandWithoutRestartingTracking(int x, int y) {
+    String command = "place " + x + " " + y;
+    localMoveSyncDebug(
+        "sendPlaceCommandWithoutRestartingTracking command="
+            + command
+            + " usePipe="
+            + usePipe
+            + " stream="
+            + (readBoardStream != null)
+            + " "
+            + pendingLocalMoveState());
+    YikeSyncDebugLog.log(
+        "ReadBoard retry pending local move command="
+            + command
+            + " retry="
+            + pendingLocalMoveRetryCount);
+    if (hideFloadBoardBeforePlace && Lizzie.frame.floatBoard != null) {
+      Lizzie.frame.floatBoard.setVisible(false);
+      hideFromPlace = true;
+    }
+    if (usePipe) {
+      sendCommandTo(command);
+    } else if (readBoardStream != null) {
+      readBoardStream.sendCommand(command);
+    }
   }
 
   private void restoreViewedNodeAfterSync(
@@ -2126,32 +3599,440 @@ public class ReadBoard {
 
   private void scheduleResumeAnalysisAfterSync(BoardHistoryNode targetNode) {
     if (Lizzie.frame == null || targetNode == null || !isReadBoardAnalysisEngineAvailable()) {
+      localMoveSyncDebug(
+          "scheduleResumeAnalysisAfterSync skip frame="
+              + (Lizzie.frame != null)
+              + " target="
+              + historyNodeSummary(targetNode)
+              + " engineAvailable="
+              + isReadBoardAnalysisEngineAvailable());
+      return;
+    }
+    if (shouldSkipResumeTargetBeforeConfirmedLocalMove(targetNode)) {
+      localMoveSyncDebug(
+          "scheduleResumeAnalysisAfterSync skip stale target before confirmed local move target="
+              + historyNodeSummary(targetNode)
+              + " "
+              + pendingLocalMoveState());
       return;
     }
     long scheduledEpoch = ++syncAnalysisEpoch;
+    localMoveSyncDebug(
+        "scheduleResumeAnalysisAfterSync epoch="
+            + scheduledEpoch
+            + " target="
+            + historyNodeSummary(targetNode)
+            + " readBoardPonder="
+            + (Lizzie.config != null && Lizzie.config.readBoardPonder)
+            + " enginePondering="
+            + (Lizzie.leelaz != null && Lizzie.leelaz.isPondering()));
     Lizzie.frame.scheduleResumeAnalysisAfterLoad(
         SYNC_ANALYSIS_RESUME_DELAY_MS,
         () -> resumeAnalysisAfterSyncIfStillCurrent(scheduledEpoch, targetNode));
   }
 
+  private boolean shouldSkipResumeTargetBeforeConfirmedLocalMove(BoardHistoryNode targetNode) {
+    return confirmedLocalMoveActive
+        && targetNode != confirmedLocalMoveNode
+        && isAncestorOf(targetNode, confirmedLocalMoveNode);
+  }
+
+  private boolean isAncestorOf(BoardHistoryNode possibleAncestor, BoardHistoryNode node) {
+    BoardHistoryNode current = node;
+    while (current != null) {
+      if (current == possibleAncestor) {
+        return true;
+      }
+      Optional<BoardHistoryNode> previous = current.previous();
+      if (!previous.isPresent()) {
+        return false;
+      }
+      current = previous.get();
+    }
+    return false;
+  }
+
+  private boolean continueGameAfterSyncIfNeeded(String reason, BoardHistoryNode targetNode) {
+    if (resumeFailedLocalMoveAfterSyncIfNeeded(reason, targetNode)) {
+      return true;
+    }
+    if (continuePlayingAgainstLeelazAfterSyncIfNeeded(reason)) {
+      return true;
+    }
+    return resumeAutoPlayAnalysisAfterSyncIfNeeded(reason, targetNode);
+  }
+
+  private boolean resumeFailedLocalMoveAfterSyncIfNeeded(
+      String reason, BoardHistoryNode targetNode) {
+    if (!failedLocalMoveRecoveryActive) {
+      return false;
+    }
+    if (failedLocalMoveAwaitingRemoteObservation
+        && !releaseFailedLocalMoveObservationIfTimedOut(reason)) {
+      localMoveSyncDebug(
+          "failed local move recovery leaves placement guard active while analysis may continue reason="
+              + reason
+              + " target="
+              + historyNodeSummary(targetNode)
+              + " "
+              + pendingLocalMoveState());
+      return false;
+    }
+    if (!failedLocalMoveRecoveryActive) {
+      return false;
+    }
+    if (targetNode == null || targetNode.getData() == null) {
+      localMoveSyncDebug(
+          "failed local move recovery skip missing target reason="
+              + reason
+              + " target="
+              + historyNodeSummary(targetNode)
+              + " "
+              + pendingLocalMoveState());
+      return true;
+    }
+    Stone failedColor = failedLocalMoveRecoveryColor;
+    if (failedColor == null || failedColor.isEmpty()) {
+      localMoveSyncDebug(
+          "failed local move recovery clear invalid color reason="
+              + reason
+              + " "
+              + pendingLocalMoveState());
+      clearFailedLocalMoveSuppression();
+      clearFailedLocalMoveRecovery();
+      return false;
+    }
+    boolean blackToPlay = targetNode.getData().blackToPlay;
+    if (failedColor.isBlack() != blackToPlay) {
+      failedLocalMoveAwaitingRemoteObservation = false;
+      failedLocalMoveWaitingForOurTurnAfterRemoteChange = true;
+      localMoveSyncDebug(
+          "failed local move observed opponent turn; waiting for failed side turn reason="
+              + reason
+              + " target="
+              + historyNodeSummary(targetNode)
+              + " "
+              + pendingLocalMoveState());
+      return true;
+    }
+    failedLocalMoveAwaitingRemoteObservation = false;
+    failedLocalMoveWaitingForOurTurnAfterRemoteChange = false;
+    if (Lizzie.frame == null || Lizzie.leelaz == null || !isReadBoardAnalysisEngineAvailable()) {
+      localMoveSyncDebug(
+          "failed local move recovery skip missing game state reason="
+              + reason
+              + " frame="
+              + (Lizzie.frame != null)
+              + " engine="
+              + (Lizzie.leelaz != null)
+              + " engineAvailable="
+              + isReadBoardAnalysisEngineAvailable()
+              + " "
+              + pendingLocalMoveState());
+      return true;
+    }
+    String genmoveColor = failedColor.isBlack() ? "B" : "W";
+    if (Lizzie.frame.isPlayingAgainstLeelaz) {
+      boolean failedColorIsEngineSide = failedColor.isBlack() != Lizzie.frame.playerIsBlack;
+      if (!failedColorIsEngineSide) {
+        localMoveSyncDebug(
+            "failed local move recovery skip player side reason="
+                + reason
+                + " target="
+                + historyNodeSummary(targetNode)
+                + " playerIsBlack="
+                + Lizzie.frame.playerIsBlack
+                + " "
+                + pendingLocalMoveState());
+        clearFailedLocalMoveSuppression();
+        clearFailedLocalMoveRecovery();
+        return false;
+      }
+      localMoveSyncDebug(
+          "failed local move recovery genmove reason="
+              + reason
+              + " color="
+              + genmoveColor
+              + " target="
+              + historyNodeSummary(targetNode)
+              + " playerIsBlack="
+              + Lizzie.frame.playerIsBlack
+              + " "
+              + pendingLocalMoveState());
+      clearFailedLocalMoveSuppression();
+      clearFailedLocalMoveRecovery();
+      Lizzie.leelaz.genmove(genmoveColor);
+      needGenmove = false;
+      return true;
+    }
+    if (Lizzie.frame.isAnaPlayingAgainstLeelaz) {
+      if (Lizzie.config != null && !Lizzie.config.readBoardPonder) {
+        localMoveSyncDebug(
+            "failed local move observed our turn but auto-play analysis skip readBoardPonder=false reason="
+                + reason
+                + " target="
+                + historyNodeSummary(targetNode)
+                + " "
+                + pendingLocalMoveState());
+        clearFailedLocalMoveSuppression();
+        clearFailedLocalMoveRecovery();
+        return true;
+      }
+      localMoveSyncDebug(
+          "failed local move observed our turn; resume auto-play analysis reason="
+              + reason
+              + " target="
+              + historyNodeSummary(targetNode)
+              + " enginePonderingBefore="
+              + Lizzie.leelaz.isPondering()
+              + " "
+              + pendingLocalMoveState());
+      clearFailedLocalMoveSuppression();
+      clearFailedLocalMoveRecovery();
+      if (!Lizzie.leelaz.isPondering()) {
+        Lizzie.leelaz.ponder();
+      }
+      return true;
+    }
+    localMoveSyncDebug(
+        "failed local move recovery skip no active game reason="
+            + reason
+            + " target="
+            + historyNodeSummary(targetNode)
+            + " playingAgainst=false autoPlaying=false "
+            + pendingLocalMoveState());
+    clearFailedLocalMoveSuppression();
+    clearFailedLocalMoveRecovery();
+    return false;
+  }
+
+  private boolean continuePlayingAgainstLeelazAfterSyncIfNeeded(String reason) {
+    if (Lizzie.frame == null || !Lizzie.frame.isPlayingAgainstLeelaz || !needGenmove) {
+      if ("rebuild".equals(reason) || failedLocalMoveRecoveryActive) {
+        localMoveSyncDebug(
+            "continuePlayingAgainstLeelaz skip inactive reason="
+                + reason
+                + " frame="
+                + (Lizzie.frame != null)
+                + " playingAgainst="
+                + (Lizzie.frame != null && Lizzie.frame.isPlayingAgainstLeelaz)
+                + " autoPlaying="
+                + (Lizzie.frame != null && Lizzie.frame.isAnaPlayingAgainstLeelaz)
+                + " needGenmove="
+                + needGenmove
+                + " "
+                + pendingLocalMoveState());
+      }
+      return false;
+    }
+    if (Lizzie.board == null || Lizzie.leelaz == null || !isReadBoardAnalysisEngineAvailable()) {
+      localMoveSyncDebug(
+          "continuePlayingAgainstLeelaz skip reason="
+              + reason
+              + " board="
+              + (Lizzie.board != null)
+              + " engine="
+              + (Lizzie.leelaz != null)
+              + " engineAvailable="
+              + isReadBoardAnalysisEngineAvailable());
+      return false;
+    }
+    boolean blacksTurn = Lizzie.board.getHistory().isBlacksTurn();
+    String genmoveColor = null;
+    if (blacksTurn != Lizzie.frame.playerIsBlack) {
+      genmoveColor = blacksTurn ? "B" : "W";
+    }
+    if (genmoveColor == null) {
+      localMoveSyncDebug(
+          "continuePlayingAgainstLeelaz skip not engine turn reason="
+              + reason
+              + " blackToPlay="
+              + blacksTurn
+              + " playerIsBlack="
+              + Lizzie.frame.playerIsBlack);
+      return false;
+    }
+    localMoveSyncDebug(
+        "continuePlayingAgainstLeelaz genmove reason="
+            + reason
+            + " color="
+            + genmoveColor
+            + " blackToPlay="
+            + blacksTurn
+            + " playerIsBlack="
+            + Lizzie.frame.playerIsBlack);
+    Lizzie.leelaz.genmove(genmoveColor);
+    needGenmove = false;
+    return true;
+  }
+
+  private boolean resumeAutoPlayAnalysisAfterSyncIfNeeded(
+      String reason, BoardHistoryNode targetNode) {
+    if (Lizzie.frame == null || !Lizzie.frame.isAnaPlayingAgainstLeelaz) {
+      return false;
+    }
+    if (hasFailedLocalMoveStateToPreserve()) {
+      if (failedLocalMoveAwaitingRemoteObservation) {
+        localMoveSyncDebug(
+            "resume auto-play analysis while failed-place guard blocks only placement reason="
+                + reason
+                + " target="
+                + historyNodeSummary(targetNode)
+                + " "
+                + pendingLocalMoveState());
+      } else {
+        localMoveSyncDebug(
+            "resume auto-play analysis held by unresolved failed local move reason="
+                + reason
+                + " target="
+                + historyNodeSummary(targetNode)
+                + " "
+                + pendingLocalMoveState());
+        return true;
+      }
+    }
+    if (hasFailedLocalMoveStateToPreserve()
+        && failedLocalMoveAwaitingRemoteObservation
+        && releaseFailedLocalMoveObservationIfTimedOut(reason)) {
+      localMoveSyncDebug(
+          "resume auto-play analysis released elapsed failed-place guard reason="
+              + reason
+              + " target="
+              + historyNodeSummary(targetNode)
+              + " "
+              + pendingLocalMoveState());
+    }
+    if (hasFailedLocalMoveStateToPreserve() && !failedLocalMoveAwaitingRemoteObservation) {
+      localMoveSyncDebug(
+          "resume auto-play analysis held by unresolved failed local move reason="
+              + reason
+              + " target="
+              + historyNodeSummary(targetNode)
+              + " "
+              + pendingLocalMoveState());
+      return true;
+    }
+    if (Lizzie.config != null && !Lizzie.config.readBoardPonder) {
+      if ("rebuild".equals(reason)) {
+        localMoveSyncDebug(
+            "resume auto-play analysis skip readBoardPonder=false reason="
+                + reason
+                + " target="
+                + historyNodeSummary(targetNode));
+      }
+      return true;
+    }
+    if (Lizzie.leelaz == null || !isReadBoardAnalysisEngineAvailable()) {
+      localMoveSyncDebug(
+          "resume auto-play analysis skip engine unavailable reason="
+              + reason
+              + " target="
+              + historyNodeSummary(targetNode)
+              + " engine="
+              + (Lizzie.leelaz != null)
+              + " engineAvailable="
+              + isReadBoardAnalysisEngineAvailable());
+      return false;
+    }
+    if (Lizzie.leelaz.isPondering()) {
+      if ("rebuild".equals(reason)) {
+        localMoveSyncDebug(
+            "resume auto-play analysis already pondering reason="
+                + reason
+                + " target="
+                + historyNodeSummary(targetNode));
+      }
+      return true;
+    }
+    localMoveSyncDebug(
+        "resume auto-play analysis reason="
+            + reason
+            + " target="
+            + historyNodeSummary(targetNode)
+            + " readBoardPonder="
+            + (Lizzie.config != null && Lizzie.config.readBoardPonder));
+    Lizzie.leelaz.ponder();
+    return true;
+  }
+
   private void resumeAnalysisAfterSyncIfStillCurrent(
       long scheduledEpoch, BoardHistoryNode targetNode) {
-    if (scheduledEpoch != syncAnalysisEpoch
-        || Lizzie.frame == null
-        || Lizzie.board == null
-        || Lizzie.config == null
-        || !Lizzie.config.readBoardPonder
-        || !isReadBoardAnalysisEngineAvailable()) {
+    if (scheduledEpoch != syncAnalysisEpoch) {
+      localMoveSyncDebug(
+          "resumeAnalysisAfterSync skip stale epoch scheduled="
+              + scheduledEpoch
+              + " current="
+              + syncAnalysisEpoch
+              + " target="
+              + historyNodeSummary(targetNode));
       return;
     }
-    if (Lizzie.board.getHistory().getCurrentHistoryNode() != targetNode) {
+    if (Lizzie.frame == null || Lizzie.board == null || Lizzie.config == null) {
+      localMoveSyncDebug(
+          "resumeAnalysisAfterSync skip missing app state frame="
+              + (Lizzie.frame != null)
+              + " board="
+              + (Lizzie.board != null)
+              + " config="
+              + (Lizzie.config != null));
       return;
     }
-    Lizzie.frame.ensureAnalysisResumedAfterLoad();
+    if (!Lizzie.config.readBoardPonder) {
+      localMoveSyncDebug(
+          "resumeAnalysisAfterSync skip readBoardPonder=false target="
+              + historyNodeSummary(targetNode));
+      return;
+    }
+    if (!isReadBoardAnalysisEngineAvailable()) {
+      localMoveSyncDebug(
+          "resumeAnalysisAfterSync skip engine unavailable target="
+              + historyNodeSummary(targetNode));
+      return;
+    }
+    BoardHistoryNode currentNode = Lizzie.board.getHistory().getCurrentHistoryNode();
+    if (currentNode != targetNode) {
+      localMoveSyncDebug(
+          "resumeAnalysisAfterSync skip current moved current="
+              + historyNodeSummary(currentNode)
+              + " target="
+              + historyNodeSummary(targetNode));
+      return;
+    }
+    localMoveSyncDebug(
+        "resumeAnalysisAfterSync run target="
+            + historyNodeSummary(targetNode)
+            + " enginePonderingBefore="
+            + (Lizzie.leelaz != null && Lizzie.leelaz.isPondering()));
+    boolean resumed = Lizzie.frame.ensureAnalysisResumedAfterLoad();
+    localMoveSyncDebug(
+        "resumeAnalysisAfterSync result resumed="
+            + resumed
+            + " enginePonderingAfter="
+            + (Lizzie.leelaz != null && Lizzie.leelaz.isPondering()));
   }
 
   private boolean isReadBoardAnalysisEngineAvailable() {
     return Lizzie.leelaz != null && Lizzie.leelaz.isStarted();
+  }
+
+  private String historyNodeSummary(BoardHistoryNode node) {
+    if (node == null) {
+      return "null";
+    }
+    BoardData data = node.getData();
+    if (data == null) {
+      return "node[data=null]";
+    }
+    return "move="
+        + data.moveNumber
+        + ",last="
+        + coordsText(data.lastMove.orElse(null))
+        + ",color="
+        + data.lastMoveColor
+        + ",blackToPlay="
+        + data.blackToPlay
+        + ",snapshot="
+        + data.isSnapshotNode();
   }
 
   private void stopPonderingIfActive() {
@@ -2239,10 +4120,10 @@ public class ReadBoard {
     Stone stone = stones[Board.getIndex(x, y)];
     if (m == 0 && stone != Stone.EMPTY) {
       if (Lizzie.frame.bothSync && lastMovePlayByLizzie) {
-        BoardHistoryNode curNode = Lizzie.board.getHistory().getMainEnd();
-        if (curNode.getData().lastMove.isPresent()) {
-          int[] lastCoords = curNode.getData().lastMove.get();
-          if (lastCoords[0] == x && lastCoords[1] == y) {
+        Optional<int[]> pendingMove = currentPendingLocalMoveCoordinates();
+        if (pendingMove.isPresent()) {
+          int[] coords = pendingMove.get();
+          if (coords[0] == x && coords[1] == y) {
             return false;
           }
         }
@@ -2259,6 +4140,17 @@ public class ReadBoard {
   }
 
   public void shutdown() {
+    shutdown(true);
+  }
+
+  void shutdownAfterProcessEnd() {
+    shutdown(false);
+  }
+
+  private void shutdown(boolean requestGracefulExit) {
+    if (!beginShutdown()) {
+      return;
+    }
     noMsg = true;
     resetActiveSyncState();
     clearResumeState();
@@ -2268,8 +4160,26 @@ public class ReadBoard {
       Lizzie.frame.syncBoard = false;
       Lizzie.frame.bothSync = false;
     }
-    this.sendCommand("quit");
+    if (requestGracefulExit && shouldSendQuitToHostedProcess()) {
+      this.sendCommand("quit");
+    }
     releaseHostedResources();
+  }
+
+  private synchronized boolean beginShutdown() {
+    if (shutdownStarted) {
+      return false;
+    }
+    shutdownStarted = true;
+    return true;
+  }
+
+  private boolean shouldSendQuitToHostedProcess() {
+    if (outputStream == null) {
+      return false;
+    }
+    Process currentProcess = process;
+    return currentProcess == null || currentProcess.isAlive();
   }
 
   public void onLocalHistoryNavigation() {
@@ -2306,6 +4216,9 @@ public class ReadBoard {
   }
 
   public void sendCommand(String command) {
+    if (command == null) {
+      return;
+    }
     if (command != null
         && (command.startsWith("yike")
             || command.startsWith("place")
@@ -2319,16 +4232,64 @@ public class ReadBoard {
               + isSyncing);
     }
     if (command.startsWith("place")) {
+      localMoveSyncDebug(
+          "sendCommand external place command="
+              + command
+              + " usePipe="
+              + usePipe
+              + " stream="
+              + (readBoardStream != null)
+              + " before "
+              + pendingLocalMoveState());
+      if (isPendingLocalMoveAwaitingReadBoard()) {
+        localMoveSyncDebug("sendCommand external place skipped; pending local move still active");
+        return;
+      }
+      clearFailedLocalMoveStateIfOutgoingPlaceDiffers(command);
       if (hideFloadBoardBeforePlace && Lizzie.frame.floatBoard != null) {
         Lizzie.frame.floatBoard.setVisible(false);
         hideFromPlace = true;
       }
       startTrackingLocalMoveFromLizzie();
       if (Lizzie.frame.isPlayingAgainstLeelaz) needGenmove = true;
+      localMoveSyncDebug("sendCommand external place after tracking " + pendingLocalMoveState());
     }
     if (usePipe) {
       sendCommandTo(command);
     } else if (readBoardStream != null) readBoardStream.sendCommand(command);
+  }
+
+  private void clearFailedLocalMoveStateIfOutgoingPlaceDiffers(String command) {
+    if (!hasFailedLocalMoveStateToPreserve()) {
+      return;
+    }
+    Optional<int[]> coords = parsePlaceCommandCoordinates(command);
+    if (!coords.isPresent()) {
+      return;
+    }
+    int[] move = coords.get();
+    if (move[0] == failedLocalMoveRecoveryX && move[1] == failedLocalMoveRecoveryY) {
+      return;
+    }
+    localMoveSyncDebug(
+        "outgoing different place clears failed local move state command="
+            + command
+            + " "
+            + pendingLocalMoveState());
+    clearFailedLocalMoveSuppression();
+    clearFailedLocalMoveRecovery();
+  }
+
+  private Optional<int[]> parsePlaceCommandCoordinates(String command) {
+    String[] params = command.trim().split("\\s+");
+    if (params.length < 3 || !"place".equals(params[0])) {
+      return Optional.empty();
+    }
+    try {
+      return Optional.of(new int[] {Integer.parseInt(params[1]), Integer.parseInt(params[2])});
+    } catch (NumberFormatException ex) {
+      return Optional.empty();
+    }
   }
 
   public void sendLossFocus() {
@@ -2363,6 +4324,8 @@ public class ReadBoard {
     InputStreamReader currentInputStream = inputStream;
     BufferedOutputStream currentOutputStream = outputStream;
     ScheduledExecutorService currentExecutor = executor;
+    ScheduledExecutorService currentPendingLocalMoveTimeoutExecutor =
+        pendingLocalMoveTimeoutExecutor;
     ReadBoardStream currentReadBoardStream = readBoardStream;
     Socket currentSocket = socket;
     ServerSocket currentServerSocket = s;
@@ -2371,6 +4334,7 @@ public class ReadBoard {
     inputStream = null;
     outputStream = null;
     executor = null;
+    pendingLocalMoveTimeoutExecutor = null;
     readBoardStream = null;
     socket = null;
     s = null;
@@ -2383,6 +4347,7 @@ public class ReadBoard {
     closeQuietly(currentSocket);
     closeQuietly(currentServerSocket);
     shutdownExecutor(currentExecutor);
+    shutdownExecutor(currentPendingLocalMoveTimeoutExecutor);
     waitForHostedProcessExit(currentProcess);
   }
 

--- a/src/main/java/featurecat/lizzie/rules/Board.java
+++ b/src/main/java/featurecat/lizzie/rules/Board.java
@@ -9,6 +9,7 @@ import featurecat.lizzie.analysis.EngineManager;
 import featurecat.lizzie.analysis.GameInfo;
 import featurecat.lizzie.analysis.Leelaz;
 import featurecat.lizzie.analysis.MoveData;
+import featurecat.lizzie.analysis.ReadBoard;
 import featurecat.lizzie.gui.LizzieFrame;
 import featurecat.lizzie.gui.ScoreResult;
 import featurecat.lizzie.util.KataGoRuntimeHelper;
@@ -1780,6 +1781,58 @@ public class Board {
 
   public void place(
       int x, int y, Stone color, boolean newBranch, boolean forSync, boolean forManual) {
+    boolean shouldLogLocalMovePlace = shouldLogLocalMovePlace(forSync);
+    if (shouldSuppressLocalPlaceAfterFailedReadBoardSync(x, y, color, forSync)) {
+      if (shouldLogLocalMovePlace) {
+        logLocalMovePlace(
+            "place suppressed after failed readboard sync x="
+                + x
+                + " y="
+                + y
+                + " color="
+                + color
+                + " newBranch="
+                + newBranch
+                + " forManual="
+                + forManual
+                + " "
+                + localMovePlaceState(forSync));
+      }
+      return;
+    }
+    if (shouldSuppressLocalPlaceWhileReadBoardPending(x, y, color, forSync)) {
+      if (shouldLogLocalMovePlace) {
+        logLocalMovePlace(
+            "place suppressed while readboard local move pending x="
+                + x
+                + " y="
+                + y
+                + " color="
+                + color
+                + " newBranch="
+                + newBranch
+                + " forManual="
+                + forManual
+                + " "
+                + localMovePlaceState(forSync));
+      }
+      return;
+    }
+    if (shouldLogLocalMovePlace) {
+      logLocalMovePlace(
+          "place enter x="
+              + x
+              + " y="
+              + y
+              + " color="
+              + color
+              + " newBranch="
+              + newBranch
+              + " forManual="
+              + forManual
+              + " "
+              + localMovePlaceState(forSync));
+    }
     boolean noCheckSuiKo = false;
     LizzieFrame.boardRenderer.removedrawmovestone();
     Lizzie.frame.suggestionclick = LizzieFrame.outOfBoundCoordinate;
@@ -1791,8 +1844,26 @@ public class Board {
       Lizzie.frame.isCounting = false;
     }
     synchronized (this) {
-      if (!isValid(x, y) || (history.getStones()[getIndex(x, y)] != Stone.EMPTY && !newBranch))
+      boolean valid = isValid(x, y);
+      boolean occupied = valid && history.getStones()[getIndex(x, y)] != Stone.EMPTY;
+      if (!valid || (occupied && !newBranch)) {
+        if (shouldLogLocalMovePlace) {
+          logLocalMovePlace(
+              "place return invalid-or-occupied valid="
+                  + valid
+                  + " occupied="
+                  + occupied
+                  + " x="
+                  + x
+                  + " y="
+                  + y
+                  + " color="
+                  + color
+                  + " "
+                  + localMovePlaceState(forSync));
+        }
         return;
+      }
       updateWinrate();
       if (EngineManager.isEngineGame) SGFParser.appendTime();
       // modifyStart();
@@ -1827,6 +1898,17 @@ public class Board {
           Lizzie.leelaz.playMove(color, convertCoordinatesToName(x, y));
           // modifyEnd(false);
           clearAfterMove();
+          if (shouldLogLocalMovePlace) {
+            logLocalMovePlace(
+                "place return urlSgf-syncBoard-variation x="
+                    + x
+                    + " y="
+                    + y
+                    + " color="
+                    + color
+                    + " "
+                    + localMovePlaceState(forSync));
+          }
           return;
           // Lizzie.leelaz.playMove(color, convertCoordinatesToName(x, y));
         }
@@ -1861,6 +1943,17 @@ public class Board {
         }
         //  modifyEnd(false);
         clearAfterMove();
+        if (shouldLogLocalMovePlace) {
+          logLocalMovePlace(
+              "place return history-next x="
+                  + x
+                  + " y="
+                  + y
+                  + " color="
+                  + color
+                  + " "
+                  + localMovePlaceState(forSync));
+        }
         Lizzie.frame.refresh();
         return;
       }
@@ -1923,15 +2016,48 @@ public class Board {
       if (!noCheckSuiKo) {
         if (history.violatesKoRule(newState)) {
           // modifyEnd();
+          if (shouldLogLocalMovePlace) {
+            logLocalMovePlace(
+                "place return ko-rule x="
+                    + x
+                    + " y="
+                    + y
+                    + " color="
+                    + color
+                    + " "
+                    + localMovePlaceState(forSync));
+          }
           return;
         }
         if (Lizzie.leelaz.canSuicidal) {
           if (isSuicidal == 1) {
             //   modifyEnd();
+            if (shouldLogLocalMovePlace) {
+              logLocalMovePlace(
+                  "place return suicide-canSuicidal x="
+                      + x
+                      + " y="
+                      + y
+                      + " color="
+                      + color
+                      + " "
+                      + localMovePlaceState(forSync));
+            }
             return;
           }
         } else if (isSuicidal > 0) {
           //   modifyEnd();
+          if (shouldLogLocalMovePlace) {
+            logLocalMovePlace(
+                "place return suicide x="
+                    + x
+                    + " y="
+                    + y
+                    + " color="
+                    + color
+                    + " "
+                    + localMovePlaceState(forSync));
+          }
           return;
         }
       }
@@ -1998,20 +2124,108 @@ public class Board {
           && !isEngineFollowTrialActive()) {
         Lizzie.leelaz.playMove(color, convertCoordinatesToName(x, y), true, color.isWhite());
       }
-      if (!forSync
-          && Lizzie.frame.bothSync
-          && Lizzie.frame.readBoard != null
-          && Lizzie.frame.readBoard.process != null
-          && Lizzie.frame.readBoard.process.isAlive()) {
-        Lizzie.frame.readBoard.sendCommand("place " + x + " " + y);
-      }
       history.addOrGoto(newState, newBranch);
+      if (shouldLogLocalMovePlace) {
+        logLocalMovePlace(
+            "place history addOrGoto done x="
+                + x
+                + " y="
+                + y
+                + " color="
+                + color
+                + " "
+                + localMovePlaceState(forSync));
+      }
+      ReadBoard readBoard = Lizzie.frame.readBoard;
+      boolean pendingReadBoardLocalMove =
+          readBoard != null && readBoard.isPendingLocalMoveAwaitingReadBoard();
+      boolean canSendReadBoardPlace =
+          !forSync
+              && Lizzie.frame.bothSync
+              && readBoard != null
+              && readBoard.process != null
+              && readBoard.process.isAlive()
+              && !pendingReadBoardLocalMove;
+      if (shouldLogLocalMovePlace) {
+        logLocalMovePlace(
+            "place readboard-gate canSend="
+                + canSendReadBoardPlace
+                + " pendingReadBoardLocalMove="
+                + pendingReadBoardLocalMove
+                + " x="
+                + x
+                + " y="
+                + y
+                + " color="
+                + color
+                + " "
+                + localMovePlaceState(forSync));
+      }
+      if (canSendReadBoardPlace) {
+        logLocalMovePlace("place send readboard command=place " + x + " " + y);
+        readBoard.sendCommand("place " + x + " " + y);
+      }
       updateIsBest();
       if (Lizzie.frame != null) Lizzie.frame.onMainEnginePonder();
       if (needGenmove) Lizzie.leelaz.genmove((color.isWhite() ? "B" : "W"));
       //   modifyEnd(false);
       if (Lizzie.config.playSound) Utils.playVoiceFile();
       if (!forSync) Lizzie.frame.refresh();
+    }
+  }
+
+  private boolean shouldSuppressLocalPlaceAfterFailedReadBoardSync(
+      int x, int y, Stone color, boolean forSync) {
+    return !forSync
+        && Lizzie.frame != null
+        && Lizzie.frame.bothSync
+        && Lizzie.frame.readBoard != null
+        && Lizzie.frame.readBoard.shouldSuppressLocalPlaceAfterFailedSync(x, y, color);
+  }
+
+  private boolean shouldSuppressLocalPlaceWhileReadBoardPending(
+      int x, int y, Stone color, boolean forSync) {
+    return !forSync
+        && Lizzie.frame != null
+        && Lizzie.frame.bothSync
+        && Lizzie.frame.readBoard != null
+        && Lizzie.frame.readBoard.isPendingLocalMoveAwaitingReadBoard();
+  }
+
+  private boolean shouldLogLocalMovePlace(boolean forSync) {
+    return !forSync && Lizzie.frame != null && Lizzie.frame.bothSync;
+  }
+
+  private void logLocalMovePlace(String message) {
+    ReadBoard.localMoveSyncDebug("Board " + message);
+  }
+
+  private String localMovePlaceState(boolean forSync) {
+    try {
+      boolean readBoardAlive =
+          Lizzie.frame != null
+              && Lizzie.frame.readBoard != null
+              && Lizzie.frame.readBoard.process != null
+              && Lizzie.frame.readBoard.process.isAlive();
+      BoardHistoryNode current = history.getCurrentHistoryNode();
+      BoardHistoryNode mainEnd = history.getMainEnd();
+      return "state{forSync="
+          + forSync
+          + ",bothSync="
+          + (Lizzie.frame != null && Lizzie.frame.bothSync)
+          + ",syncBoard="
+          + (Lizzie.frame != null && Lizzie.frame.syncBoard)
+          + ",readBoardAlive="
+          + readBoardAlive
+          + ",currentMove="
+          + (current != null ? current.getData().moveNumber : -1)
+          + ",mainEndMove="
+          + (mainEnd != null ? mainEnd.getData().moveNumber : -1)
+          + ",currentIsMainEnd="
+          + (current != null && current == mainEnd)
+          + "}";
+    } catch (Exception ex) {
+      return "state{unavailable=" + ex.getClass().getSimpleName() + "}";
     }
   }
 

--- a/src/test/java/featurecat/lizzie/analysis/ReadBoardEngineResumeTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/ReadBoardEngineResumeTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import featurecat.lizzie.Config;
 import featurecat.lizzie.Lizzie;
@@ -63,6 +65,557 @@ class ReadBoardEngineResumeTest {
 
       assertEquals(1, harness.frame.scheduleResumeAnalysisCount);
       assertNotNull(harness.frame.lastScheduledResumeAction);
+    }
+  }
+
+  @Test
+  void forceRebuildStopsPonderBeforeLoadingSnapshot() throws Exception {
+    try (EngineResumeHarness harness =
+        EngineResumeHarness.create(rootHistory(emptyStones(), true))) {
+      harness.leelaz.isKatago = true;
+      harness.leelaz.Pondering();
+      HistoryPath path =
+          buildHistory(harness.board, placement(0, 0, Stone.BLACK), placement(1, 0, Stone.WHITE));
+      BoardHistoryNode mainEnd = path.nodes.get(path.nodes.size() - 1);
+
+      harness.readBoard.parseLine("forceRebuild");
+      harness.sync(
+          snapshot(
+              mainEnd.getData().stones,
+              mainEnd.getData().lastMove,
+              mainEnd.getData().lastMoveColor));
+
+      assertEquals(
+          0,
+          harness.leelaz.clearCount,
+          "snapshot rebuild should not use clear(), which restarts ponder.");
+      assertEquals("stop", harness.leelaz.sentCommands.get(0));
+      assertEquals("clear_board", harness.leelaz.sentCommands.get(1));
+      assertTrue(harness.leelaz.sentCommands.get(2).startsWith("loadsgf "));
+      assertFalse(
+          harness.leelaz.isPondering(),
+          "analysis should stay stopped until the scheduled resume runs.");
+
+      harness.frame.lastScheduledResumeAction.run();
+      assertEquals(1, harness.leelaz.ponderCount);
+    }
+  }
+
+  @Test
+  void forceRebuildContinuesPlayingAgainstLeelazGenmove() throws Exception {
+    try (EngineResumeHarness harness =
+        EngineResumeHarness.create(rootHistory(emptyStones(), true))) {
+      harness.frame.isPlayingAgainstLeelaz = true;
+      harness.frame.playerIsBlack = true;
+      setField(harness.readBoard, "needGenmove", true);
+      HistoryPath path =
+          buildHistory(
+              harness.board,
+              placement(0, 0, Stone.BLACK),
+              placement(1, 0, Stone.WHITE),
+              placement(0, 1, Stone.BLACK));
+      BoardHistoryNode mainEnd = path.nodes.get(path.nodes.size() - 1);
+
+      harness.readBoard.parseLine("forceRebuild");
+      harness.sync(
+          snapshot(
+              mainEnd.getData().stones,
+              mainEnd.getData().lastMove,
+              mainEnd.getData().lastMoveColor));
+
+      assertEquals(1, harness.leelaz.genmoveCount);
+      assertEquals("W", harness.leelaz.lastGenmoveColor);
+      assertEquals(0, harness.frame.scheduleResumeAnalysisCount);
+    }
+  }
+
+  @Test
+  void forceRebuildResumesAutoPlayAfterRemoteChangesFollowingFailedLocalMove() throws Exception {
+    try (EngineResumeHarness harness =
+        EngineResumeHarness.create(rootHistory(emptyStones(), true))) {
+      harness.frame.isAnaPlayingAgainstLeelaz = true;
+      buildHistory(
+          harness.board,
+          placement(0, 0, Stone.BLACK),
+          placement(1, 0, Stone.WHITE),
+          placement(0, 1, Stone.BLACK));
+      markPendingLocalMoveAwaitingReadBoard(harness.readBoard);
+      invokePlacementFailed(harness.readBoard);
+
+      harness.readBoard.parseLine("forceRebuild");
+      harness.sync(
+          snapshot(
+              stones(
+                  placement(0, 0, Stone.BLACK),
+                  placement(1, 0, Stone.WHITE),
+                  placement(2, 0, Stone.WHITE)),
+              Optional.of(new int[] {2, 0}),
+              Stone.WHITE));
+
+      assertEquals(1, harness.leelaz.ponderCount);
+      assertEquals(0, harness.leelaz.genmoveCount);
+      assertEquals(0, harness.frame.scheduleResumeAnalysisCount);
+      assertFalse(getBooleanField(harness.readBoard, "failedLocalMoveRecoveryActive"));
+    }
+  }
+
+  @Test
+  void forceRebuildRegeneratesFailedEngineMoveWhenPlayingAgainstLeelaz() throws Exception {
+    try (EngineResumeHarness harness =
+        EngineResumeHarness.create(rootHistory(emptyStones(), true))) {
+      harness.frame.isPlayingAgainstLeelaz = true;
+      harness.frame.playerIsBlack = false;
+      buildHistory(
+          harness.board,
+          placement(0, 0, Stone.BLACK),
+          placement(1, 0, Stone.WHITE),
+          placement(0, 1, Stone.BLACK));
+      markPendingLocalMoveAwaitingReadBoard(harness.readBoard);
+      invokePlacementFailed(harness.readBoard);
+
+      harness.readBoard.parseLine("forceRebuild");
+      harness.sync(
+          snapshot(
+              stones(
+                  placement(0, 0, Stone.BLACK),
+                  placement(1, 0, Stone.WHITE),
+                  placement(2, 0, Stone.WHITE)),
+              Optional.of(new int[] {2, 0}),
+              Stone.WHITE));
+
+      assertEquals(1, harness.leelaz.genmoveCount);
+      assertEquals("B", harness.leelaz.lastGenmoveColor);
+      assertEquals(0, harness.frame.scheduleResumeAnalysisCount);
+      assertFalse(getBooleanField(harness.readBoard, "failedLocalMoveRecoveryActive"));
+    }
+  }
+
+  @Test
+  void placementFailureRollsBackFailedMainEndAndResumesAnalysisWithPlacementGuard()
+      throws Exception {
+    try (EngineResumeHarness harness =
+        EngineResumeHarness.create(rootHistory(emptyStones(), true))) {
+      harness.frame.isAnaPlayingAgainstLeelaz = true;
+      harness.frame.bothSync = true;
+      HistoryPath path =
+          buildHistory(
+              harness.board,
+              placement(0, 0, Stone.BLACK),
+              placement(1, 0, Stone.WHITE),
+              placement(0, 1, Stone.BLACK));
+      BoardHistoryNode remoteNode = path.nodes.get(1);
+
+      markPendingLocalMoveAwaitingReadBoard(harness.readBoard);
+      invokePlacementFailed(harness.readBoard);
+
+      assertSame(
+          remoteNode,
+          harness.board.getHistory().getCurrentHistoryNode(),
+          "the local failed engine move must be rolled back to the last remote-confirmed node.");
+      assertSame(
+          remoteNode,
+          harness.board.getHistory().getMainEnd(),
+          "the failed child must be removed so the next engine move cannot be consumed as history-next.");
+      assertFalse(
+          remoteNode.next().isPresent(),
+          "the rejected local move should not remain as the next mainline child.");
+      assertEquals(
+          Stone.EMPTY,
+          harness.leelaz.copyStones()[stoneIndex(0, 1)],
+          "the engine process must be restored to the rolled-back board before analysis resumes.");
+      assertTrue(
+          harness.leelaz.sentCommands.stream().anyMatch(command -> command.startsWith("loadsgf ")),
+          "rollback should reload an exact snapshot into the engine rather than leaving the failed play applied.");
+      assertEquals(
+          1,
+          harness.leelaz.ponderCount,
+          "analysis should resume immediately after rollback; only physical placement is guarded briefly.");
+      assertEquals(0, harness.leelaz.genmoveCount);
+      assertTrue(
+          getBooleanField(harness.readBoard, "failedLocalMoveRecoveryActive"),
+          "auto-play must keep the failed move guard until the remote board is observed or the guard expires.");
+      assertTrue(getBooleanField(harness.readBoard, "failedLocalMoveAwaitingRemoteObservation"));
+      assertTrue(
+          harness.readBoard.shouldSuppressLocalPlaceAfterFailedSync(0, 1, Stone.BLACK),
+          "no local place should be sent during the short remote-observation guard.");
+
+      harness.board.place(0, 1, Stone.BLACK, false, false, false);
+
+      assertSame(
+          remoteNode,
+          harness.board.getHistory().getCurrentHistoryNode(),
+          "an immediate repeat of the failed move should be swallowed before it re-enters the mainline.");
+      assertFalse(
+          remoteNode.next().isPresent(),
+          "an immediate repeat of the failed move should not recreate the rejected child.");
+    }
+  }
+
+  @Test
+  void pendingLocalMoveAckTimeoutRollsBackAndResumesAnalysisWithPlacementGuard() throws Exception {
+    try (EngineResumeHarness harness =
+        EngineResumeHarness.create(rootHistory(emptyStones(), true))) {
+      harness.frame.isAnaPlayingAgainstLeelaz = true;
+      harness.frame.bothSync = true;
+      HistoryPath path =
+          buildHistory(
+              harness.board,
+              placement(0, 0, Stone.BLACK),
+              placement(1, 0, Stone.WHITE),
+              placement(0, 1, Stone.BLACK));
+      BoardHistoryNode remoteNode = path.nodes.get(1);
+
+      markPendingLocalMoveAwaitingReadBoard(harness.readBoard);
+      setField(
+          harness.readBoard, "lastPendingLocalMoveRetryTimeMs", System.currentTimeMillis() - 5000L);
+      harness.sync(
+          snapshot(
+              remoteNode.getData().stones,
+              remoteNode.getData().lastMove,
+              remoteNode.getData().lastMoveColor));
+
+      assertSame(
+          remoteNode,
+          harness.board.getHistory().getCurrentHistoryNode(),
+          "a pending place without any readboard result must roll back to the last remote-confirmed node.");
+      assertSame(
+          remoteNode,
+          harness.board.getHistory().getMainEnd(),
+          "the unconfirmed local child must be removed after the place-result timeout.");
+      assertFalse(remoteNode.next().isPresent());
+      assertFalse(harness.readBoard.lastMovePlayByLizzie);
+      assertFalse(getBooleanField(harness.readBoard, "waitingForReadBoardLocalMoveAck"));
+      assertEquals(
+          Stone.EMPTY,
+          harness.leelaz.copyStones()[stoneIndex(0, 1)],
+          "the engine process must not keep the timed-out local move applied.");
+      assertTrue(
+          harness.leelaz.sentCommands.stream().anyMatch(command -> command.startsWith("loadsgf ")),
+          "timeout recovery should reload the rolled-back board into the engine.");
+      assertEquals(1, harness.leelaz.ponderCount);
+      assertTrue(getBooleanField(harness.readBoard, "failedLocalMoveRecoveryActive"));
+      assertTrue(getBooleanField(harness.readBoard, "failedLocalMoveAwaitingRemoteObservation"));
+      assertTrue(
+          harness.readBoard.shouldSuppressLocalPlaceAfterFailedSync(0, 1, Stone.BLACK),
+          "physical placement must still be guarded briefly after timeout recovery.");
+    }
+  }
+
+  @Test
+  void pendingLocalMoveAckTimeoutWithoutSyncFrameRollsBackAndResumesAnalysis() throws Exception {
+    try (EngineResumeHarness harness =
+        EngineResumeHarness.create(rootHistory(emptyStones(), true))) {
+      harness.frame.isAnaPlayingAgainstLeelaz = true;
+      harness.frame.bothSync = true;
+      HistoryPath path =
+          buildHistory(
+              harness.board,
+              placement(0, 0, Stone.BLACK),
+              placement(1, 0, Stone.WHITE),
+              placement(0, 1, Stone.BLACK));
+      BoardHistoryNode remoteNode = path.nodes.get(1);
+
+      markPendingLocalMoveAwaitingReadBoard(harness.readBoard);
+      setField(
+          harness.readBoard, "lastPendingLocalMoveRetryTimeMs", System.currentTimeMillis() - 5000L);
+
+      assertTrue(invokeAckTimeoutWithoutSnapshot(harness.readBoard));
+
+      assertSame(
+          remoteNode,
+          harness.board.getHistory().getMainEnd(),
+          "a pending place must not wait forever when readboard sends no follow-up board frame.");
+      assertFalse(harness.readBoard.lastMovePlayByLizzie);
+      assertFalse(getBooleanField(harness.readBoard, "waitingForReadBoardLocalMoveAck"));
+      assertEquals(1, harness.leelaz.ponderCount);
+      assertTrue(getBooleanField(harness.readBoard, "failedLocalMoveRecoveryActive"));
+      assertTrue(getBooleanField(harness.readBoard, "failedLocalMoveAwaitingRemoteObservation"));
+    }
+  }
+
+  @Test
+  void placementFailureLineBypassesStalePlaceCompleteQuarantine() throws Exception {
+    try (EngineResumeHarness harness =
+        EngineResumeHarness.create(rootHistory(emptyStones(), true))) {
+      harness.frame.isAnaPlayingAgainstLeelaz = true;
+      harness.frame.bothSync = true;
+      HistoryPath path =
+          buildHistory(
+              harness.board,
+              placement(0, 0, Stone.BLACK),
+              placement(1, 0, Stone.WHITE),
+              placement(0, 1, Stone.BLACK));
+      BoardHistoryNode remoteNode = path.nodes.get(1);
+
+      markPendingLocalMoveAwaitingReadBoard(harness.readBoard);
+      setField(harness.readBoard, "ignoreReadBoardPlaceResultsForCurrentPending", true);
+
+      invokePlacementFailedLine(harness.readBoard);
+
+      assertSame(
+          remoteNode,
+          harness.board.getHistory().getMainEnd(),
+          "the stale-placeComplete quarantine must not swallow the real error place failed for the current command.");
+      assertFalse(harness.readBoard.lastMovePlayByLizzie);
+      assertFalse(getBooleanField(harness.readBoard, "waitingForReadBoardLocalMoveAck"));
+      assertEquals(1, harness.leelaz.ponderCount);
+    }
+  }
+
+  @Test
+  void pendingLocalMoveRemoteChangeWithoutTargetRollsBackBeforeAckTimeout() throws Exception {
+    try (EngineResumeHarness harness =
+        EngineResumeHarness.create(rootHistory(emptyStones(), true))) {
+      harness.frame.isAnaPlayingAgainstLeelaz = true;
+      harness.frame.bothSync = true;
+      HistoryPath path =
+          buildHistory(
+              harness.board,
+              placement(0, 0, Stone.BLACK),
+              placement(1, 0, Stone.WHITE),
+              placement(0, 1, Stone.BLACK));
+      BoardHistoryNode remoteNode = path.nodes.get(1);
+
+      markPendingLocalMoveAwaitingReadBoard(harness.readBoard);
+      setField(harness.readBoard, "lastPendingLocalMoveRetryTimeMs", System.currentTimeMillis());
+
+      int[] misplacedSnapshot =
+          snapshot(
+              stones(
+                  placement(0, 0, Stone.BLACK),
+                  placement(1, 0, Stone.WHITE),
+                  placement(2, 0, Stone.BLACK)),
+              Optional.of(new int[] {2, 0}),
+              Stone.BLACK);
+
+      harness.sync(misplacedSnapshot);
+
+      assertSame(
+          remoteNode,
+          harness.board.getHistory().getMainEnd(),
+          "if the remote board changed but never contains the pending target, the local pending move must be released immediately.");
+      assertFalse(harness.readBoard.lastMovePlayByLizzie);
+      assertTrue(getBooleanField(harness.readBoard, "failedLocalMoveRecoveryActive"));
+
+      harness.sync(misplacedSnapshot);
+
+      assertEquals(3, harness.board.getHistory().getMainEnd().getData().moveNumber);
+      assertTrue(
+          getBooleanField(harness.readBoard, "failedLocalMoveWaitingForOurTurnAfterRemoteChange"));
+    }
+  }
+
+  @Test
+  void boardPlaceWhileReadBoardPendingDoesNotMutateMainline() throws Exception {
+    try (EngineResumeHarness harness =
+        EngineResumeHarness.create(rootHistory(emptyStones(), true))) {
+      harness.frame.bothSync = true;
+      HistoryPath path =
+          buildHistory(
+              harness.board,
+              placement(0, 0, Stone.BLACK),
+              placement(1, 0, Stone.WHITE),
+              placement(0, 1, Stone.BLACK));
+      BoardHistoryNode pendingNode = path.nodes.get(2);
+
+      markPendingLocalMoveAwaitingReadBoard(harness.readBoard);
+
+      harness.board.place(2, 2, Stone.WHITE, false, false, false);
+
+      assertSame(
+          pendingNode,
+          harness.board.getHistory().getMainEnd(),
+          "a new local place while readboard is still confirming the previous move must not rewrite the pending target.");
+      assertFalse(
+          pendingNode.next().isPresent(),
+          "the suppressed local place must not create a new mainline child.");
+    }
+  }
+
+  @Test
+  void placementFailureWithUnchangedRemoteSnapshotResumesAnalysisForOurTurn() throws Exception {
+    try (EngineResumeHarness harness =
+        EngineResumeHarness.create(rootHistory(emptyStones(), true))) {
+      harness.frame.isAnaPlayingAgainstLeelaz = true;
+      harness.frame.bothSync = true;
+      HistoryPath path =
+          buildHistory(
+              harness.board,
+              placement(0, 0, Stone.BLACK),
+              placement(1, 0, Stone.WHITE),
+              placement(0, 1, Stone.BLACK));
+      BoardHistoryNode remoteNode = path.nodes.get(1);
+
+      markPendingLocalMoveAwaitingReadBoard(harness.readBoard);
+      invokePlacementFailed(harness.readBoard);
+      harness.sync(
+          snapshot(
+              remoteNode.getData().stones,
+              remoteNode.getData().lastMove,
+              remoteNode.getData().lastMoveColor));
+
+      assertEquals(
+          1,
+          harness.leelaz.ponderCount,
+          "if the remote board did not change, it is still our turn and analysis can resume.");
+      assertFalse(getBooleanField(harness.readBoard, "failedLocalMoveRecoveryActive"));
+      assertFalse(getBooleanField(harness.readBoard, "failedLocalMoveAwaitingRemoteObservation"));
+      assertFalse(
+          getBooleanField(harness.readBoard, "failedLocalMoveWaitingForOurTurnAfterRemoteChange"));
+      assertFalse(harness.readBoard.shouldSuppressLocalPlaceAfterFailedSync(0, 1, Stone.BLACK));
+    }
+  }
+
+  @Test
+  void placementFailureObservationSurvivesReadBoardControlReset() throws Exception {
+    try (EngineResumeHarness harness =
+        EngineResumeHarness.create(rootHistory(emptyStones(), true))) {
+      harness.frame.isAnaPlayingAgainstLeelaz = true;
+      harness.frame.bothSync = true;
+      HistoryPath path =
+          buildHistory(
+              harness.board,
+              placement(0, 0, Stone.BLACK),
+              placement(1, 0, Stone.WHITE),
+              placement(0, 1, Stone.BLACK));
+      BoardHistoryNode remoteNode = path.nodes.get(1);
+
+      markPendingLocalMoveAwaitingReadBoard(harness.readBoard);
+      invokePlacementFailed(harness.readBoard);
+
+      harness.readBoard.parseLine("stopsync");
+
+      assertTrue(
+          harness.readBoard.shouldSuppressLocalPlaceAfterFailedSync(0, 1, Stone.BLACK),
+          "readboard control lines must preserve the short failed-place observation gate.");
+
+      harness.readBoard.parseLine("play");
+
+      assertTrue(
+          harness.readBoard.shouldSuppressLocalPlaceAfterFailedSync(0, 1, Stone.BLACK),
+          "readboard play control lines must not clear the short failed-place observation gate.");
+
+      harness.board.place(0, 1, Stone.BLACK, false, false, false);
+
+      assertSame(remoteNode, harness.board.getHistory().getCurrentHistoryNode());
+      assertFalse(remoteNode.next().isPresent());
+    }
+  }
+
+  @Test
+  void autoPlaySideChangeClearsStaleFailedPlacementRecovery() throws Exception {
+    try (EngineResumeHarness harness =
+        EngineResumeHarness.create(rootHistory(emptyStones(), true))) {
+      harness.frame.isAnaPlayingAgainstLeelaz = true;
+      harness.frame.bothSync = true;
+      buildHistory(harness.board, placement(0, 0, Stone.BLACK), placement(1, 0, Stone.WHITE));
+
+      markPendingLocalMoveAwaitingReadBoard(harness.readBoard);
+      invokePlacementFailed(harness.readBoard);
+
+      assertTrue(getBooleanField(harness.readBoard, "failedLocalMoveRecoveryActive"));
+
+      invokeClearFailedLocalMoveStateIfAutoPlaySideChanged(harness.readBoard, Stone.WHITE);
+
+      assertTrue(
+          getBooleanField(harness.readBoard, "failedLocalMoveRecoveryActive"),
+          "same-side play control should keep the failed-place guard.");
+
+      invokeClearFailedLocalMoveStateIfAutoPlaySideChanged(harness.readBoard, Stone.BLACK);
+
+      assertFalse(
+          getBooleanField(harness.readBoard, "failedLocalMoveRecoveryActive"),
+          "switching auto-play from the failed side must drop stale failed-place recovery.");
+      assertFalse(getBooleanField(harness.readBoard, "failedLocalMoveSuppressionActive"));
+      assertFalse(harness.readBoard.shouldSuppressLocalPlaceAfterFailedSync(0, 1, Stone.BLACK));
+    }
+  }
+
+  @Test
+  void placementFailureWithRemoteChangeToOpponentTurnDoesNotResumeAutoPlace() throws Exception {
+    try (EngineResumeHarness harness =
+        EngineResumeHarness.create(rootHistory(emptyStones(), true))) {
+      harness.frame.isAnaPlayingAgainstLeelaz = true;
+      harness.frame.bothSync = true;
+      HistoryPath path =
+          buildHistory(
+              harness.board,
+              placement(0, 0, Stone.BLACK),
+              placement(1, 0, Stone.WHITE),
+              placement(0, 1, Stone.BLACK));
+
+      markPendingLocalMoveAwaitingReadBoard(harness.readBoard);
+      invokePlacementFailed(harness.readBoard);
+      harness.sync(
+          snapshot(
+              stones(
+                  placement(0, 0, Stone.BLACK),
+                  placement(1, 0, Stone.WHITE),
+                  placement(2, 0, Stone.BLACK)),
+              Optional.of(new int[] {2, 0}),
+              Stone.BLACK));
+
+      assertEquals(
+          1,
+          harness.leelaz.ponderCount,
+          "the rollback may resume analysis, but the remote-change state must not trigger another local place.");
+      assertTrue(getBooleanField(harness.readBoard, "failedLocalMoveRecoveryActive"));
+      assertFalse(getBooleanField(harness.readBoard, "failedLocalMoveAwaitingRemoteObservation"));
+      assertTrue(
+          getBooleanField(harness.readBoard, "failedLocalMoveWaitingForOurTurnAfterRemoteChange"));
+      assertTrue(
+          harness.readBoard.shouldSuppressLocalPlaceAfterFailedSync(0, 2, Stone.BLACK),
+          "while the remote board says it is the opponent's turn, even a different local move must wait.");
+      assertEquals(3, harness.board.getHistory().getMainEnd().getData().moveNumber);
+    }
+  }
+
+  @Test
+  void placementFailureResumesAnalysisAfterOpponentRepliesAndItIsOurTurnAgain() throws Exception {
+    try (EngineResumeHarness harness =
+        EngineResumeHarness.create(rootHistory(emptyStones(), true))) {
+      harness.frame.isAnaPlayingAgainstLeelaz = true;
+      harness.frame.bothSync = true;
+      buildHistory(
+          harness.board,
+          placement(0, 0, Stone.BLACK),
+          placement(1, 0, Stone.WHITE),
+          placement(0, 1, Stone.BLACK));
+
+      markPendingLocalMoveAwaitingReadBoard(harness.readBoard);
+      invokePlacementFailed(harness.readBoard);
+      harness.sync(
+          snapshot(
+              stones(
+                  placement(0, 0, Stone.BLACK),
+                  placement(1, 0, Stone.WHITE),
+                  placement(2, 0, Stone.BLACK)),
+              Optional.of(new int[] {2, 0}),
+              Stone.BLACK));
+
+      assertEquals(
+          1,
+          harness.leelaz.ponderCount,
+          "after the misplaced local stone, analysis may already be running, but no local place should resume yet.");
+
+      harness.sync(
+          snapshot(
+              stones(
+                  placement(0, 0, Stone.BLACK),
+                  placement(1, 0, Stone.WHITE),
+                  placement(2, 0, Stone.BLACK),
+                  placement(2, 1, Stone.WHITE)),
+              Optional.of(new int[] {2, 1}),
+              Stone.WHITE));
+
+      assertEquals(
+          1,
+          harness.leelaz.ponderCount,
+          "if the observed remote board is back to our turn, analyze first and let the next move come from analysis.");
+      assertFalse(getBooleanField(harness.readBoard, "failedLocalMoveRecoveryActive"));
+      assertFalse(
+          getBooleanField(harness.readBoard, "failedLocalMoveWaitingForOurTurnAfterRemoteChange"));
+      assertEquals(4, harness.board.getHistory().getMainEnd().getData().moveNumber);
     }
   }
 
@@ -372,6 +925,12 @@ class ReadBoardEngineResumeTest {
     field.set(target, value);
   }
 
+  private static boolean getBooleanField(Object target, String name) throws Exception {
+    Field field = findField(target.getClass(), name);
+    field.setAccessible(true);
+    return field.getBoolean(target);
+  }
+
   private static Field findField(Class<?> type, String name) throws NoSuchFieldException {
     Class<?> current = type;
     while (current != null) {
@@ -388,6 +947,42 @@ class ReadBoardEngineResumeTest {
     Method method = ReadBoard.class.getDeclaredMethod("syncBoardStones", boolean.class);
     method.setAccessible(true);
     method.invoke(readBoard, false);
+  }
+
+  private static void markPendingLocalMoveAwaitingReadBoard(ReadBoard readBoard) throws Exception {
+    Method method = ReadBoard.class.getDeclaredMethod("startTrackingLocalMoveFromLizzie");
+    method.setAccessible(true);
+    method.invoke(readBoard);
+  }
+
+  private static void invokePlacementFailed(ReadBoard readBoard) throws Exception {
+    Method method =
+        ReadBoard.class.getDeclaredMethod("handlePendingLocalMovePlacementFailure", String.class);
+    method.setAccessible(true);
+    method.invoke(readBoard, "test placement failed");
+  }
+
+  private static void invokePlacementFailedLine(ReadBoard readBoard) throws Exception {
+    Method method =
+        ReadBoard.class.getDeclaredMethod("handleLocalMovePlacementFailed", String.class);
+    method.setAccessible(true);
+    method.invoke(readBoard, "error place failed");
+  }
+
+  private static boolean invokeAckTimeoutWithoutSnapshot(ReadBoard readBoard) throws Exception {
+    Method method =
+        ReadBoard.class.getDeclaredMethod("failPendingLocalMoveIfAckTimedOutWithoutSnapshot");
+    method.setAccessible(true);
+    return (boolean) method.invoke(readBoard);
+  }
+
+  private static void invokeClearFailedLocalMoveStateIfAutoPlaySideChanged(
+      ReadBoard readBoard, Stone autoPlayColor) throws Exception {
+    Method method =
+        ReadBoard.class.getDeclaredMethod(
+            "clearFailedLocalMoveStateIfAutoPlaySideChanged", Stone.class);
+    method.setAccessible(true);
+    method.invoke(readBoard, autoPlayColor);
   }
 
   private static final class EngineResumeHarness implements AutoCloseable {

--- a/src/test/java/featurecat/lizzie/analysis/ReadBoardPendingLocalMoveSyncTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/ReadBoardPendingLocalMoveSyncTest.java
@@ -11,8 +11,11 @@ import featurecat.lizzie.rules.BoardData;
 import featurecat.lizzie.rules.BoardHistoryList;
 import featurecat.lizzie.rules.Stone;
 import featurecat.lizzie.rules.Zobrist;
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayOutputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
@@ -28,6 +31,7 @@ class ReadBoardPendingLocalMoveSyncTest {
       Board.boardHeight = 2;
       Zobrist.init();
       ReadBoard readBoard = allocate(ReadBoard.class);
+      initializeReadBoardTrackers(readBoard);
       Board board = allocate(Board.class);
       board.setHistory(
           moveHistory(
@@ -40,16 +44,20 @@ class ReadBoardPendingLocalMoveSyncTest {
       LizzieFrame frame = allocate(LizzieFrame.class);
       frame.bothSync = true;
       Lizzie.frame = frame;
-      readBoard.lastMovePlayByLizzie = true;
+      invokeStartTrackingLocalMove(readBoard);
 
-      invokeAcknowledgeLocalMove(
-          readBoard,
-          new Stone[] {Stone.BLACK, Stone.EMPTY, Stone.EMPTY, Stone.EMPTY},
-          new int[] {1, 0, 0, 0});
+      boolean acknowledged =
+          invokeAcknowledgeLocalMove(
+              readBoard,
+              new Stone[] {Stone.BLACK, Stone.EMPTY, Stone.EMPTY, Stone.EMPTY},
+              new int[] {1, 0, 0, 0});
 
       assertFalse(
           readBoard.lastMovePlayByLizzie,
           "once the remote snapshot matches the local board, pending local-move ignore state should be cleared.");
+      assertTrue(
+          acknowledged,
+          "syncBoardStones must stop the current pass once this snapshot acknowledges the pending move.");
     } finally {
       Board.boardWidth = previousBoardWidth;
       Board.boardHeight = previousBoardHeight;
@@ -70,6 +78,7 @@ class ReadBoardPendingLocalMoveSyncTest {
       Board.boardHeight = 2;
       Zobrist.init();
       ReadBoard readBoard = allocate(ReadBoard.class);
+      initializeReadBoardTrackers(readBoard);
       Board board = allocate(Board.class);
       board.setHistory(
           moveHistory(
@@ -82,16 +91,19 @@ class ReadBoardPendingLocalMoveSyncTest {
       LizzieFrame frame = allocate(LizzieFrame.class);
       frame.bothSync = true;
       Lizzie.frame = frame;
-      readBoard.lastMovePlayByLizzie = true;
+      invokeStartTrackingLocalMove(readBoard);
 
-      invokeAcknowledgeLocalMove(
-          readBoard,
-          new Stone[] {Stone.BLACK, Stone.EMPTY, Stone.EMPTY, Stone.EMPTY},
-          new int[] {0, 0, 0, 0});
+      boolean acknowledged =
+          invokeAcknowledgeLocalMove(
+              readBoard,
+              new Stone[] {Stone.BLACK, Stone.EMPTY, Stone.EMPTY, Stone.EMPTY},
+              new int[] {0, 0, 0, 0});
 
       assertTrue(
           readBoard.lastMovePlayByLizzie,
           "the ignore state must remain while the remote board still has not caught up to the local move.");
+      assertFalse(
+          acknowledged, "a missing pending move must not short-circuit the rest of the sync pass.");
     } finally {
       Board.boardWidth = previousBoardWidth;
       Board.boardHeight = previousBoardHeight;
@@ -102,10 +114,26 @@ class ReadBoardPendingLocalMoveSyncTest {
   }
 
   @Test
-  void placeCompleteStopsIgnoringMissingLastLocalMove() throws Exception {
+  void placeCompleteWaitsForRemoteSnapshotBeforeClearingPendingMove() throws Exception {
+    int previousBoardWidth = Board.boardWidth;
+    int previousBoardHeight = Board.boardHeight;
+    Board previousBoard = Lizzie.board;
     LizzieFrame previousFrame = Lizzie.frame;
     try {
+      Board.boardWidth = 2;
+      Board.boardHeight = 2;
+      Zobrist.init();
       ReadBoard readBoard = allocate(ReadBoard.class);
+      initializeReadBoardTrackers(readBoard);
+      Board board = allocate(Board.class);
+      board.setHistory(
+          moveHistory(
+              stones(Stone.BLACK, Stone.EMPTY, Stone.EMPTY, Stone.EMPTY),
+              new int[] {0, 0},
+              Stone.BLACK,
+              false,
+              1));
+      Lizzie.board = board;
       LizzieFrame frame = allocate(LizzieFrame.class);
       frame.bothSync = true;
       Lizzie.frame = frame;
@@ -118,10 +146,542 @@ class ReadBoardPendingLocalMoveSyncTest {
 
       invokeMarkLocalMoveCommandCompleted(readBoard);
 
+      assertTrue(
+          invokeShouldIgnoreCurrentLastLocalMove(readBoard),
+          "placeComplete is only a connector hint; the pending move must wait for the remote snapshot.");
+
+      boolean acknowledged =
+          invokeAcknowledgeLocalMove(
+              readBoard,
+              new Stone[] {Stone.BLACK, Stone.EMPTY, Stone.EMPTY, Stone.EMPTY},
+              new int[] {1, 0, 0, 0});
+
+      assertTrue(acknowledged);
       assertFalse(
           invokeShouldIgnoreCurrentLastLocalMove(readBoard),
-          "once readboard reports placeComplete, a later snapshot missing that move should no longer be treated as pending lag.");
+          "the pending move clears only after the remote snapshot contains the placed stone.");
     } finally {
+      Board.boardWidth = previousBoardWidth;
+      Board.boardHeight = previousBoardHeight;
+      Zobrist.init();
+      Lizzie.board = previousBoard;
+      Lizzie.frame = previousFrame;
+    }
+  }
+
+  @Test
+  void externalPlaceCommandIsSkippedWhilePreviousLocalMoveIsPending() throws Exception {
+    LizzieFrame previousFrame = Lizzie.frame;
+    try {
+      ReadBoard readBoard = allocate(ReadBoard.class);
+      LizzieFrame frame = allocate(LizzieFrame.class);
+      frame.bothSync = true;
+      Lizzie.frame = frame;
+
+      TrackingBufferedOutputStream outputStream = new TrackingBufferedOutputStream();
+      setField(readBoard, "usePipe", true);
+      setField(readBoard, "outputStream", outputStream);
+
+      invokeStartTrackingLocalMove(readBoard);
+
+      readBoard.sendCommand("place 1 1");
+
+      assertFalse(
+          outputStream.writtenText().contains("place 1 1"),
+          "a second place command must not be sent while the previous local move is still waiting for readboard.");
+    } finally {
+      Lizzie.frame = previousFrame;
+    }
+  }
+
+  @Test
+  void readBoardControlResetPreservesPendingLocalMoveAwaitingAck() throws Exception {
+    LizzieFrame previousFrame = Lizzie.frame;
+    try {
+      ReadBoard readBoard = allocate(ReadBoard.class);
+      setField(readBoard, "conflictTracker", new SyncConflictTracker());
+      setField(readBoard, "historyJumpTracker", new SyncHistoryJumpTracker());
+
+      LizzieFrame frame = allocate(LizzieFrame.class);
+      frame.bothSync = true;
+      Lizzie.frame = frame;
+
+      invokeStartTrackingLocalMove(readBoard);
+
+      invokeResetActiveSyncStateForReadBoardControlLine(readBoard);
+
+      assertTrue(
+          invokeShouldIgnoreCurrentLastLocalMove(readBoard),
+          "readboard start/clear control lines must not clear a local move before placeComplete or error place failed.");
+    } finally {
+      Lizzie.frame = previousFrame;
+    }
+  }
+
+  @Test
+  void doesNotRetryPlaceCommandAfterPlaceCompleteWhileWaitingForSnapshot() throws Exception {
+    int previousBoardWidth = Board.boardWidth;
+    int previousBoardHeight = Board.boardHeight;
+    Board previousBoard = Lizzie.board;
+    LizzieFrame previousFrame = Lizzie.frame;
+    try {
+      Board.boardWidth = 2;
+      Board.boardHeight = 2;
+      Zobrist.init();
+
+      ReadBoard readBoard = allocate(ReadBoard.class);
+      initializeReadBoardTrackers(readBoard);
+      Board board = allocate(Board.class);
+      board.setHistory(
+          moveHistory(
+              stones(Stone.BLACK, Stone.EMPTY, Stone.EMPTY, Stone.EMPTY),
+              new int[] {0, 0},
+              Stone.BLACK,
+              false,
+              1));
+      Lizzie.board = board;
+
+      LizzieFrame frame = allocate(LizzieFrame.class);
+      frame.bothSync = true;
+      Lizzie.frame = frame;
+
+      TrackingBufferedOutputStream outputStream = new TrackingBufferedOutputStream();
+      setField(readBoard, "usePipe", true);
+      setField(readBoard, "outputStream", outputStream);
+
+      invokeStartTrackingLocalMove(readBoard);
+      invokeMarkLocalMoveCommandCompleted(readBoard);
+      setField(readBoard, "lastPendingLocalMoveRetryTimeMs", 0L);
+
+      invokeRetryPendingLocalMoveIfSnapshotStillMissing(readBoard, new int[] {0, 0, 0, 0});
+
+      assertFalse(
+          outputStream.writtenText().contains("place 0 0"),
+          "a completed click attempt that did not appear in the next snapshot should not keep clicking.");
+      assertTrue(
+          invokeShouldIgnoreCurrentLastLocalMove(readBoard),
+          "placeComplete alone must not confirm the move; a later snapshot still has to contain the stone.");
+    } finally {
+      Board.boardWidth = previousBoardWidth;
+      Board.boardHeight = previousBoardHeight;
+      Zobrist.init();
+      Lizzie.board = previousBoard;
+      Lizzie.frame = previousFrame;
+    }
+  }
+
+  @Test
+  void keepsPendingLocalMoveWithoutConnectorResultBeforeAckTimeout() throws Exception {
+    int previousBoardWidth = Board.boardWidth;
+    int previousBoardHeight = Board.boardHeight;
+    Board previousBoard = Lizzie.board;
+    LizzieFrame previousFrame = Lizzie.frame;
+    try {
+      Board.boardWidth = 2;
+      Board.boardHeight = 2;
+      Zobrist.init();
+
+      ReadBoard readBoard = allocate(ReadBoard.class);
+      initializeReadBoardTrackers(readBoard);
+      Board board = allocate(Board.class);
+      board.setHistory(
+          moveHistory(
+              stones(Stone.BLACK, Stone.EMPTY, Stone.EMPTY, Stone.EMPTY),
+              new int[] {0, 0},
+              Stone.BLACK,
+              false,
+              1));
+      Lizzie.board = board;
+
+      LizzieFrame frame = allocate(LizzieFrame.class);
+      frame.bothSync = true;
+      Lizzie.frame = frame;
+
+      TrackingBufferedOutputStream outputStream = new TrackingBufferedOutputStream();
+      setField(readBoard, "usePipe", true);
+      setField(readBoard, "outputStream", outputStream);
+
+      invokeStartTrackingLocalMove(readBoard);
+      setField(readBoard, "lastPendingLocalMoveRetryTimeMs", System.currentTimeMillis());
+
+      boolean stoppedCurrentSyncPass =
+          invokeRetryPendingLocalMoveIfSnapshotStillMissing(readBoard, new int[] {0, 0, 0, 0});
+
+      assertFalse(
+          stoppedCurrentSyncPass,
+          "a recent place attempt should keep waiting without ending the current sync pass.");
+      assertFalse(
+          outputStream.writtenText().contains("place 0 0"),
+          "a missing placeComplete should not trigger another mouse click.");
+      assertTrue(
+          invokeShouldIgnoreCurrentLastLocalMove(readBoard),
+          "without either placeComplete or error place failed, the connector may still be verifying the move.");
+    } finally {
+      Board.boardWidth = previousBoardWidth;
+      Board.boardHeight = previousBoardHeight;
+      Zobrist.init();
+      Lizzie.board = previousBoard;
+      Lizzie.frame = previousFrame;
+    }
+  }
+
+  @Test
+  void pendingLocalMoveWithoutConnectorResultTimesOutAndStopsHoldingSnapshots() throws Exception {
+    int previousBoardWidth = Board.boardWidth;
+    int previousBoardHeight = Board.boardHeight;
+    Board previousBoard = Lizzie.board;
+    LizzieFrame previousFrame = Lizzie.frame;
+    try {
+      Board.boardWidth = 2;
+      Board.boardHeight = 2;
+      Zobrist.init();
+
+      ReadBoard readBoard = allocate(ReadBoard.class);
+      initializeReadBoardTrackers(readBoard);
+      Board board = allocate(Board.class);
+      board.setHistory(
+          moveHistory(
+              stones(Stone.BLACK, Stone.EMPTY, Stone.EMPTY, Stone.EMPTY),
+              new int[] {0, 0},
+              Stone.BLACK,
+              false,
+              1));
+      Lizzie.board = board;
+
+      LizzieFrame frame = allocate(LizzieFrame.class);
+      frame.bothSync = true;
+      Lizzie.frame = frame;
+
+      TrackingBufferedOutputStream outputStream = new TrackingBufferedOutputStream();
+      setField(readBoard, "usePipe", true);
+      setField(readBoard, "outputStream", outputStream);
+
+      invokeStartTrackingLocalMove(readBoard);
+      setField(readBoard, "lastPendingLocalMoveRetryTimeMs", System.currentTimeMillis() - 5000L);
+
+      boolean stoppedCurrentSyncPass =
+          invokeRetryPendingLocalMoveIfSnapshotStillMissing(readBoard, new int[] {0, 0, 0, 0});
+
+      assertTrue(
+          stoppedCurrentSyncPass,
+          "a timed-out place attempt rolls back local state, so the current sync pass must stop before using stale local stones.");
+      assertFalse(
+          outputStream.writtenText().contains("place 0 0"),
+          "a missing place result must not trigger another mouse click.");
+      assertFalse(
+          invokeShouldIgnoreCurrentLastLocalMove(readBoard),
+          "after the place-result timeout, the missing local stone must stop being ignored.");
+      assertFalse(
+          invokeShouldHoldCompleteSnapshotRecoveryForPendingLocalMove(
+              readBoard, new int[] {0, 0, 0, 0}),
+          "after the timeout clears pending tracking, complete snapshot recovery must not stay held.");
+    } finally {
+      Board.boardWidth = previousBoardWidth;
+      Board.boardHeight = previousBoardHeight;
+      Zobrist.init();
+      Lizzie.board = previousBoard;
+      Lizzie.frame = previousFrame;
+    }
+  }
+
+  @Test
+  void placementFailureNoRemoteChangeReleasesMoveForFreshAnalysis() throws Exception {
+    int previousBoardWidth = Board.boardWidth;
+    int previousBoardHeight = Board.boardHeight;
+    Config previousConfig = Lizzie.config;
+    Board previousBoard = Lizzie.board;
+    LizzieFrame previousFrame = Lizzie.frame;
+    try {
+      Board.boardWidth = 2;
+      Board.boardHeight = 2;
+      Zobrist.init();
+
+      ReadBoard readBoard = allocate(ReadBoard.class);
+      initializeReadBoardTrackers(readBoard);
+      Config config = allocate(Config.class);
+      config.alwaysSyncBoardStat = false;
+      Lizzie.config = config;
+
+      Board board = allocate(Board.class);
+      Stone[] localStones = stones(Stone.BLACK, Stone.EMPTY, Stone.EMPTY, Stone.EMPTY);
+      board.setHistory(moveHistory(localStones, new int[] {0, 0}, Stone.BLACK, false, 1));
+      Lizzie.board = board;
+
+      LizzieFrame frame = allocate(LizzieFrame.class);
+      frame.bothSync = true;
+      Lizzie.frame = frame;
+
+      invokeStartTrackingLocalMove(readBoard);
+      invokeHandleLocalMovePlacementFailed(readBoard, "error place failed");
+      invokeRetryPendingLocalMoveIfSnapshotStillMissing(readBoard, new int[] {0, 0, 0, 0});
+      setField(readBoard, "failedLocalMoveSuppressionSnapshotKey", "0000");
+
+      assertFalse(
+          readBoard.lastMovePlayByLizzie,
+          "an explicit connector failure must stop ignoring the missing local move.");
+      assertTrue(
+          invokeShouldResyncAfterIncrementalSync(readBoard, localStones, new int[] {0, 0, 0, 0}),
+          "once the failed move is no longer pending, the one-stone local/remote mismatch should drive resync.");
+      assertTrue(
+          readBoard.shouldSuppressLocalPlaceAfterFailedSync(0, 0, Stone.BLACK),
+          "the same local move should be suppressed immediately after readboard rejects it.");
+      assertTrue(
+          readBoard.shouldSuppressLocalPlaceAfterFailedSync(1, 0, Stone.BLACK),
+          "before the remote board is observed, all local moves should be suppressed.");
+
+      invokeUpdateFailedLocalMoveSuppressionForSnapshot(readBoard, new int[] {0, 0, 0, 0});
+
+      assertFalse(
+          readBoard.shouldSuppressLocalPlaceAfterFailedSync(0, 0, Stone.BLACK),
+          "once the remote snapshot proves nothing was added, analysis may choose and send a fresh move.");
+
+      invokeStartTrackingLocalMove(readBoard);
+      setField(readBoard, "pendingLocalMoveBaselineKey", "0000");
+      invokeRetryPendingLocalMoveIfSnapshotStillMissing(readBoard, new int[] {0, 1, 0, 0});
+
+      invokeUpdateFailedLocalMoveSuppressionForSnapshot(readBoard, new int[] {0, 1, 0, 0});
+
+      assertTrue(
+          readBoard.shouldSuppressLocalPlaceAfterFailedSync(0, 0, Stone.BLACK),
+          "a raw snapshot change should stay suppressed until sync decides whose turn it is.");
+      assertTrue(
+          readBoard.shouldSuppressLocalPlaceAfterFailedSync(1, 0, Stone.BLACK),
+          "a changed snapshot must suppress even a different candidate until the turn has been resolved.");
+    } finally {
+      Board.boardWidth = previousBoardWidth;
+      Board.boardHeight = previousBoardHeight;
+      Zobrist.init();
+      Lizzie.config = previousConfig;
+      Lizzie.board = previousBoard;
+      Lizzie.frame = previousFrame;
+    }
+  }
+
+  @Test
+  void placementFailureObservationGuardExpiresWithoutRemoteSnapshot() throws Exception {
+    int previousBoardWidth = Board.boardWidth;
+    int previousBoardHeight = Board.boardHeight;
+    Config previousConfig = Lizzie.config;
+    Board previousBoard = Lizzie.board;
+    LizzieFrame previousFrame = Lizzie.frame;
+    try {
+      Board.boardWidth = 2;
+      Board.boardHeight = 2;
+      Zobrist.init();
+
+      ReadBoard readBoard = allocate(ReadBoard.class);
+      initializeReadBoardTrackers(readBoard);
+      Config config = allocate(Config.class);
+      config.alwaysSyncBoardStat = false;
+      Lizzie.config = config;
+
+      Board board = allocate(Board.class);
+      board.setHistory(
+          moveHistory(
+              stones(Stone.BLACK, Stone.EMPTY, Stone.EMPTY, Stone.EMPTY),
+              new int[] {0, 0},
+              Stone.BLACK,
+              false,
+              1));
+      Lizzie.board = board;
+
+      LizzieFrame frame = allocate(LizzieFrame.class);
+      frame.bothSync = true;
+      Lizzie.frame = frame;
+
+      invokeStartTrackingLocalMove(readBoard);
+      invokeHandleLocalMovePlacementFailed(readBoard, "error place failed");
+      invokeRetryPendingLocalMoveIfSnapshotStillMissing(readBoard, new int[] {0, 0, 0, 0});
+      setField(readBoard, "failedLocalMoveObservationDeadlineMs", System.currentTimeMillis() - 1L);
+
+      assertFalse(
+          readBoard.shouldSuppressLocalPlaceAfterFailedSync(0, 0, Stone.BLACK),
+          "if readboard does not send another snapshot promptly, the guard must expire and allow a fresh analyzed move.");
+      assertFalse(
+          readBoard.shouldSuppressLocalPlaceAfterFailedSync(1, 0, Stone.BLACK),
+          "the expired guard must not keep blocking different candidate moves either.");
+    } finally {
+      Board.boardWidth = previousBoardWidth;
+      Board.boardHeight = previousBoardHeight;
+      Zobrist.init();
+      Lizzie.config = previousConfig;
+      Lizzie.board = previousBoard;
+      Lizzie.frame = previousFrame;
+    }
+  }
+
+  @Test
+  void placementFailureVisibleInNextSnapshotClearsFailedMoveSuppression() throws Exception {
+    int previousBoardWidth = Board.boardWidth;
+    int previousBoardHeight = Board.boardHeight;
+    Config previousConfig = Lizzie.config;
+    Board previousBoard = Lizzie.board;
+    LizzieFrame previousFrame = Lizzie.frame;
+    try {
+      Board.boardWidth = 2;
+      Board.boardHeight = 2;
+      Zobrist.init();
+
+      ReadBoard readBoard = allocate(ReadBoard.class);
+      initializeReadBoardTrackers(readBoard);
+      Config config = allocate(Config.class);
+      config.alwaysSyncBoardStat = false;
+      Lizzie.config = config;
+
+      Board board = allocate(Board.class);
+      board.setHistory(
+          moveHistory(
+              stones(Stone.BLACK, Stone.EMPTY, Stone.EMPTY, Stone.EMPTY),
+              new int[] {0, 0},
+              Stone.BLACK,
+              false,
+              1));
+      Lizzie.board = board;
+
+      LizzieFrame frame = allocate(LizzieFrame.class);
+      frame.bothSync = true;
+      Lizzie.frame = frame;
+
+      invokeStartTrackingLocalMove(readBoard);
+      invokeHandleLocalMovePlacementFailed(readBoard, "error place failed");
+      assertTrue(
+          readBoard.shouldSuppressLocalPlaceAfterFailedSync(0, 0, Stone.BLACK),
+          "an explicit connector failure immediately rolls back and briefly guards the failed move.");
+
+      invokeUpdateFailedLocalMoveSuppressionForSnapshot(readBoard, new int[] {3, 0, 0, 0});
+
+      assertFalse(
+          readBoard.shouldSuppressLocalPlaceAfterFailedSync(0, 0, Stone.BLACK),
+          "if the next remote snapshot contains the rejected move, the failure was stale and must not suppress later play.");
+    } finally {
+      Board.boardWidth = previousBoardWidth;
+      Board.boardHeight = previousBoardHeight;
+      Zobrist.init();
+      Lizzie.config = previousConfig;
+      Lizzie.board = previousBoard;
+      Lizzie.frame = previousFrame;
+    }
+  }
+
+  @Test
+  void placeCompleteKeepsPendingGuardUntilConfirmedMoveAppearsInSnapshot() throws Exception {
+    int previousBoardWidth = Board.boardWidth;
+    int previousBoardHeight = Board.boardHeight;
+    Board previousBoard = Lizzie.board;
+    LizzieFrame previousFrame = Lizzie.frame;
+    try {
+      Board.boardWidth = 2;
+      Board.boardHeight = 2;
+      Zobrist.init();
+
+      ReadBoard readBoard = allocate(ReadBoard.class);
+      initializeReadBoardTrackers(readBoard);
+      Board board = allocate(Board.class);
+      board.setHistory(
+          moveHistory(
+              stones(Stone.BLACK, Stone.EMPTY, Stone.EMPTY, Stone.EMPTY),
+              new int[] {0, 0},
+              Stone.BLACK,
+              false,
+              1));
+      Lizzie.board = board;
+
+      LizzieFrame frame = allocate(LizzieFrame.class);
+      frame.bothSync = true;
+      Lizzie.frame = frame;
+
+      invokeStartTrackingLocalMove(readBoard);
+      invokeMarkLocalMoveCommandCompleted(readBoard);
+
+      assertTrue(
+          invokeShouldHoldCompleteSnapshotRecoveryForPendingLocalMove(
+              readBoard, new int[] {0, 0, 0, 0}),
+          "a stale snapshot arriving after placeComplete must not recover analysis to the previous move.");
+
+      boolean acknowledged =
+          invokeAcknowledgeLocalMove(
+              readBoard,
+              new Stone[] {Stone.BLACK, Stone.EMPTY, Stone.EMPTY, Stone.EMPTY},
+              new int[] {1, 0, 0, 0});
+
+      assertTrue(acknowledged);
+      assertFalse(
+          invokeShouldHoldCompleteSnapshotRecoveryForPendingLocalMove(
+              readBoard, new int[] {1, 0, 0, 0}),
+          "once the confirmed move is visible remotely, normal synchronization may continue.");
+    } finally {
+      Board.boardWidth = previousBoardWidth;
+      Board.boardHeight = previousBoardHeight;
+      Zobrist.init();
+      Lizzie.board = previousBoard;
+      Lizzie.frame = previousFrame;
+    }
+  }
+
+  @Test
+  void placementFailureWithoutPendingMoveDoesNotCreateSuppression() throws Exception {
+    LizzieFrame previousFrame = Lizzie.frame;
+    try {
+      ReadBoard readBoard = allocate(ReadBoard.class);
+      LizzieFrame frame = allocate(LizzieFrame.class);
+      frame.bothSync = true;
+      Lizzie.frame = frame;
+
+      invokeHandleLocalMovePlacementFailed(readBoard, "error place failed");
+
+      assertFalse(
+          readBoard.shouldSuppressLocalPlaceAfterFailedSync(0, 0, Stone.BLACK),
+          "a stale placement failure line should not suppress future local moves when no move is pending.");
+    } finally {
+      Lizzie.frame = previousFrame;
+    }
+  }
+
+  @Test
+  void snapshotContainingPendingLocalMoveClearsIgnoreEvenWithOtherDiffs() throws Exception {
+    int previousBoardWidth = Board.boardWidth;
+    int previousBoardHeight = Board.boardHeight;
+    Board previousBoard = Lizzie.board;
+    LizzieFrame previousFrame = Lizzie.frame;
+    try {
+      Board.boardWidth = 2;
+      Board.boardHeight = 2;
+      Zobrist.init();
+
+      ReadBoard readBoard = allocate(ReadBoard.class);
+      Board board = allocate(Board.class);
+      board.setHistory(
+          moveHistory(
+              stones(Stone.BLACK, Stone.EMPTY, Stone.EMPTY, Stone.EMPTY),
+              new int[] {0, 0},
+              Stone.BLACK,
+              false,
+              1));
+      Lizzie.board = board;
+
+      LizzieFrame frame = allocate(LizzieFrame.class);
+      frame.bothSync = true;
+      Lizzie.frame = frame;
+
+      invokeStartTrackingLocalMove(readBoard);
+
+      boolean acknowledged =
+          invokeAcknowledgeLocalMove(
+              readBoard,
+              new Stone[] {Stone.BLACK, Stone.EMPTY, Stone.EMPTY, Stone.EMPTY},
+              new int[] {1, 2, 0, 0});
+
+      assertFalse(
+          readBoard.lastMovePlayByLizzie,
+          "once the pending local move is visible remotely, later diffs should be handled as normal sync instead of keeping the old move pending.");
+      assertTrue(
+          acknowledged,
+          "a snapshot containing the pending move should be handled in a fresh sync pass even when other intersections differ.");
+    } finally {
+      Board.boardWidth = previousBoardWidth;
+      Board.boardHeight = previousBoardHeight;
+      Zobrist.init();
+      Lizzie.board = previousBoard;
       Lizzie.frame = previousFrame;
     }
   }
@@ -191,11 +751,13 @@ class ReadBoardPendingLocalMoveSyncTest {
       Lizzie.frame = frame;
       invokeStartTrackingLocalMove(readBoard);
 
-      invokeAcknowledgeLocalMove(readBoard, localStones, new int[] {1, 0, 0, 0});
+      boolean acknowledged =
+          invokeAcknowledgeLocalMove(readBoard, localStones, new int[] {1, 0, 0, 0});
 
       assertTrue(
           readBoard.lastMovePlayByLizzie,
           "snapshot metadata cannot acknowledge a pending local move before a real MOVE node exists.");
+      assertFalse(acknowledged, "snapshot metadata must not short-circuit the current sync pass.");
     } finally {
       Board.boardWidth = previousBoardWidth;
       Board.boardHeight = previousBoardHeight;
@@ -219,13 +781,13 @@ class ReadBoardPendingLocalMoveSyncTest {
     return (boolean) method.invoke(readBoard, stones, snapshotCodes);
   }
 
-  private static void invokeAcknowledgeLocalMove(
+  private static boolean invokeAcknowledgeLocalMove(
       ReadBoard readBoard, Stone[] stones, int[] snapshotCodes) throws Exception {
     Method method =
         ReadBoard.class.getDeclaredMethod(
             "acknowledgeLocalMoveIfSnapshotCaughtUp", Stone[].class, int[].class);
     method.setAccessible(true);
-    method.invoke(readBoard, stones, snapshotCodes);
+    return (boolean) method.invoke(readBoard, stones, snapshotCodes);
   }
 
   private static void invokeStartTrackingLocalMove(ReadBoard readBoard) throws Exception {
@@ -238,6 +800,65 @@ class ReadBoardPendingLocalMoveSyncTest {
     Method method = ReadBoard.class.getDeclaredMethod("markLocalMoveCommandCompleted");
     method.setAccessible(true);
     method.invoke(readBoard);
+  }
+
+  private static void invokeResetActiveSyncStateForReadBoardControlLine(ReadBoard readBoard)
+      throws Exception {
+    Method method =
+        ReadBoard.class.getDeclaredMethod("resetActiveSyncStateForReadBoardControlLine");
+    method.setAccessible(true);
+    method.invoke(readBoard);
+  }
+
+  private static boolean invokeRetryPendingLocalMoveIfSnapshotStillMissing(
+      ReadBoard readBoard, int[] snapshotCodes) throws Exception {
+    Method method =
+        ReadBoard.class.getDeclaredMethod(
+            "retryPendingLocalMoveIfSnapshotStillMissing", int[].class);
+    method.setAccessible(true);
+    return (boolean) method.invoke(readBoard, snapshotCodes);
+  }
+
+  private static void invokeHandleLocalMovePlacementFailed(ReadBoard readBoard, String line)
+      throws Exception {
+    Method method =
+        ReadBoard.class.getDeclaredMethod("handleLocalMovePlacementFailed", String.class);
+    method.setAccessible(true);
+    method.invoke(readBoard, line);
+  }
+
+  private static void invokeUpdateFailedLocalMoveSuppressionForSnapshot(
+      ReadBoard readBoard, int[] snapshotCodes) throws Exception {
+    Method method =
+        ReadBoard.class.getDeclaredMethod(
+            "updateFailedLocalMoveSuppressionForSnapshot", int[].class);
+    method.setAccessible(true);
+    method.invoke(readBoard, snapshotCodes);
+  }
+
+  private static void invokeUpdateConfirmedLocalMoveForSnapshot(
+      ReadBoard readBoard, int[] snapshotCodes) throws Exception {
+    Method method =
+        ReadBoard.class.getDeclaredMethod("updateConfirmedLocalMoveForSnapshot", int[].class);
+    method.setAccessible(true);
+    method.invoke(readBoard, snapshotCodes);
+  }
+
+  private static boolean invokeShouldHoldSyncForConfirmedLocalMove(
+      ReadBoard readBoard, int[] snapshotCodes) throws Exception {
+    Method method =
+        ReadBoard.class.getDeclaredMethod("shouldHoldSyncForConfirmedLocalMove", int[].class);
+    method.setAccessible(true);
+    return (boolean) method.invoke(readBoard, snapshotCodes);
+  }
+
+  private static boolean invokeShouldHoldCompleteSnapshotRecoveryForPendingLocalMove(
+      ReadBoard readBoard, int[] snapshotCodes) throws Exception {
+    Method method =
+        ReadBoard.class.getDeclaredMethod(
+            "shouldHoldCompleteSnapshotRecoveryForPendingLocalMove", int[].class);
+    method.setAccessible(true);
+    return (boolean) method.invoke(readBoard, snapshotCodes);
   }
 
   private static boolean invokeShouldIgnoreCurrentLastLocalMove(ReadBoard readBoard)
@@ -299,6 +920,35 @@ class ReadBoardPendingLocalMoveSyncTest {
       }
     }
     return zobrist;
+  }
+
+  private static void setField(Object target, String name, Object value) throws Exception {
+    Field field = target.getClass().getDeclaredField(name);
+    field.setAccessible(true);
+    field.set(target, value);
+  }
+
+  private static void initializeReadBoardTrackers(ReadBoard readBoard) throws Exception {
+    setField(readBoard, "conflictTracker", new SyncConflictTracker());
+    setField(readBoard, "historyJumpTracker", new SyncHistoryJumpTracker());
+    setField(readBoard, "localNavigationTracker", new SyncLocalNavigationTracker());
+  }
+
+  private static final class TrackingBufferedOutputStream extends BufferedOutputStream {
+    private final ByteArrayOutputStream capture;
+
+    private TrackingBufferedOutputStream() {
+      this(new ByteArrayOutputStream());
+    }
+
+    private TrackingBufferedOutputStream(ByteArrayOutputStream capture) {
+      super(capture);
+      this.capture = capture;
+    }
+
+    private String writtenText() {
+      return capture.toString(StandardCharsets.UTF_8);
+    }
   }
 
   private static final class UnsafeHolder {

--- a/src/test/java/featurecat/lizzie/analysis/ReadBoardShutdownTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/ReadBoardShutdownTest.java
@@ -1,5 +1,6 @@
 package featurecat.lizzie.analysis;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -80,6 +81,85 @@ class ReadBoardShutdownTest {
       assertTrue(
           outputStream.writtenText().contains("quit"),
           "shutdown should send quit before releasing resources.");
+    } finally {
+      Lizzie.frame = previousFrame;
+    }
+  }
+
+  @Test
+  void shutdownAfterProcessEndDoesNotWriteQuitToClosedPipe() throws Exception {
+    LizzieFrame previousFrame = Lizzie.frame;
+    try {
+      ReadBoard readBoard = allocate(ReadBoard.class);
+      LizzieFrame frame = allocate(LizzieFrame.class);
+      TrackingInputStreamReader inputStream =
+          new TrackingInputStreamReader(new ByteArrayInputStream(new byte[0]));
+      TrackingBufferedOutputStream outputStream = new TrackingBufferedOutputStream();
+      ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+
+      frame.syncBoard = true;
+      frame.bothSync = true;
+      frame.readBoard = readBoard;
+      Lizzie.frame = frame;
+
+      setField(readBoard, "conflictTracker", new SyncConflictTracker());
+      setField(readBoard, "historyJumpTracker", new SyncHistoryJumpTracker());
+      setField(readBoard, "localNavigationTracker", new SyncLocalNavigationTracker());
+      setField(readBoard, "tempcount", new ArrayList<Integer>());
+      setField(readBoard, "usePipe", true);
+      setField(readBoard, "inputStream", inputStream);
+      setField(readBoard, "outputStream", outputStream);
+      setField(readBoard, "executor", executor);
+
+      readBoard.shutdownAfterProcessEnd();
+
+      assertFalse(frame.syncBoard, "process-ended shutdown should clear syncBoard state.");
+      assertFalse(frame.bothSync, "process-ended shutdown should clear bothSync state.");
+      assertNull(frame.readBoard, "process-ended shutdown should detach the closed ReadBoard.");
+      assertTrue(outputStream.closeCalled, "process-ended shutdown should close hosted stdin.");
+      assertTrue(
+          inputStream.closeCalled, "process-ended shutdown should close hosted stdout reader.");
+      assertFalse(
+          outputStream.writtenText().contains("quit"),
+          "process-ended shutdown should not write quit to a readboard pipe that already ended.");
+    } finally {
+      Lizzie.frame = previousFrame;
+    }
+  }
+
+  @Test
+  void shutdownOnlyWritesQuitOnceWhenCalledRepeatedly() throws Exception {
+    LizzieFrame previousFrame = Lizzie.frame;
+    try {
+      ReadBoard readBoard = allocate(ReadBoard.class);
+      LizzieFrame frame = allocate(LizzieFrame.class);
+      TrackingInputStreamReader inputStream =
+          new TrackingInputStreamReader(new ByteArrayInputStream(new byte[0]));
+      TrackingBufferedOutputStream outputStream = new TrackingBufferedOutputStream();
+      ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+
+      frame.readBoard = readBoard;
+      Lizzie.frame = frame;
+
+      setField(readBoard, "conflictTracker", new SyncConflictTracker());
+      setField(readBoard, "historyJumpTracker", new SyncHistoryJumpTracker());
+      setField(readBoard, "localNavigationTracker", new SyncLocalNavigationTracker());
+      setField(readBoard, "tempcount", new ArrayList<Integer>());
+      setField(readBoard, "usePipe", true);
+      setField(readBoard, "inputStream", inputStream);
+      setField(readBoard, "outputStream", outputStream);
+      setField(readBoard, "executor", executor);
+
+      readBoard.shutdown();
+      String firstShutdownWrite = outputStream.writtenText();
+      readBoard.shutdown();
+
+      assertTrue(
+          firstShutdownWrite.contains("quit"), "normal shutdown should ask readboard to quit.");
+      assertEquals(
+          firstShutdownWrite,
+          outputStream.writtenText(),
+          "repeated shutdown should not write another quit command.");
     } finally {
       Lizzie.frame = previousFrame;
     }

--- a/src/test/java/featurecat/lizzie/analysis/SnapshotTrackingLeelaz.java
+++ b/src/test/java/featurecat/lizzie/analysis/SnapshotTrackingLeelaz.java
@@ -22,6 +22,8 @@ class SnapshotTrackingLeelaz extends Leelaz {
   int ponderCount;
   int togglePonderCount;
   int nameCmdCount;
+  int genmoveCount;
+  String lastGenmoveColor;
   List<String> playedMoves;
   List<String> sentCommands;
   private Stone[] stones;
@@ -39,6 +41,8 @@ class SnapshotTrackingLeelaz extends Leelaz {
     leelaz.ponderCount = 0;
     leelaz.togglePonderCount = 0;
     leelaz.nameCmdCount = 0;
+    leelaz.genmoveCount = 0;
+    leelaz.lastGenmoveColor = null;
     leelaz.playedMoves = new ArrayList<>();
     leelaz.sentCommands = new ArrayList<>();
     leelaz.started = true;
@@ -71,7 +75,14 @@ class SnapshotTrackingLeelaz extends Leelaz {
 
   @Override
   public void ponder() {
+    Pondering();
     ponderCount++;
+  }
+
+  @Override
+  public void genmove(String color) {
+    genmoveCount++;
+    lastGenmoveColor = color;
   }
 
   @Override


### PR DESCRIPTION
## Summary

- Fixes #32。
- 修复 ReadBoard 本地自动落子在 `place` 失败、漏点、错点后的恢复逻辑。
- pending 本地落子现在会绑定到发送 `place` 时的固定节点、坐标和颜色，不再从可变化的 `mainEnd` 动态推导。
- pending 未解决前，新的本地 `Board.place(...)` 不再允许先污染本地主线。
- 即使正在隔离旧的 `placeComplete`，`error place failed` 也会被正常处理，不会被吞掉。
- 落子失败后会回滚本地 pending 落子，把引擎恢复到已确认的远端棋盘，再继续分析。
- 修复开局选错执棋方后切换时，旧 failed-place 状态污染新执棋方的问题。

本 PR 依赖下游 readboard v3.0.6 或更新版本。v3.0.6 已支持落子验证重试次数配置化，因此 LizzieYzy 可以在开启“验证落子以确保成功”的同时，避免验证失败后反复点击旧目标点污染后续落子。

## Type Of Change

- [x] Bug fix
- [ ] Feature
- [ ] Packaging / release update
- [ ] Docs / translation
- [ ] Refactor

## Testing

- [x] Tested locally
- [ ] Verified package contents if packaging changed
- [x] Verified Fox sync flow if related
- [ ] Added screenshots if UI changed
- [ ] Updated README / docs if user-facing behavior changed
- [x] Noted affected platforms if the change is platform-specific

本地测试命令：

```powershell
mvn -Dtest=ReadBoardEngineResumeTest,ReadBoardPendingLocalMoveSyncTest,ReadBoardShutdownTest test
```

测试结果：

- `ReadBoardEngineResumeTest`: 26 passed
- `ReadBoardPendingLocalMoveSyncTest`: 16 passed
- `ReadBoardShutdownTest`: 4 passed
- 总计：46 passed

同时已使用下游 readboard v3.0.6 进行实际对局测试，当前反馈看错点、漏点、切换执棋方后的旧状态污染问题均已解决。

## Notes

本 PR 修复的关键行为：

- `placeComplete` 不再直接等同于远端真实落子成功。
- pending 本地落子只有在远端快照中出现目标子后才算确认。
- 收到 `error place failed` 后，会回滚本地 pending 落子并恢复引擎状态。
- 如果远端棋盘发生变化但没有出现 pending 目标点，说明可能发生错点，会以远端真实棋盘为准恢复。
- 如果漏点后没有远端快照继续到达，会通过 3 秒超时释放 pending 状态并恢复分析。
- 切换自动落子方时，如果旧 failed-place 状态属于另一方，会立即清理，避免污染新执棋方。

运行/打包注意：

- 需要使用下游 readboard v3.0.6 或更新版本。
- 建议开启“验证落子以确保成功 / Verify Placed Stone”。
- 同时将 readboard 的落子验证重试次数配置为较低值，推荐 `0`，避免验证失败后持续点击旧目标点。
- 当前 PR 主要修复 LizzieYzy 侧状态机；如果发布包需要内置 readboard v3.0.6，需要另行更新打包内容。