### PR TITLE
修复首次 OpenCL 自动调优导致引擎启动被误判为异常关闭

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -152,6 +152,7 @@ public class Leelaz {
   public boolean autoAnalysed = false;
   private static final long BUNDLED_ENGINE_START_TIMEOUT_MS = 90000L;
   private static final long NVIDIA_ENGINE_START_TIMEOUT_MS = 180000L;
+  private static final long FIRST_OPENCL_TUNING_START_TIMEOUT_MS = 600000L;
   private static final long LOAD_SGF_SEND_FAILURE_CLEANUP_TIMEOUT_MILLIS = 1000L;
   private static final long LOAD_SGF_PENDING_RESPONSE_GRACE_TIMEOUT_MILLIS = 3000L;
   private static final long LOAD_SGF_NO_RESPONSE_EXTRA_TIMEOUT_MILLIS = 2000L;
@@ -4759,8 +4760,12 @@ public class Leelaz {
       return;
     }
     final boolean nvidiaBundled = KataGoRuntimeHelper.isNvidiaBundledPath(engineExecutable);
+    final boolean firstOpenCLTuning =
+        !nvidiaBundled && KataGoRuntimeHelper.needsFirstOpenCLTuning(engineExecutable);
     final long timeoutMillis =
-        nvidiaBundled ? NVIDIA_ENGINE_START_TIMEOUT_MS : BUNDLED_ENGINE_START_TIMEOUT_MS;
+        firstOpenCLTuning
+            ? FIRST_OPENCL_TUNING_START_TIMEOUT_MS
+            : (nvidiaBundled ? NVIDIA_ENGINE_START_TIMEOUT_MS : BUNDLED_ENGINE_START_TIMEOUT_MS);
     Thread watchdog =
         new Thread(
             () -> {
@@ -4771,6 +4776,13 @@ public class Leelaz {
                 }
                 if (process != null && !process.isAlive()) {
                   break;
+                }
+                // OpenCL autotuning can take several minutes; keep waiting while it runs.
+                if (isTuning) {
+                  deadline =
+                      Math.max(
+                          deadline,
+                          System.currentTimeMillis() + FIRST_OPENCL_TUNING_START_TIMEOUT_MS);
                 }
                 try {
                   Thread.sleep(250L);

--- a/src/main/java/featurecat/lizzie/util/KataGoRuntimeHelper.java
+++ b/src/main/java/featurecat/lizzie/util/KataGoRuntimeHelper.java
@@ -2223,6 +2223,39 @@ public final class KataGoRuntimeHelper {
         .normalize();
   }
 
+  /**
+   * Returns true when the bundled engine still needs a one-time OpenCL autotuning pass, i.e. no
+   * cached tuning parameters exist yet. The first OpenCL tuning can take a few minutes, so callers
+   * should grant a longer startup budget in that case.
+   */
+  public static boolean needsFirstOpenCLTuning(Path enginePath) {
+    if (!isWindowsPlatform()) {
+      return false;
+    }
+    if (enginePath == null
+        || !Config.isBundledKataGoCommand(enginePath.toAbsolutePath().normalize().toString())) {
+      return false;
+    }
+    // NVIDIA TensorRT/CUDA packages do not rely on the OpenCL tuning cache.
+    if (resolveNvidiaBackend(enginePath) != null) {
+      return false;
+    }
+    Path homeDataDir = getBundledHomeDataDir();
+    if (homeDataDir == null) {
+      return false;
+    }
+    Path tuningDir = homeDataDir.resolve("opencltuning");
+    if (!Files.isDirectory(tuningDir)) {
+      return true;
+    }
+    try (Stream<Path> entries = Files.list(tuningDir)) {
+      return entries.noneMatch(
+          p -> p.getFileName().toString().toLowerCase(Locale.ROOT).endsWith(".txt"));
+    } catch (IOException e) {
+      return true;
+    }
+  }
+
   private static void appendOverrideConfig(List<String> command, String keyValue) {
     if (command == null || keyValue == null || keyValue.trim().isEmpty()) {
       return;


### PR DESCRIPTION
## 问题现象

在 Windows 上打开 `LizzieYzy Next OpenCL` 启动引擎时，会弹出"引擎异常关闭"，但在命令行里直接运行 KataGo 却完全正常。

## 问题原因

GUI 启动时有一个看门狗（startup watchdog），对内置引擎的启动超时设置为 90 秒（`BUNDLED_ENGINE_START_TIMEOUT_MS = 90000`）。

但是 OpenCL 后端在**首次**启动时需要做一次 OpenCL 自动调优（autotuning），这个过程相当耗时。实测 CLI 日志：

- `23:26:40` Performing autotuning
- `23:28:54` Done tuning

整个调优约 130 秒，超过了看门狗的 90 秒超时。于是看门狗判定引擎"启动失败"，调用 `process.destroyForcibly()` 强行杀掉引擎进程，并弹出异常关闭对话框。

命令行直接运行没有这个看门狗，所以不会被杀掉，能正常完成调优。由于调优结果会写入缓存（`katago-home/opencltuning/tune11_*.txt`），第一次成功后就不再需要重新调优，因此该问题表现为偶发——只在缓存不存在的首次启动时出现。

另外，由于 `gtp.cfg` 中 `logToStderr=false`，KataGo 的调优进度只写入日志文件、不输出到 stderr，GUI 端原有的 `isTuning` 标志在启动阶段无法稳定捕获到调优状态，因此不能仅依赖它来判断。

## 修复方案

1. 新增 `KataGoRuntimeHelper.needsFirstOpenCLTuning(...)`：仅在 Windows、内置引擎、非 NVIDIA 后端、且 `katago-home/opencltuning` 下没有 `.txt` 调优缓存时返回 true，即精确识别"首次 OpenCL 调优"场景。
2. 在 `Leelaz.startBundledStartupWatchdog` 中，当检测到首次需要 OpenCL 调优时，把启动超时从 90 秒延长到 600 秒（`FIRST_OPENCL_TUNING_START_TIMEOUT_MS = 600000`）。
3. 作为兜底，当 `isTuning` 为 true 时持续顺延看门狗的 deadline，避免调优进行中被误杀。

修复后首次启动会给足调优时间，调优完成并写入缓存后，后续启动仍走正常的快速超时逻辑。