### PR TITLE
Fix live komi and UI polish

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/GameInfo.java
+++ b/src/main/java/featurecat/lizzie/analysis/GameInfo.java
@@ -61,8 +61,12 @@ public class GameInfo {
 
   public void setKomi(double komi) {
     this.komi = komi;
-    LizzieFrame.menu.txtKomi.setText(String.valueOf(komi));
-    if (Lizzie.frame.isInScoreMode) Lizzie.board.showGroupResult();
+    if (LizzieFrame.menu != null && LizzieFrame.menu.txtKomi != null) {
+      LizzieFrame.menu.txtKomi.setText(String.valueOf(komi));
+    }
+    if (Lizzie.frame != null && Lizzie.frame.isInScoreMode && Lizzie.board != null) {
+      Lizzie.board.showGroupResult();
+    }
   }
 
   public void setKomiNoMenu(double komi) {

--- a/src/main/java/featurecat/lizzie/gui/ConfigDialog2.java
+++ b/src/main/java/featurecat/lizzie/gui/ConfigDialog2.java
@@ -191,6 +191,7 @@ public class ConfigDialog2 extends JDialog {
   private JCheckBox chkShowSubBoard;
   private JCheckBox chkShowStatus;
   private JCheckBox chkShowCoordinates;
+  private JCheckBox chkHideCommentControlPane;
   private JRadioButton rdoShowMoveNumberNo;
   private JRadioButton rdoShowMoveNumberAll;
   private JRadioButton rdoShowMoveNumberLast;
@@ -783,6 +784,14 @@ public class ConfigDialog2 extends JDialog {
     chkAppendWinrateToComment.setBounds(837, 606, 26, 23);
     uiTab.add(chkAppendWinrateToComment);
 
+    JLabel lblHideCommentControlPane =
+        new JLabel(resourceBundle.getString("LizzieConfig.title.hideCommentControlPane"));
+    lblHideCommentControlPane.setBounds(608, 636, 221, 16);
+    uiTab.add(lblHideCommentControlPane);
+    chkHideCommentControlPane = new JCheckBox("");
+    chkHideCommentControlPane.setBounds(837, 633, 26, 23);
+    uiTab.add(chkHideCommentControlPane);
+
     JLabel lblShowSuggestionMoveOrder =
         new JLabel(
             resourceBundle.getString("LizzieConfig.lblShowSuggestionMoveOrder")); // ("显示选点右上方角标");
@@ -982,6 +991,7 @@ public class ConfigDialog2 extends JDialog {
     chkShowMoveAllInBranch.setSelected(Lizzie.config.showMoveAllInBranch);
     // chkDynamicWinrateGraphWidth.setSelected(Lizzie.config.dynamicWinrateGraphWidth);
     chkAppendWinrateToComment.setSelected(Lizzie.config.appendWinrateToComment);
+    chkHideCommentControlPane.setSelected(Lizzie.config.hideBlunderControlPane);
     chkShowSuggLabel.setSelected(Lizzie.config.showSuggestionOrder);
     chkMaxValueReverseColor.setSelected(Lizzie.config.showSuggestionMaxRed);
     chkShowVairationsOnMouse.setSelected(Lizzie.config.showSuggestionVariations);
@@ -2476,7 +2486,11 @@ public class ConfigDialog2 extends JDialog {
               {"点击复盘", toggleText(chkEnableClickReview, Lizzie.config.enableClickReview)},
               {"拖拽棋子", toggleText(chkEnableDragStone, Lizzie.config.allowDrag)},
               {"显示坐标", toggleText(chkShowCoordinates, Lizzie.config.showCoordinates)},
-              {"评论面板", toggleText(chkShowComment, Lizzie.config.showComment)}
+              {"评论面板", toggleText(chkShowComment, Lizzie.config.showComment)},
+              {
+                "隐藏评论/问题手控制条",
+                toggleText(chkHideCommentControlPane, Lizzie.config.hideBlunderControlPane)
+              }
             });
         addSummaryTip(modernSummaryBody, "<html><b>操作优先</b><br>这里的设置会直接影响鼠标和键盘复盘手感。</html>");
         break;
@@ -3090,6 +3104,7 @@ public class ConfigDialog2 extends JDialog {
         addToggleRow(operation, "启用点击复盘", "点击棋盘时进入更顺手的复盘操作", chkEnableClickReview);
         addToggleRow(operation, "启用拖拽棋子", "允许在棋盘上拖拽调整棋子位置", chkEnableDragStone);
         addToggleRow(operation, "显示评论面板", "展示棋谱评论和分析说明", chkShowComment);
+        addToggleRow(operation, "隐藏评论/问题手控制条", "隐藏评论和问题手区域鼠标悬停时出现的控制条", chkHideCommentControlPane);
         addToggleRow(operation, "显示坐标", "在棋盘边缘显示坐标", chkShowCoordinates);
         addToggleRow(operation, "小棋盘不跟随刷新", "鼠标经过小棋盘时保持当前局部预览", chkNoRefreshSub);
         return operation;
@@ -3168,6 +3183,7 @@ public class ConfigDialog2 extends JDialog {
   private void addToggleRow(JPanel card, String title, String subtitle, JCheckBox toggle) {
     JPanel row = createDesignRow(title, subtitle);
     addDesignRowControl(row, prepareDesignSwitch(toggle));
+    installToggleRowClickTargets(row, toggle);
     card.add(row);
   }
 
@@ -3252,6 +3268,27 @@ public class ConfigDialog2 extends JDialog {
     button.setMinimumSize(new Dimension(54, 30));
     button.setHorizontalAlignment(SwingConstants.RIGHT);
     return button;
+  }
+
+  private void installToggleRowClickTargets(Component component, JCheckBox toggle) {
+    if (component instanceof AbstractButton) {
+      return;
+    }
+    component.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+    component.addMouseListener(
+        new MouseAdapter() {
+          @Override
+          public void mouseClicked(MouseEvent e) {
+            if (SwingUtilities.isLeftMouseButton(e) && toggle.isEnabled()) {
+              toggle.doClick();
+            }
+          }
+        });
+    if (component instanceof java.awt.Container) {
+      for (Component child : ((java.awt.Container) component).getComponents()) {
+        installToggleRowClickTargets(child, toggle);
+      }
+    }
   }
 
   private Component detachComponent(Component component) {
@@ -6058,6 +6095,14 @@ public class ConfigDialog2 extends JDialog {
       Lizzie.config.appendWinrateToComment = chkAppendWinrateToComment.isSelected();
       Lizzie.config.uiConfig.putOpt(
           "append-winrate-to-comment", Lizzie.config.appendWinrateToComment);
+      Lizzie.config.hideBlunderControlPane = chkHideCommentControlPane.isSelected();
+      Lizzie.config.uiConfig.putOpt(
+          "hide-blunder-table-control-pane", Lizzie.config.hideBlunderControlPane);
+      if (Lizzie.config.hideBlunderControlPane
+          && Lizzie.frame != null
+          && Lizzie.frame.commentBlunderControlPane != null) {
+        Lizzie.frame.commentBlunderControlPane.setVisible(false);
+      }
       Lizzie.config.showSuggestionOrder = chkShowSuggLabel.isSelected();
       Lizzie.config.uiConfig.putOpt("show-suggestion-order", Lizzie.config.showSuggestionOrder);
       Lizzie.config.showSuggestionMaxRed = chkMaxValueReverseColor.isSelected();

--- a/src/main/java/featurecat/lizzie/gui/FloatBoardRenderer.java
+++ b/src/main/java/featurecat/lizzie/gui/FloatBoardRenderer.java
@@ -1065,26 +1065,9 @@ public class FloatBoardRenderer {
       double winrateDiff,
       double scoreDiff,
       boolean isLastMove) {
-    float radiusF = 0.1f;
-    if (winrateDiff <= Lizzie.config.winLossThreshold5
-        || scoreDiff <= Lizzie.config.scoreLossThreshold5) {
-      g.setColor(new Color(155, 25, 150));
-      radiusF = 0.19f;
-    } else if (winrateDiff <= Lizzie.config.winLossThreshold4
-        || scoreDiff <= Lizzie.config.scoreLossThreshold4) {
-      g.setColor(new Color(208, 16, 19));
-      radiusF = 0.1675f;
-    } else if (winrateDiff <= Lizzie.config.winLossThreshold3
-        || scoreDiff <= Lizzie.config.scoreLossThreshold3) {
-      g.setColor(new Color(200, 140, 50));
-      radiusF = 0.145f;
-    } else if (winrateDiff <= Lizzie.config.winLossThreshold2
-        || scoreDiff <= Lizzie.config.scoreLossThreshold2) {
-      g.setColor(new Color(180, 180, 0));
-      radiusF = 0.1225f;
-    } else if (winrateDiff <= Lizzie.config.winLossThreshold1
-        || scoreDiff <= Lizzie.config.scoreLossThreshold1) g.setColor(new Color(140, 202, 34));
-    else g.setColor(new Color(0, 180, 0));
+    double severity = moveRankMarkSeverity(winrateDiff, scoreDiff);
+    float radiusF = (float) (0.1 + Math.min(1.0, severity / 6.0) * 0.09);
+    g.setColor(moveRankMarkColor(severity));
 
     if (isLastMove) {
       switch (Lizzie.config.stoneIndicatorType) {
@@ -1100,6 +1083,74 @@ public class FloatBoardRenderer {
       int radius = (int) Math.round(squareWidth * radiusF);
       fillCircle(g, markX, markY, radius);
     }
+  }
+
+  static double moveRankMarkSeverity(double winrateDiff, double scoreDiff) {
+    double winrateSeverity =
+        moveRankMetricSeverity(
+            winrateDiff,
+            Lizzie.config.winLossThreshold1,
+            Lizzie.config.winLossThreshold2,
+            Lizzie.config.winLossThreshold3,
+            Lizzie.config.winLossThreshold4,
+            Lizzie.config.winLossThreshold5);
+    double scoreSeverity =
+        moveRankMetricSeverity(
+            scoreDiff,
+            Lizzie.config.scoreLossThreshold1,
+            Lizzie.config.scoreLossThreshold2,
+            Lizzie.config.scoreLossThreshold3,
+            Lizzie.config.scoreLossThreshold4,
+            Lizzie.config.scoreLossThreshold5);
+    return Math.max(winrateSeverity, scoreSeverity);
+  }
+
+  static Color moveRankMarkColor(double severity) {
+    Color[] stops = {
+      new Color(31, 157, 92),
+      new Color(121, 184, 74),
+      new Color(215, 176, 61),
+      new Color(232, 132, 58),
+      new Color(221, 75, 58),
+      new Color(180, 38, 78),
+      new Color(122, 26, 138)
+    };
+    double clamped = Math.max(0, Math.min(stops.length - 1, severity));
+    int lower = (int) Math.floor(clamped);
+    int upper = Math.min(stops.length - 1, lower + 1);
+    double ratio = clamped - lower;
+    return interpolateColor(stops[lower], stops[upper], ratio);
+  }
+
+  private static double moveRankMetricSeverity(
+      double diff,
+      double threshold1,
+      double threshold2,
+      double threshold3,
+      double threshold4,
+      double threshold5) {
+    if (diff > threshold1) {
+      return 0;
+    }
+    double[] thresholds = {threshold1, threshold2, threshold3, threshold4, threshold5};
+    for (int i = 0; i < thresholds.length - 1; i++) {
+      double upper = thresholds[i];
+      double lower = thresholds[i + 1];
+      if (diff > lower) {
+        double span = Math.max(0.0001, upper - lower);
+        return (i + 1) + (upper - diff) / span;
+      }
+    }
+    double extremeSpan = Math.max(1.0, Math.abs(threshold5));
+    return 5 + Math.min(1.0, (threshold5 - diff) / extremeSpan);
+  }
+
+  private static Color interpolateColor(Color start, Color end, double ratio) {
+    int red = (int) Math.round(start.getRed() + (end.getRed() - start.getRed()) * ratio);
+    int green =
+        (int) Math.round(start.getGreen() + (end.getGreen() - start.getGreen()) * ratio);
+    int blue = (int) Math.round(start.getBlue() + (end.getBlue() - start.getBlue()) * ratio);
+    return new Color(red, green, blue);
   }
 
   /** Draw move numbers and/or mark the last played move */

--- a/src/main/java/featurecat/lizzie/gui/HtmlMessage.java
+++ b/src/main/java/featurecat/lizzie/gui/HtmlMessage.java
@@ -4,7 +4,10 @@ import featurecat.lizzie.Config;
 import featurecat.lizzie.gui.LizzieFrame.HtmlKit;
 import java.awt.Desktop;
 import java.awt.Font;
+import java.awt.Toolkit;
 import java.awt.Window;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.io.IOException;
 import javax.imageio.ImageIO;
 import javax.swing.JDialog;
@@ -21,6 +24,18 @@ public class HtmlMessage extends JDialog {
   public HtmlMessage(String title, String content, Window owner) {
     super(owner);
     this.setResizable(false);
+    setDefaultCloseOperation(DISPOSE_ON_CLOSE);
+    addWindowListener(
+        new WindowAdapter() {
+          @Override
+          public void windowClosed(WindowEvent e) {
+            if (owner != null) {
+              owner.invalidate();
+              owner.repaint();
+            }
+            Toolkit.getDefaultToolkit().sync();
+          }
+        });
     // setType(Type.POPUP);
     setTitle(title);
     setAlwaysOnTop(true);

--- a/src/main/java/featurecat/lizzie/gui/Message.java
+++ b/src/main/java/featurecat/lizzie/gui/Message.java
@@ -3,6 +3,7 @@ package featurecat.lizzie.gui;
 import featurecat.lizzie.Config;
 import featurecat.lizzie.Lizzie;
 import java.awt.Font;
+import java.awt.Toolkit;
 import java.awt.Window;
 import java.io.IOException;
 import java.util.ResourceBundle;
@@ -10,6 +11,8 @@ import javax.imageio.ImageIO;
 import javax.swing.BorderFactory;
 import javax.swing.JDialog;
 import javax.swing.JLabel;
+import javax.swing.SwingUtilities;
+import javax.swing.Timer;
 
 public class Message extends JDialog {
   JLabel lblmessage;
@@ -21,6 +24,7 @@ public class Message extends JDialog {
     this.setResizable(false);
     setTitle(resourceBundle.getString("Message.title")); // "消息提醒");
     setAlwaysOnTop(true);
+    setDefaultCloseOperation(DISPOSE_ON_CLOSE);
     //  setLocationByPlatform(true);
     lblmessage = new JLabel("", JLabel.CENTER);
     getContentPane().setBackground(MessageTheme.background());
@@ -36,67 +40,75 @@ public class Message extends JDialog {
   }
 
   public void setMessage(String message) {
-    String regex = "[\u4e00-\u9fa5]";
-    lblmessage.setText(message);
-    setSize((int) (message.replaceAll(regex, "12").length() * (Config.frameFontSize / 1.6)), 80);
-    setLocationRelativeTo(Lizzie.frame != null ? Lizzie.frame : null);
-    setVisible(true);
-    Lizzie.setFrameSize(
-        this, (int) (message.replaceAll(regex, "12").length() * (Config.frameFontSize / 1.6)), 80);
-    this.setModal(true);
-    setVisible(false);
-    setVisible(true);
+    showMessage(message, Lizzie.frame != null ? Lizzie.frame : null, true);
   }
 
   public void setMessageNoModal(String message) {
-    String regex = "[\u4e00-\u9fa5]";
-    lblmessage.setText(message);
-    setSize((int) (message.replaceAll(regex, "12").length() * (Config.frameFontSize / 1.6)), 80);
-    setLocationRelativeTo(Lizzie.frame != null ? Lizzie.frame : null);
-    setVisible(true);
-    Lizzie.setFrameSize(
-        this, (int) (message.replaceAll(regex, "12").length() * (Config.frameFontSize / 1.6)), 80);
-    setVisible(false);
-    setVisible(true);
+    showMessage(message, Lizzie.frame != null ? Lizzie.frame : null, false);
   }
 
   public void setMessageNoModal(String message, int seconds) {
-    String regex = "[\u4e00-\u9fa5]";
-    lblmessage.setText(message);
-    setSize((int) (message.replaceAll(regex, "12").length() * (Config.frameFontSize / 1.6)), 80);
-    setLocationRelativeTo(Lizzie.frame != null ? Lizzie.frame : null);
-    setVisible(true);
-    Lizzie.setFrameSize(
-        this, (int) (message.replaceAll(regex, "12").length() * (Config.frameFontSize / 1.6)), 80);
-    setVisible(false);
-    setVisible(true);
-
-    Runnable runnable =
-        new Runnable() {
-          public void run() {
-            try {
-              Thread.sleep(seconds * 1000);
-              setVisible(false);
-            } catch (InterruptedException e) {
-              // TODO Auto-generated catch block
-              e.printStackTrace();
-            }
-          }
-        };
-    Thread closeTh = new Thread(runnable);
-    closeTh.start();
+    showMessage(message, Lizzie.frame != null ? Lizzie.frame : null, false);
+    Timer closeTimer =
+        new Timer(
+            Math.max(1, seconds) * 1000,
+            e -> {
+              closeAndDispose();
+            });
+    closeTimer.setRepeats(false);
+    closeTimer.start();
   }
 
   public void setMessage(String message, Window owner) {
-    // TODO Auto-generated method stub
+    showMessage(message, owner, true);
+  }
+
+  private void showMessage(String message, Window owner, boolean modal) {
+    Runnable show =
+        () -> {
+          int width = messageWidth(message);
+          setModal(modal);
+          lblmessage.setText(message);
+          setSize(width, 80);
+          Lizzie.setFrameSize(this, width, 80);
+          setLocationRelativeTo(owner);
+          setVisible(true);
+        };
+    runOnEdt(show);
+  }
+
+  private static int messageWidth(String message) {
     String regex = "[\u4e00-\u9fa5]";
-    lblmessage.setText(message);
-    setSize((int) (message.replaceAll(regex, "12").length() * (Config.frameFontSize / 1.6)), 80);
-    setLocationRelativeTo(owner);
-    setVisible(true);
-    Lizzie.setFrameSize(
-        this, (int) (message.replaceAll(regex, "12").length() * (Config.frameFontSize / 1.6)), 80);
-    setVisible(false);
-    setVisible(true);
+    String text = message == null ? "" : message;
+    return Math.max(
+        180, (int) (text.replaceAll(regex, "12").length() * (Config.frameFontSize / 1.6)));
+  }
+
+  private void closeAndDispose() {
+    Runnable close =
+        () -> {
+          Window owner = getOwner();
+          setVisible(false);
+          dispose();
+          Window repaintTarget = owner != null ? owner : Lizzie.frame;
+          if (repaintTarget != null) {
+            repaintTarget.invalidate();
+            repaintTarget.repaint();
+          }
+          Toolkit.getDefaultToolkit().sync();
+        };
+    runOnEdt(close);
+  }
+
+  private static void runOnEdt(Runnable runnable) {
+    if (SwingUtilities.isEventDispatchThread()) {
+      runnable.run();
+      return;
+    }
+    try {
+      SwingUtilities.invokeAndWait(runnable);
+    } catch (Exception ex) {
+      SwingUtilities.invokeLater(runnable);
+    }
   }
 }

--- a/src/main/java/featurecat/lizzie/gui/OnlineDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/OnlineDialog.java
@@ -1,6 +1,7 @@
 package featurecat.lizzie.gui;
 
 import featurecat.lizzie.Lizzie;
+import featurecat.lizzie.analysis.GameInfo;
 import featurecat.lizzie.rules.Board;
 import featurecat.lizzie.rules.BoardData;
 import featurecat.lizzie.rules.BoardHistoryList;
@@ -237,6 +238,16 @@ public class OnlineDialog extends JDialog {
 
     boolean matches(String otherSessionKey) {
       return !Utils.isBlank(otherSessionKey) && otherSessionKey.equals(sessionKey);
+    }
+  }
+
+  static final class LiveKomi {
+    final double value;
+    final boolean manuallyChanged;
+
+    private LiveKomi(double value, boolean manuallyChanged) {
+      this.value = value;
+      this.manuallyChanged = manuallyChanged;
     }
   }
 
@@ -799,6 +810,30 @@ public class OnlineDialog extends JDialog {
     return !stopped && urlSgf && currentType == expectedType && activeSessionId == requestSessionId;
   }
 
+  static LiveKomi resolveLiveKomi(GameInfo currentGameInfo, double remoteKomi) {
+    if (currentGameInfo != null && currentGameInfo.changedKomi) {
+      return new LiveKomi(currentGameInfo.getKomi(), true);
+    }
+    return new LiveKomi(remoteKomi, false);
+  }
+
+  private static void applyLiveKomi(GameInfo targetGameInfo, LiveKomi liveKomi) {
+    if (targetGameInfo == null || liveKomi == null) {
+      return;
+    }
+    targetGameInfo.setKomi(liveKomi.value);
+    if (liveKomi.manuallyChanged) {
+      targetGameInfo.changeKomi();
+    }
+  }
+
+  private static GameInfo currentLiveGameInfo() {
+    if (Lizzie.board == null || Lizzie.board.getHistory() == null) {
+      return null;
+    }
+    return Lizzie.board.getHistory().getGameInfo();
+  }
+
   private boolean shouldSyncYikeMainlineOnly() {
     return type == YikeUrlInfo.TYPE_OLD_LIVE_ROOM
         || type == YikeUrlInfo.TYPE_OLD_LIVE_BOARD
@@ -999,11 +1034,12 @@ public class OnlineDialog extends JDialog {
                   live.optString("whiteName"),
                   whitePlayer);
         }
+        LiveKomi liveKomi = resolveLiveKomi(currentLiveGameInfo(), komi);
         if (shouldReplaceYikeMainline()) {
           replaceYikeMainline(
               liveNode,
               live,
-              komi,
+              liveKomi,
               handicap,
               previousPosition,
               previousBoardWidth,
@@ -1044,7 +1080,7 @@ public class OnlineDialog extends JDialog {
           Lizzie.board.getHistory().getGameInfo().setPlayerBlack(blackPlayer);
           Lizzie.board.getHistory().getGameInfo().setPlayerWhite(whitePlayer);
           if (Lizzie.config.readKomi) {
-            Lizzie.board.getHistory().getGameInfo().setKomi(komi);
+            applyLiveKomi(Lizzie.board.getHistory().getGameInfo(), liveKomi);
           }
           firstTime = false;
         }
@@ -1089,7 +1125,7 @@ public class OnlineDialog extends JDialog {
   private void replaceYikeMainline(
       BoardHistoryList liveNode,
       JSONObject live,
-      double komi,
+      LiveKomi liveKomi,
       int handicap,
       BoardData previousPosition,
       int previousBoardWidth,
@@ -1123,7 +1159,7 @@ public class OnlineDialog extends JDialog {
     Lizzie.board.getHistory().getGameInfo().setPlayerWhite(whitePlayer);
     Lizzie.board.getHistory().getGameInfo().setHandicap(handicap);
     if (Lizzie.config.readKomi) {
-      Lizzie.board.getHistory().getGameInfo().setKomi(komi);
+      applyLiveKomi(Lizzie.board.getHistory().getGameInfo(), liveKomi);
     }
     Lizzie.frame.setPlayers(whitePlayer, blackPlayer);
     if (live != null
@@ -1931,7 +1967,9 @@ public class OnlineDialog extends JDialog {
               komi = ((double) a5 / 100);
             }
             if (Lizzie.config.readKomi) {
-              Lizzie.board.getHistory().getGameInfo().setKomi(komi);
+              applyLiveKomi(
+                  Lizzie.board.getHistory().getGameInfo(),
+                  resolveLiveKomi(currentLiveGameInfo(), komi));
             }
           } else {
             break;
@@ -3083,6 +3121,7 @@ public class OnlineDialog extends JDialog {
     int size = info.optInt("boardSize", 19);
     boardSize = size;
     onYikeBoardSizeResolved();
+    GameInfo preSyncGameInfo = currentLiveGameInfo();
     Lizzie.board.reopen(boardSize, boardSize);
     history = new BoardHistoryList(BoardData.empty(size, size)); // TODO boardSize
     blackPlayer = info.optString("blackName");
@@ -3100,7 +3139,8 @@ public class OnlineDialog extends JDialog {
       double komi = info.optDouble("komi", history.getGameInfo().getKomi());
       int handicap = info.optInt("handicap", history.getGameInfo().getHandicap());
       if (Lizzie.config.readKomi) {
-        Lizzie.board.getHistory().getGameInfo().setKomi(komi);
+        applyLiveKomi(
+            Lizzie.board.getHistory().getGameInfo(), resolveLiveKomi(preSyncGameInfo, komi));
       }
       Lizzie.board.getHistory().getGameInfo().setHandicap(handicap);
       int preservedAnalysis = preserveYikeMainlineAnalysis(Lizzie.board.getHistory(), history);

--- a/src/main/java/featurecat/lizzie/gui/SMessage.java
+++ b/src/main/java/featurecat/lizzie/gui/SMessage.java
@@ -15,6 +15,7 @@ public class SMessage extends JDialog {
   public SMessage() {
     this.setModal(true);
     this.setResizable(false);
+    setDefaultCloseOperation(DISPOSE_ON_CLOSE);
     // setType(Type.POPUP);
     setTitle(Lizzie.resourceBundle.getString("Message.title"));
     setAlwaysOnTop(true);

--- a/src/main/resources/l10n/DisplayStrings.properties
+++ b/src/main/resources/l10n/DisplayStrings.properties
@@ -1456,6 +1456,7 @@ LizzieConfig.title.showBestMovesByHold=Show Best Moves By Hold
 LizzieConfig.title.showBlunderBar=Show Blunder Bar
 LizzieConfig.title.showCaptured=Show Captured
 LizzieConfig.title.showComment=Show Comment
+LizzieConfig.title.hideCommentControlPane=Hide comment/problem control bar
 LizzieConfig.title.showCommentNodeColor=Show Comment Node Color
 LizzieConfig.title.showCoordinates=Show Coordinates
 LizzieConfig.title.showLcbWinrate=Display WinRate As

--- a/src/main/resources/l10n/DisplayStrings_en_US.properties
+++ b/src/main/resources/l10n/DisplayStrings_en_US.properties
@@ -1390,6 +1390,7 @@ LizzieConfig.title.showBestMovesByHold=Show Best Moves By Hold
 LizzieConfig.title.showBlunderBar=Show Blunder Bar
 LizzieConfig.title.showCaptured=Show Captured
 LizzieConfig.title.showComment=Show Comment
+LizzieConfig.title.hideCommentControlPane=Hide comment/problem control bar
 LizzieConfig.title.showCommentNodeColor=Show Comment Node Color
 LizzieConfig.title.showCoordinates=Show Coordinates
 LizzieConfig.title.showLcbWinrate=Display WinRate As

--- a/src/main/resources/l10n/DisplayStrings_ja_JP.properties
+++ b/src/main/resources/l10n/DisplayStrings_ja_JP.properties
@@ -1347,6 +1347,7 @@ LizzieConfig.title.showVariationGraph=\u30D0\u30EA\u30A8\u30FC\u30B7\u30E7\u30F3
 LizzieConfig.lblShowStatus=\u30B9\u30C6\u30FC\u30BF\u30B9\u30D1\u30CD\u30EB\u3092\u8868\u793A
 LizzieConfig.title.showWinrate=\u52DD\u7387\u30B0\u30E9\u30D5\u306E\u30D1\u30CD\u30EB\u3092\u8868\u793A
 LizzieConfig.title.showComment=\u30B3\u30E1\u30F3\u30C8\u30D1\u30CD\u30EB\u3092\u8868\u793A
+LizzieConfig.title.hideCommentControlPane=\u30B3\u30E1\u30F3\u30C8/\u554F\u984C\u624B\u30B3\u30F3\u30C8\u30ED\u30FC\u30EB\u30D0\u30FC\u3092\u975E\u8868\u793A
 LizzieConfig.lblShowMoveList=\u5019\u88DC\u624B\u30EA\u30B9\u30C8\u3092\u8868\u793A
 LizzieConfig.title.showMoveNumber=\u7740\u624B\u756A\u53F7\u3092\u8868\u793A
 LizzieConfig.title.showMoveNumberAll=\u5168

--- a/src/main/resources/l10n/DisplayStrings_ko.properties
+++ b/src/main/resources/l10n/DisplayStrings_ko.properties
@@ -1197,6 +1197,7 @@ LizzieConfig.title.showBestMovesByHold=Show Best Moves By Hold
 LizzieConfig.title.showBlunderBar=\uC2E4\uCC29 \uD45C\uC2DC
 LizzieConfig.title.showCaptured=\uC0AC\uC11D \uD45C\uC2DC
 LizzieConfig.title.showComment=\uC8FC\uC11D(\uC124\uBA85) \uD45C\uC2DC
+LizzieConfig.title.hideCommentControlPane=\uC8FC\uC11D/\uBB38\uC81C\uC218 \uCEE8\uD2B8\uB864\uBC14 \uC228\uAE30\uAE30
 LizzieConfig.title.showCommentNodeColor=\uC8FC\uC11D(\uC124\uBA85)\uB178\uB4DC \uC0C9 \uC9C0\uC815
 LizzieConfig.title.showCoordinates=\uC88C\uD45C \uD45C\uC2DC
 LizzieConfig.title.showLcbWinrate=Display WinRate As

--- a/src/main/resources/l10n/DisplayStrings_zh_CN.properties
+++ b/src/main/resources/l10n/DisplayStrings_zh_CN.properties
@@ -2333,6 +2333,7 @@ LizzieConfig.title.showWinrate=\u663E\u793A\u80DC\u7387\u9762\u677F
 LizzieConfig.title.showVariationGraph=\u663E\u793A\u5206\u652F\u9762\u677F
 LizzieConfig.title.showSubBoard=\u663E\u793A\u5C0F\u68CB\u76D8
 LizzieConfig.title.showComment=\u663E\u793A\u8BC4\u8BBA\u9762\u677F
+LizzieConfig.title.hideCommentControlPane=\u9690\u85CF\u8BC4\u8BBA/\u95EE\u9898\u624B\u63A7\u5236\u6761
 LizzieConfig.title.showCoordinates=\u663E\u793A\u5750\u6807
 LizzieConfig.title.showMoveNumber=\u663E\u793A\u624B\u6570
 LizzieConfig.title.showMoveNumberNo=\u4E0D\u663E\u793A

--- a/src/main/resources/l10n/DisplayStrings_zh_HK.properties
+++ b/src/main/resources/l10n/DisplayStrings_zh_HK.properties
@@ -2083,6 +2083,7 @@ LizzieConfig.title.showWinrate=\u663E\u793A\u80DC\u7387\u9762\u677F
 LizzieConfig.title.showVariationGraph=\u663E\u793A\u5206\u652F\u9762\u677F
 LizzieConfig.title.showSubBoard=\u663E\u793A\u5C0F\u68CB\u76D8
 LizzieConfig.title.showComment=\u663E\u793A\u8BC4\u8BBA\u9762\u677F
+LizzieConfig.title.hideCommentControlPane=\u9690\u85CF\u8BC4\u8BBA/\u95EE\u9898\u624B\u63A7\u5236\u6761
 LizzieConfig.title.showCoordinates=\u663E\u793A\u5750\u6807
 LizzieConfig.title.showMoveNumber=\u663E\u793A\u624B\u6570
 LizzieConfig.title.showMoveNumberNo=\u4E0D\u663E\u793A

--- a/src/main/resources/l10n/DisplayStrings_zh_TW.properties
+++ b/src/main/resources/l10n/DisplayStrings_zh_TW.properties
@@ -2083,6 +2083,7 @@ LizzieConfig.title.showWinrate=\u663E\u793A\u80DC\u7387\u9762\u677F
 LizzieConfig.title.showVariationGraph=\u663E\u793A\u5206\u652F\u9762\u677F
 LizzieConfig.title.showSubBoard=\u663E\u793A\u5C0F\u68CB\u76D8
 LizzieConfig.title.showComment=\u663E\u793A\u8BC4\u8BBA\u9762\u677F
+LizzieConfig.title.hideCommentControlPane=\u9690\u85CF\u8BC4\u8BBA/\u95EE\u9898\u624B\u63A7\u5236\u6761
 LizzieConfig.title.showCoordinates=\u663E\u793A\u5750\u6807
 LizzieConfig.title.showMoveNumber=\u663E\u793A\u624B\u6570
 LizzieConfig.title.showMoveNumberNo=\u4E0D\u663E\u793A

--- a/src/test/java/featurecat/lizzie/gui/MoveOnlyUiGateTest.java
+++ b/src/test/java/featurecat/lizzie/gui/MoveOnlyUiGateTest.java
@@ -20,10 +20,12 @@ import java.awt.image.BufferedImage;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.ResourceBundle;
+import java.util.Set;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.table.AbstractTableModel;
@@ -310,6 +312,45 @@ class MoveOnlyUiGateTest {
           "float board move-rank marks should still render for real moves.");
     } finally {
       env.close();
+    }
+  }
+
+  @Test
+  void floatBoardMoveRankMarkColorsUseContinuousSeverityShades() throws Exception {
+    Config previousConfig = Lizzie.config;
+    Config config = allocate(Config.class);
+    config.winLossThreshold1 = -1;
+    config.winLossThreshold2 = -3;
+    config.winLossThreshold3 = -6;
+    config.winLossThreshold4 = -12;
+    config.winLossThreshold5 = -24;
+    config.scoreLossThreshold1 = -0.5;
+    config.scoreLossThreshold2 = -1.5;
+    config.scoreLossThreshold3 = -3;
+    config.scoreLossThreshold4 = -6;
+    config.scoreLossThreshold5 = -12;
+    Lizzie.config = config;
+    try {
+      Set<Integer> colors = new HashSet<Integer>();
+      colors.add(
+          FloatBoardRenderer.moveRankMarkColor(FloatBoardRenderer.moveRankMarkSeverity(0, 0))
+              .getRGB());
+      colors.add(
+          FloatBoardRenderer.moveRankMarkColor(FloatBoardRenderer.moveRankMarkSeverity(-1.5, 0))
+              .getRGB());
+      colors.add(
+          FloatBoardRenderer.moveRankMarkColor(FloatBoardRenderer.moveRankMarkSeverity(-5, 0))
+              .getRGB());
+      colors.add(
+          FloatBoardRenderer.moveRankMarkColor(FloatBoardRenderer.moveRankMarkSeverity(-16, 0))
+              .getRGB());
+      colors.add(
+          FloatBoardRenderer.moveRankMarkColor(FloatBoardRenderer.moveRankMarkSeverity(-40, 0))
+              .getRGB());
+
+      assertTrue(colors.size() >= 5, "move rank marks should expose several severity shades.");
+    } finally {
+      Lizzie.config = previousConfig;
     }
   }
 

--- a/src/test/java/featurecat/lizzie/gui/OnlineDialogYikeSessionStateTest.java
+++ b/src/test/java/featurecat/lizzie/gui/OnlineDialogYikeSessionStateTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import featurecat.lizzie.analysis.GameInfo;
 import featurecat.lizzie.rules.Board;
 import featurecat.lizzie.rules.BoardData;
 import featurecat.lizzie.rules.BoardHistoryList;
@@ -80,6 +81,29 @@ class OnlineDialogYikeSessionStateTest {
     assertEquals(3, OnlineDialog.normalizeYikeRefreshSeconds(3));
     assertEquals(1, OnlineDialog.normalizeYikeRefreshSeconds(1));
     assertEquals(1, OnlineDialog.normalizeYikeRefreshSeconds(0));
+  }
+
+  @Test
+  void yikeLiveKomiKeepsManualOverrideOnRefresh() {
+    GameInfo current = new GameInfo();
+    current.setKomiNoMenu(7.0);
+    current.changeKomi();
+
+    OnlineDialog.LiveKomi liveKomi = OnlineDialog.resolveLiveKomi(current, 7.5);
+
+    assertEquals(7.0, liveKomi.value, 0.001);
+    assertTrue(liveKomi.manuallyChanged);
+  }
+
+  @Test
+  void yikeLiveKomiUsesRemoteValueBeforeManualOverride() {
+    GameInfo current = new GameInfo();
+    current.setKomiNoMenu(6.5);
+
+    OnlineDialog.LiveKomi liveKomi = OnlineDialog.resolveLiveKomi(current, 7.5);
+
+    assertEquals(7.5, liveKomi.value, 0.001);
+    assertFalse(liveKomi.manuallyChanged);
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Keep user-adjusted komi during Yike live refresh instead of resetting to the remote 7.5 value on every move.
- Add a smoother severity color scale for move-rank markers instead of the old coarse three-color feel.
- Improve macOS/Swing message disposal to reduce transparent ghost windows after prompts close.
- Add a setting to hide the comment/problem-move hover control bar, including modern settings UI and localized labels.
- Make modern settings toggle rows easier to click by allowing the whole row to toggle the switch.

## Testing
- User-perspective GUI smoke on local macOS from shaded jar with isolated `-Dlizzie.work.dir`.
- Verified settings path: Shift+X -> 对局与操作 -> 隐藏评论/问题手控制条 -> Return save writes `hide-blunder-table-control-pane: true`.
- `git diff --check`
- `mvn -B -Dfmt.skip=true -Dtest=featurecat.lizzie.gui.OnlineDialogYikeSessionStateTest,featurecat.lizzie.gui.MoveOnlyUiGateTest,featurecat.lizzie.gui.MessageThemeTest test`
- `mvn -B -Dfmt.skip=true test`
- `mvn -B -Dfmt.skip=true -DskipTests package`

## Notes
- Full local test run: 783 tests, 0 failures, 0 errors.
- The GTP send-failure stack traces in test output are expected simulated failure-path coverage.
