### PR TITLE
Fix Fox handicap stones dropped from board and engine

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/GetFoxRequest.java
+++ b/src/main/java/featurecat/lizzie/analysis/GetFoxRequest.java
@@ -393,13 +393,73 @@ public class GetFoxRequest {
       List<SgfMove> mainLineMoves = recoverPreferredMoves(tree, rootMoves);
       String nextColor = mainLineMoves.isEmpty() ? null : mainLineMoves.get(0).color;
       List<SgfMove> rootPrefix = chooseCompatibleRootPrefix(rootMoves, nextColor);
-      List<SgfMove> moves = normalizeMoves(rootPrefix, mainLineMoves);
+
+      List<SgfMove> orderedMoves = new ArrayList<SgfMove>(rootPrefix.size() + mainLineMoves.size());
+      orderedMoves.addAll(rootPrefix);
+      orderedMoves.addAll(mainLineMoves);
+      List<SgfMove> handicapStones = extractLeadingHandicapStones(orderedMoves);
+
+      List<SgfMove> moves;
+      if (!handicapStones.isEmpty()) {
+        applyHandicapStones(rootProperties, handicapStones);
+        moves = appendNormalizedMoves(new ArrayList<SgfMove>(), orderedMoves, null);
+      } else {
+        moves = normalizeMoves(rootPrefix, mainLineMoves);
+      }
 
       if (rootProperties.isEmpty() && moves.isEmpty()) {
         return input;
       }
 
       return buildSgf(rootProperties, moves);
+    }
+
+    /**
+     * Fox encodes handicap stones as a leading run of consecutive {@code B[]} moves rather than as
+     * {@code AB[]} root properties, and its {@code HA[]} field is unreliable. Strict alternation
+     * normalization would collapse that run into a single stone, silently dropping the rest of the
+     * handicap. Detect the leading black run (two or more placed stones) and pull it out so it can
+     * be emitted as proper {@code HA}/{@code AB} root setup. The supplied list is mutated in place
+     * to remove the extracted stones.
+     */
+    private List<SgfMove> extractLeadingHandicapStones(List<SgfMove> moves) {
+      int count = 0;
+      for (SgfMove move : moves) {
+        if (move == null || !"B".equals(move.color) || !isPlacedStone(move.coordinate)) {
+          break;
+        }
+        count++;
+      }
+      if (count < 2) {
+        return new ArrayList<SgfMove>();
+      }
+      List<SgfMove> handicap = new ArrayList<SgfMove>(moves.subList(0, count));
+      moves.subList(0, count).clear();
+      return handicap;
+    }
+
+    private boolean isPlacedStone(String coordinate) {
+      return coordinate != null && coordinate.length() == 2 && !"tt".equals(coordinate);
+    }
+
+    private void applyHandicapStones(
+        List<SgfProperty> rootProperties, List<SgfMove> handicapStones) {
+      List<SgfProperty> filtered = new ArrayList<SgfProperty>(rootProperties.size());
+      for (SgfProperty property : rootProperties) {
+        if (!"HA".equals(property.name) && !"AB".equals(property.name)) {
+          filtered.add(property);
+        }
+      }
+      rootProperties.clear();
+      rootProperties.addAll(filtered);
+
+      List<String> coordinates = new ArrayList<String>(handicapStones.size());
+      for (SgfMove stone : handicapStones) {
+        coordinates.add(stone.coordinate);
+      }
+      rootProperties.add(
+          new SgfProperty("HA", Arrays.asList(String.valueOf(handicapStones.size()))));
+      rootProperties.add(new SgfProperty("AB", coordinates));
     }
 
     private String buildSgf(List<SgfProperty> rootProperties, List<SgfMove> moves) {

--- a/src/test/java/featurecat/lizzie/analysis/GetFoxRequestTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/GetFoxRequestTest.java
@@ -29,4 +29,30 @@ class GetFoxRequestTest {
     assertTrue(normalizedSgf.contains(";W[pp];B[dd])"), normalizedSgf);
     assertFalse(normalizedSgf.contains(";AB[pd][dp];"), normalizedSgf);
   }
+
+  @Test
+  void normalizeFoxSgfPayloadPromotesLeadingConsecutiveBlackMovesToHandicap() throws Exception {
+    GetFoxRequest request = new GetFoxRequest(null);
+    Method normalizeMethod =
+        GetFoxRequest.class.getDeclaredMethod("normalizeFoxSgfPayload", String.class);
+    normalizeMethod.setAccessible(true);
+
+    String payload =
+        new JSONObject()
+            .put(
+                "chess",
+                "(;GM[1]FF[4]SZ[19]GN[]DT[2026-06-11]PB[随机2536]PW[廿月廿]BR[15级]WR[7段]"
+                    + "KM[375]HA[0]RU[Chinese]AP[GNU Go:3.8]RN[3]RE[W+R]TM[300]TC[3]TT[30]"
+                    + "AP[foxwq]RL[0];B[pd];B[pq];B[dd];B[dp];W[qo];B[qp];W[op];B[oq])")
+            .toString();
+
+    String normalizedPayload = (String) normalizeMethod.invoke(request, payload);
+    String normalizedSgf = new JSONObject(normalizedPayload).getString("chess");
+
+    assertTrue(normalizedSgf.contains("HA[4]"), normalizedSgf);
+    assertTrue(normalizedSgf.contains("AB[pd][pq][dd][dp]"), normalizedSgf);
+    assertFalse(normalizedSgf.contains("HA[0]"), normalizedSgf);
+    assertTrue(normalizedSgf.contains(";W[qo];B[qp];W[op];B[oq])"), normalizedSgf);
+    assertFalse(normalizedSgf.contains(";B[pd];B[pq]"), normalizedSgf);
+  }
 }


### PR DESCRIPTION
## Summary
- Fox 野狐 把让子棋编码成开局连续的 `B[]` 走子（而不是 `AB[]` 根节点 setup），并且它的 `HA[]` 字段不可靠。`SgfMainLineNormalizer` 之前强制交替归一化，会把这串连续黑棋折叠成一手，静默丢掉其余让子，导致下载下来的让子棋在棋盘和引擎里都没有让子。
- 现在在交替归一化之前检测开头连续黑棋（≥2 手已落子），还原成正确的 `HA[n]` / `AB[...]` 根节点 setup。

## Test plan
- [x] 新增回归测试 `normalizeFoxSgfPayloadPromotesLeadingConsecutiveBlackMovesToHandicap`，使用真实 4 子让子棋的 Fox payload，断言输出含 `HA[4]` 与 `AB[pd][pq][dd][dp]`，且不再有 `HA[0]` 或 `;B[pd];B[pq]`。
- [x] `mvn -o test -Dtest=GetFoxRequestTest` 全部通过（2/2）。
- [x] 在 Windows 测试机上 package 后实际下载该让子棋，棋盘与引擎均正确识别让子。