### PR TITLE
fix(gui): 修复候选点表预览状态泄漏

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
+++ b/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
@@ -4658,6 +4658,11 @@ public class BoardRenderer {
 
   public void clearBranch() {
     isShowingBranch = false;
+    branchOpt = Optional.empty();
+    variationOpt = Optional.empty();
+    mouseOverTemp = null;
+    branchStonesImage = emptyImage;
+    branchStonesShadowImage = emptyImage;
   }
 
   public boolean isInside(int x1, int y1) {

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -2654,17 +2654,7 @@ public class LizzieFrame extends JFrame {
 
   public boolean openRightClickMenu(int x, int y) {
     if (Lizzie.frame.clickOrder != -1) {
-      Lizzie.frame.clickOrder = -1;
-      boardRenderer.startNormalBoard();
-      Lizzie.frame.suggestionclick = LizzieFrame.outOfBoundCoordinate;
-      Lizzie.frame.mouseOverCoordinate = LizzieFrame.outOfBoundCoordinate;
-      boardRenderer.clearBranch();
-      if (Lizzie.config.isDoubleEngineMode()) {
-        boardRenderer2.startNormalBoard();
-        boardRenderer2.clearBranch();
-      }
-      Lizzie.frame.selectedorder = -1;
-      Lizzie.frame.currentRow = -1;
+      clearSuggestionTablePreview();
       return true;
     }
     if (!Lizzie.config.showRightMenu && !isMouseOverSuggestions()) {
@@ -7236,11 +7226,14 @@ public class LizzieFrame extends JFrame {
         }
       }
     }
-    if (clickOrder != -1) {
-      return false;
-    }
     // mouseOverCoordinate = outOfBoundCoordinate;
     Optional<int[]> coords = boardRenderer.convertScreenToCoordinates(x, y);
+    if (clickOrder != -1) {
+      if (!coords.isPresent()) {
+        return false;
+      }
+      clearSuggestionTablePreview();
+    }
     boolean inBoard = coords.isPresent();
     if (inBoard) {
       int[] curCoords = coords.get();
@@ -7358,6 +7351,21 @@ public class LizzieFrame extends JFrame {
       boardRenderer2.startNormalBoard();
       boardRenderer2.clearBranch();
       boardRenderer2.notShowingBranch();
+    }
+  }
+
+  void clearSuggestionTablePreview() {
+    clickOrder = -1;
+    selectedorder = -1;
+    currentRow = -1;
+    suggestionclick = outOfBoundCoordinate;
+    mouseOverCoordinate = outOfBoundCoordinate;
+    isMouseOver = false;
+    boardRenderer.startNormalBoard();
+    boardRenderer.clearBranch();
+    if (Lizzie.config.isDoubleEngineMode()) {
+      boardRenderer2.startNormalBoard();
+      boardRenderer2.clearBranch();
     }
   }
 

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -2653,7 +2653,7 @@ public class LizzieFrame extends JFrame {
   //  }
 
   public boolean openRightClickMenu(int x, int y) {
-    if (Lizzie.frame.clickOrder != -1) {
+    if (clickOrder != -1) {
       clearSuggestionTablePreview();
       return true;
     }
@@ -7228,13 +7228,13 @@ public class LizzieFrame extends JFrame {
     }
     // mouseOverCoordinate = outOfBoundCoordinate;
     Optional<int[]> coords = boardRenderer.convertScreenToCoordinates(x, y);
+    boolean inBoard = coords.isPresent();
     if (clickOrder != -1) {
-      if (!coords.isPresent()) {
+      if (!inBoard) {
         return false;
       }
       clearSuggestionTablePreview();
     }
-    boolean inBoard = coords.isPresent();
     if (inBoard) {
       int[] curCoords = coords.get();
       Lizzie.board.clearPressStoneInfo(curCoords);
@@ -7344,12 +7344,9 @@ public class LizzieFrame extends JFrame {
   public void clearMoved() {
     isReplayVariation = false;
     Lizzie.frame.isMouseOver = false;
-    boardRenderer.startNormalBoard();
-    boardRenderer.clearBranch();
+    clearBoardBranchPreview();
     boardRenderer.notShowingBranch();
     if (Lizzie.config.isDoubleEngineMode()) {
-      boardRenderer2.startNormalBoard();
-      boardRenderer2.clearBranch();
       boardRenderer2.notShowingBranch();
     }
   }
@@ -7361,6 +7358,10 @@ public class LizzieFrame extends JFrame {
     suggestionclick = outOfBoundCoordinate;
     mouseOverCoordinate = outOfBoundCoordinate;
     isMouseOver = false;
+    clearBoardBranchPreview();
+  }
+
+  private void clearBoardBranchPreview() {
     boardRenderer.startNormalBoard();
     boardRenderer.clearBranch();
     if (Lizzie.config.isDoubleEngineMode()) {
@@ -10688,25 +10689,18 @@ public class LizzieFrame extends JFrame {
   private void handleTableClick(int row, int col) {
     LizzieFrame.boardRenderer.startNormalBoard();
     if (listTable.getValueAt(row, 1).toString().startsWith("pass")) return;
+    int[] coords = Board.convertNameToCoordinates(listTable.getValueAt(row, 1).toString());
     if (clickOrder != -1
         && selectedorder >= 0
-        && Board.convertNameToCoordinates(listTable.getValueAt(row, 1).toString())[0]
-            == Lizzie.frame.suggestionclick[0]
-        && Board.convertNameToCoordinates(listTable.getValueAt(row, 1).toString())[1]
-            == Lizzie.frame.suggestionclick[1]) {
-      Lizzie.frame.suggestionclick = LizzieFrame.outOfBoundCoordinate;
-      Lizzie.frame.mouseOverCoordinate = LizzieFrame.outOfBoundCoordinate;
-      LizzieFrame.boardRenderer.clearBranch();
-      selectedorder = -1;
-      clickOrder = -1;
-      currentRow = -1;
+        && coords[0] == Lizzie.frame.suggestionclick[0]
+        && coords[1] == Lizzie.frame.suggestionclick[1]) {
+      clearSuggestionTablePreview();
       isMouseOver = true;
       Lizzie.frame.refresh();
     } else {
       clickOrder = row;
       selectedorder = row;
       currentRow = row;
-      int[] coords = Board.convertNameToCoordinates(listTable.getValueAt(row, 1).toString());
       Lizzie.frame.mouseOverCoordinate = coords;
       isMouseOver = true;
       Lizzie.frame.suggestionclick = coords;

--- a/src/main/java/featurecat/lizzie/gui/VariationTree.java
+++ b/src/main/java/featurecat/lizzie/gui/VariationTree.java
@@ -484,6 +484,7 @@ public class VariationTree {
       Optional<BoardHistoryNode> node = draw(null, area.x, area.y, area.width, area.height, true);
       // if (node.isPresent()) Lizzie.frame.noautocounting();
       if (node.isPresent()) {
+        Lizzie.frame.clearSuggestionTablePreview();
         Lizzie.board.moveToAnyPosition(node.get());
         Lizzie.frame.refresh();
       }

--- a/src/main/java/featurecat/lizzie/gui/VariationTreeBig.java
+++ b/src/main/java/featurecat/lizzie/gui/VariationTreeBig.java
@@ -386,6 +386,7 @@ public class VariationTreeBig {
       Optional<BoardHistoryNode> node = draw(null, area.x, area.y, area.width, area.height, true);
       // if (node.isPresent()) Lizzie.frame.noautocounting();
       if (node.isPresent()) {
+        Lizzie.frame.clearSuggestionTablePreview();
         Lizzie.board.moveToAnyPosition(node.get());
         Lizzie.frame.refresh();
       }

--- a/src/test/java/featurecat/lizzie/gui/MoveOnlyUiGateTest.java
+++ b/src/test/java/featurecat/lizzie/gui/MoveOnlyUiGateTest.java
@@ -139,6 +139,95 @@ class MoveOnlyUiGateTest {
   }
 
   @Test
+  void suggestionTablePreviewClearsWhenMouseReturnsToBoardCandidate() throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    try {
+      TrackingLizzieFrame frame = configuredFrame();
+      Lizzie.frame = frame;
+      Lizzie.board = boardWith(historyForCurrentNode(currentData()));
+      LizzieFrame.boardRenderer = new CoordinateBoardRenderer(new int[] {0, 1});
+      frame.clickOrder = 0;
+      frame.selectedorder = 0;
+      frame.currentRow = 0;
+      frame.suggestionclick = new int[] {1, 0};
+      frame.mouseOverCoordinate = LizzieFrame.outOfBoundCoordinate;
+      frame.isMouseOver = false;
+
+      frame.onMouseMoved(0, 0);
+
+      assertEquals(-1, frame.clickOrder, "board hover should exit table-preview lock.");
+      assertEquals(-1, frame.selectedorder, "board hover should clear selected suggestion row.");
+      assertEquals(-1, frame.currentRow, "board hover should clear current suggestion row.");
+      assertTrue(frame.isMouseOver, "board hover should activate the hovered candidate preview.");
+      assertEquals(
+          0, frame.mouseOverCoordinate[0], "hovered candidate x should replace old preview.");
+      assertEquals(
+          1, frame.mouseOverCoordinate[1], "hovered candidate y should replace old preview.");
+    } finally {
+      env.close();
+    }
+  }
+
+  @Test
+  void clearSuggestionTablePreviewClearsLockedSuggestionState() throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    try {
+      TrackingLizzieFrame frame = configuredFrame();
+      Lizzie.frame = frame;
+      frame.clickOrder = 2;
+      frame.selectedorder = 2;
+      frame.currentRow = 2;
+      frame.suggestionclick = new int[] {1, 1};
+      frame.mouseOverCoordinate = new int[] {1, 1};
+      frame.isMouseOver = true;
+
+      frame.clearSuggestionTablePreview();
+
+      assertEquals(-1, frame.clickOrder);
+      assertEquals(-1, frame.selectedorder);
+      assertEquals(-1, frame.currentRow);
+      assertEquals(LizzieFrame.outOfBoundCoordinate, frame.suggestionclick);
+      assertEquals(LizzieFrame.outOfBoundCoordinate, frame.mouseOverCoordinate);
+      assertFalse(frame.isMouseOver);
+    } finally {
+      env.close();
+    }
+  }
+
+  @Test
+  void boardRendererClearBranchDropsStaleBranchState() throws Exception {
+    BoardRenderer renderer = new BoardRenderer(false);
+    setField(BoardRenderer.class, renderer, "isShowingBranch", true);
+    setField(BoardRenderer.class, renderer, "branchOpt", Optional.of(new Object()));
+    setField(BoardRenderer.class, renderer, "variationOpt", Optional.of(List.of("A1")));
+    setField(BoardRenderer.class, renderer, "mouseOverTemp", bestMove(0, 1));
+    setField(
+        BoardRenderer.class,
+        renderer,
+        "branchStonesImage",
+        new BufferedImage(3, 3, BufferedImage.TYPE_INT_ARGB));
+    setField(
+        BoardRenderer.class,
+        renderer,
+        "branchStonesShadowImage",
+        new BufferedImage(3, 3, BufferedImage.TYPE_INT_ARGB));
+
+    renderer.clearBranch();
+
+    assertFalse(renderer.isShowingBranch());
+    assertFalse(((Optional<?>) getField(BoardRenderer.class, renderer, "branchOpt")).isPresent());
+    assertFalse(
+        ((Optional<?>) getField(BoardRenderer.class, renderer, "variationOpt")).isPresent());
+    assertEquals(
+        1,
+        ((BufferedImage) getField(BoardRenderer.class, renderer, "branchStonesImage")).getWidth());
+    assertEquals(
+        1,
+        ((BufferedImage) getField(BoardRenderer.class, renderer, "branchStonesShadowImage"))
+            .getWidth());
+  }
+
+  @Test
   void independentMainBoardBlunderHoverIgnoresSnapshotMarker() throws Exception {
     TestEnvironment env = TestEnvironment.open();
     try {
@@ -262,6 +351,19 @@ class MoveOnlyUiGateTest {
     Field field = target.getClass().getDeclaredField(name);
     field.setAccessible(true);
     field.setInt(target, value);
+  }
+
+  private static void setField(Class<?> owner, Object target, String name, Object value)
+      throws Exception {
+    Field field = owner.getDeclaredField(name);
+    field.setAccessible(true);
+    field.set(target, value);
+  }
+
+  private static Object getField(Class<?> owner, Object target, String name) throws Exception {
+    Field field = owner.getDeclaredField(name);
+    field.setAccessible(true);
+    return field.get(target);
   }
 
   private static BoardHistoryList historyWithNext(BoardData current, BoardData next) {

--- a/src/test/java/featurecat/lizzie/gui/MoveOnlyUiGateTest.java
+++ b/src/test/java/featurecat/lizzie/gui/MoveOnlyUiGateTest.java
@@ -2,6 +2,8 @@ package featurecat.lizzie.gui;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import featurecat.lizzie.Config;
@@ -186,8 +188,8 @@ class MoveOnlyUiGateTest {
       assertEquals(-1, frame.clickOrder);
       assertEquals(-1, frame.selectedorder);
       assertEquals(-1, frame.currentRow);
-      assertEquals(LizzieFrame.outOfBoundCoordinate, frame.suggestionclick);
-      assertEquals(LizzieFrame.outOfBoundCoordinate, frame.mouseOverCoordinate);
+      assertSame(LizzieFrame.outOfBoundCoordinate, frame.suggestionclick);
+      assertSame(LizzieFrame.outOfBoundCoordinate, frame.mouseOverCoordinate);
       assertFalse(frame.isMouseOver);
     } finally {
       env.close();
@@ -214,17 +216,14 @@ class MoveOnlyUiGateTest {
 
     renderer.clearBranch();
 
+    Object emptyImage = getField(BoardRenderer.class, null, "emptyImage");
     assertFalse(renderer.isShowingBranch());
     assertFalse(((Optional<?>) getField(BoardRenderer.class, renderer, "branchOpt")).isPresent());
     assertFalse(
         ((Optional<?>) getField(BoardRenderer.class, renderer, "variationOpt")).isPresent());
-    assertEquals(
-        1,
-        ((BufferedImage) getField(BoardRenderer.class, renderer, "branchStonesImage")).getWidth());
-    assertEquals(
-        1,
-        ((BufferedImage) getField(BoardRenderer.class, renderer, "branchStonesShadowImage"))
-            .getWidth());
+    assertNull(getField(BoardRenderer.class, renderer, "mouseOverTemp"));
+    assertSame(emptyImage, getField(BoardRenderer.class, renderer, "branchStonesImage"));
+    assertSame(emptyImage, getField(BoardRenderer.class, renderer, "branchStonesShadowImage"));
   }
 
   @Test


### PR DESCRIPTION
## Summary

- 背景：点击右侧候选点表的序号后，会进入表格锁定预览状态；但此前这个状态在切回棋盘候选点 hover 或点击右上角变化图节点时没有被可靠清理。
- 这会导致旧 PV 分支棋子残留，或者鼠标移回棋盘候选点时无法显示新的 hover 预览，必须通过右键棋盘等其他路径才能退出旧状态。
- 本 PR 将候选点表预览状态集中到 `LizzieFrame` 中清理，避免多个交互路径各自维护部分字段。
- 鼠标回到主棋盘候选点时，会先退出旧表格预览，再继续正常候选点 hover 逻辑。
- 点击变化图节点前会清理表格预览状态，避免切换历史节点后继续绘制旧 PV。
- `BoardRenderer.clearBranch()` 现在也会清理旧分支数据和分支贴图缓存，避免异常路径复用旧渲染状态。
- 本修复只影响主窗口 UI 预览状态，不改变 SNAPSHOT/PASS、SGF、引擎恢复、候选点排序或同步语义。

## Type Of Change

- [x] Bug fix
- [ ] Feature
- [ ] Packaging / release update
- [ ] Docs / translation
- [x] Refactor

## Testing

- [x] Tested locally
- [ ] Verified package contents if packaging changed
- [ ] Verified Fox sync flow if related
- [ ] Added screenshots if UI changed
- [ ] Updated README / docs if user-facing behavior changed
- [ ] Noted affected platforms if the change is platform-specific

测试命令：

- `.\.tools\apache-maven-3.9.10\bin\mvn.cmd -Dtest=MoveOnlyUiGateTest test`
- `.\.tools\apache-maven-3.9.10\bin\mvn.cmd "-Dtest=SnapshotMoveUiGateTest,PassPreviewGateTest" test`
- `.\.tools\apache-maven-3.9.10\bin\mvn.cmd "-Dtest=MoveOnlyUiGateTest,SnapshotMoveUiGateTest,PassPreviewGateTest" test`
- `.\.tools\apache-maven-3.9.10\bin\mvn.cmd -DskipTests package`

## Notes

- 已核对 `docs/SNAPSHOT_NODE_KIND.md`、`docs/TRACKING_ANALYSIS_CONTRACT.md`、`docs/superpowers/specs/2026-04-22-tracking-analysis-design.md`。
- 修复范围刻意限定在 `LizzieFrame.listTable` 的预览状态生命周期，以及共享的分支预览清理。
- 不修改 SNAPSHOT/PASS 合同，不修改 SGF 导入导出、引擎恢复、候选点表列、候选点排序或同步逻辑。