### PR TITLE
Preserve existing analysis during flash analysis

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/AnalysisEngine.java
+++ b/src/main/java/featurecat/lizzie/analysis/AnalysisEngine.java
@@ -284,14 +284,18 @@ public class AnalysisEngine {
               resourceBundle.getString("AnalysisEngine.flashAnalyze"),
               false,
               MoveData.getPlayouts(moves),
-              (ArrayList<Double>) (List) list);
-    } else
+              (ArrayList<Double>) (List) list,
+              Lizzie.config.analysisAlwaysOverride);
+    } else {
       node.getData()
           .tryToSetBestMoves(
               moves,
               resourceBundle.getString("AnalysisEngine.flashAnalyze"),
               false,
-              MoveData.getPlayouts(moves));
+              MoveData.getPlayouts(moves),
+              null,
+              Lizzie.config.analysisAlwaysOverride);
+    }
 
     node.getData().comment = SGFParser.formatComment(node);
     Lizzie.board.updateMovelist(node);
@@ -313,16 +317,19 @@ public class AnalysisEngine {
     if (Lizzie.config.analysisAlwaysOverride) {
       Lizzie.config.enableLizzieCache = false;
     }
-    Lizzie.board.setMovelistAll();
-    if (Lizzie.board.getHistory().getCurrentHistoryNode() == Lizzie.board.getHistory().getStart())
-      Lizzie.board.nextMove(true);
-    Lizzie.frame.refresh();
-    Lizzie.frame.requestProblemListRefresh();
-    if (Lizzie.config.analysisAutoQuit && !Lizzie.frame.isBatchAna) {
-      normalQuit();
+    try {
+      Lizzie.board.setMovelistAll();
+      if (Lizzie.board.getHistory().getCurrentHistoryNode() == Lizzie.board.getHistory().getStart())
+        Lizzie.board.nextMove(true);
+      Lizzie.frame.refresh();
+      Lizzie.frame.requestProblemListRefresh();
+      if (Lizzie.config.analysisAutoQuit && !Lizzie.frame.isBatchAna) {
+        normalQuit();
+      }
+    } finally {
+      if (Lizzie.config.analysisAlwaysOverride)
+        Lizzie.config.enableLizzieCache = oriEnableLizzieCache;
     }
-    if (Lizzie.config.analysisAlwaysOverride)
-      Lizzie.config.enableLizzieCache = oriEnableLizzieCache;
     if (shouldRePonder && !Lizzie.leelaz.isPondering()) Lizzie.leelaz.togglePonder();
     Lizzie.frame.renderVarTree(0, 0, false, false);
     runCompletionCallback();
@@ -348,7 +355,7 @@ public class AnalysisEngine {
     stack.push(node);
     while (!stack.isEmpty()) {
       BoardHistoryNode cur = stack.pop();
-      if (shouldAnalyzeBranchNode(cur)) {
+      if (shouldAnalyzeNode(cur)) {
         if (!sendRequest(cur)) break;
       }
       if (cur.numberOfChildren() >= 1) {
@@ -369,7 +376,7 @@ public class AnalysisEngine {
     BoardHistoryNode node = firstHistoryActionNode(Lizzie.board.getHistory().getStart());
     int moveNum = 1;
     while (node != null) {
-      if (shouldAnalyzeTurn(moveNum, startMove, endMove)) {
+      if (shouldAnalyzeTurn(moveNum, startMove, endMove) && shouldAnalyzeNode(node)) {
         if (!sendRequest(node)) break;
       }
       node = nextHistoryActionNode(node);
@@ -383,7 +390,7 @@ public class AnalysisEngine {
     prepareRequestState(showProgressDialog);
     BoardHistoryNode node = firstHistoryActionNode(Lizzie.board.getHistory().getStart());
     while (node != null) {
-      if (!node.getData().hasPrimaryAnalysisPayload()) {
+      if (shouldAnalyzeMissingNode(node)) {
         if (!sendRequest(node)) break;
       }
       node = nextHistoryActionNode(node);
@@ -522,7 +529,7 @@ public class AnalysisEngine {
   }
 
   private static boolean isRealHistoryAction(BoardData data) {
-    return data.isMoveNode() || (data.isPassNode() && !data.dummy);
+    return data != null && (data.isMoveNode() || (data.isPassNode() && !data.dummy));
   }
 
   private static boolean shouldAnalyzeTurn(int moveNum, int startMove, int endMove) {
@@ -660,8 +667,15 @@ public class AnalysisEngine {
     return moveList;
   }
 
-  private static boolean shouldAnalyzeBranchNode(BoardHistoryNode node) {
-    return isRealHistoryAction(node.getData());
+  private static boolean shouldAnalyzeNode(BoardHistoryNode node) {
+    BoardData data = node == null ? null : node.getData();
+    return isRealHistoryAction(data)
+        && (Lizzie.config.analysisAlwaysOverride || !data.hasPrimaryAnalysisPayload());
+  }
+
+  private static boolean shouldAnalyzeMissingNode(BoardHistoryNode node) {
+    BoardData data = node == null ? null : node.getData();
+    return isRealHistoryAction(data) && !data.hasPrimaryAnalysisPayload();
   }
 
   public void shutdown() {

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -16056,7 +16056,7 @@ public class LizzieFrame extends JFrame {
       node = node.next().get();
       if (!isRealHistoryActionNode(node.getData())) continue;
       mainTrunkMoves++;
-      if (node.getData().getPlayouts() > 0 || node.getData().isKataData) {
+      if (node.getData().hasPrimaryAnalysisPayload()) {
         analyzedMoves++;
       }
     }

--- a/src/main/java/featurecat/lizzie/rules/BoardData.java
+++ b/src/main/java/featurecat/lizzie/rules/BoardData.java
@@ -333,7 +333,18 @@ public class BoardData {
       boolean isFromLeelaz,
       int totalplayouts,
       ArrayList<Double> estimateArray) {
-    if (Lizzie.config.enableLizzieCache
+    tryToSetBestMoves(moves, engName, isFromLeelaz, totalplayouts, estimateArray, false);
+  }
+
+  public void tryToSetBestMoves(
+      List<MoveData> moves,
+      String engName,
+      boolean isFromLeelaz,
+      int totalplayouts,
+      ArrayList<Double> estimateArray,
+      boolean forceOverride) {
+    if (!forceOverride
+        && Lizzie.config.enableLizzieCache
         && !Lizzie.config.isAutoAna
         && !EngineManager.isEngineGame) {
       if (!(totalplayouts > playouts || isChanged || pda != Lizzie.leelaz.pda)) {

--- a/src/test/java/featurecat/lizzie/analysis/AnalysisEngineRequestTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/AnalysisEngineRequestTest.java
@@ -12,6 +12,7 @@ import featurecat.lizzie.gui.LizzieFrame;
 import featurecat.lizzie.rules.Board;
 import featurecat.lizzie.rules.BoardData;
 import featurecat.lizzie.rules.BoardHistoryList;
+import featurecat.lizzie.rules.BoardHistoryNode;
 import featurecat.lizzie.rules.Movelist;
 import featurecat.lizzie.rules.SGFParser;
 import featurecat.lizzie.rules.Stone;
@@ -135,6 +136,131 @@ class AnalysisEngineRequestTest {
           request.getJSONArray("moves").toList(),
           "Yike curve completion should request only the missing current mainline node.");
       assertEquals(List.of(2), request.getJSONArray("analyzeTurns").toList());
+    }
+  }
+
+  @Test
+  void startRequestMissingMainlineStillSkipsExistingAnalysisWhenOverrideIsEnabled()
+      throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      Lizzie.config.analysisAlwaysOverride = true;
+      BoardHistoryList history = new BoardHistoryList(BoardData.empty(BOARD_SIZE, BOARD_SIZE));
+      BoardData analyzed =
+          moveNode(stones(placement(0, 0, Stone.BLACK)), new int[] {0, 0}, Stone.BLACK, false, 1);
+      analyzed.setPlayouts(120);
+      analyzed.engineName = "cached-analysis";
+      history.add(analyzed);
+      history.add(
+          moveNode(
+              stones(placement(0, 0, Stone.BLACK), placement(1, 0, Stone.WHITE)),
+              new int[] {1, 0},
+              Stone.WHITE,
+              true,
+              2));
+      boardWithHistory(history);
+      TrackingAnalysisEngine engine = TrackingAnalysisEngine.create();
+
+      int requested = engine.startRequestMissingMainline(false);
+
+      assertEquals(
+          1,
+          requested,
+          "missing-mainline completion is a preservation path and should not reanalyze cached nodes.");
+      assertEquals(1, engine.requestCount());
+      assertEquals(List.of(2), engine.singleRequest().getJSONArray("analyzeTurns").toList());
+    }
+  }
+
+  @Test
+  void startRequestSkipsExistingAnalysisByDefault() throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      BoardHistoryList history = new BoardHistoryList(BoardData.empty(BOARD_SIZE, BOARD_SIZE));
+      BoardData analyzed =
+          moveNode(stones(placement(0, 0, Stone.BLACK)), new int[] {0, 0}, Stone.BLACK, false, 1);
+      analyzed.setPlayouts(120);
+      analyzed.engineName = "cached-analysis";
+      history.add(analyzed);
+      history.add(
+          moveNode(
+              stones(placement(0, 0, Stone.BLACK), placement(1, 0, Stone.WHITE)),
+              new int[] {1, 0},
+              Stone.WHITE,
+              true,
+              2));
+      boardWithHistory(history);
+      TrackingAnalysisEngine engine = TrackingAnalysisEngine.create();
+
+      engine.startRequest(-1, -1, false);
+
+      assertEquals(
+          1,
+          engine.requestCount(),
+          "flash analysis should preserve existing node analysis unless override is enabled.");
+      JSONObject request = engine.singleRequest();
+      assertEquals(
+          List.of(List.of("B", "A3"), List.of("W", "B3")),
+          request.getJSONArray("moves").toList(),
+          "continuing analysis should still send the full move context for the missing node.");
+      assertEquals(List.of(2), request.getJSONArray("analyzeTurns").toList());
+    }
+  }
+
+  @Test
+  void startRequestReanalyzesExistingMovesWhenAlwaysOverrideIsEnabled() throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      Lizzie.config.analysisAlwaysOverride = true;
+      BoardHistoryList history = new BoardHistoryList(BoardData.empty(BOARD_SIZE, BOARD_SIZE));
+      BoardData analyzed =
+          moveNode(stones(placement(0, 0, Stone.BLACK)), new int[] {0, 0}, Stone.BLACK, false, 1);
+      analyzed.setPlayouts(120);
+      history.add(analyzed);
+      history.add(
+          moveNode(
+              stones(placement(0, 0, Stone.BLACK), placement(1, 0, Stone.WHITE)),
+              new int[] {1, 0},
+              Stone.WHITE,
+              true,
+              2));
+      boardWithHistory(history);
+      TrackingAnalysisEngine engine = TrackingAnalysisEngine.create();
+
+      engine.startRequest(-1, -1, false);
+
+      assertEquals(
+          2,
+          engine.requestCount(),
+          "explicit override should still allow users to recalculate the whole selected range.");
+      assertEquals(List.of(1), engine.requestAt(0).getJSONArray("analyzeTurns").toList());
+      assertEquals(List.of(2), engine.requestAt(1).getJSONArray("analyzeTurns").toList());
+    }
+  }
+
+  @Test
+  void parseResultHonorsAlwaysOverrideEvenWhenNewVisitsAreLower() throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      Lizzie.config.analysisAlwaysOverride = true;
+      Lizzie.config.enableLizzieCache = true;
+      BoardHistoryList history = new BoardHistoryList(BoardData.empty(BOARD_SIZE, BOARD_SIZE));
+      BoardData analyzed =
+          moveNode(stones(placement(0, 0, Stone.BLACK)), new int[] {0, 0}, Stone.BLACK, false, 1);
+      analyzed.setPlayouts(120);
+      analyzed.winrate = 42.0;
+      analyzed.engineName = "cached-analysis";
+      history.add(analyzed);
+      BoardHistoryNode analyzedNode = history.getCurrentHistoryNode();
+      boardWithHistory(history);
+      TrackingAnalysisEngine engine = TrackingAnalysisEngine.create();
+      engine.trackPending(1, analyzedNode);
+      engine.trackPending(2, analyzedNode);
+
+      engine.parseResult(analysisResponse(1, 1, 0.77).toString());
+
+      assertEquals(
+          1,
+          analyzed.getPlayouts(),
+          "always override should bypass cache guards even when the new flash result has fewer visits.");
+      assertEquals(77.0, analyzed.winrate, 0.0001);
+      assertFalse("cached-analysis".equals(analyzed.engineName));
     }
   }
 
@@ -679,6 +805,24 @@ class AnalysisEngineRequestTest {
     return result;
   }
 
+  private static JSONObject analysisResponse(int id, int visits, double winrate) {
+    JSONObject moveInfo = new JSONObject();
+    moveInfo.put("order", 0);
+    moveInfo.put("move", "C3");
+    moveInfo.put("visits", visits);
+    moveInfo.put("winrate", winrate);
+    moveInfo.put("lcb", winrate);
+    moveInfo.put("prior", 0.25);
+    moveInfo.put("scoreLead", 1.5);
+    moveInfo.put("scoreStdev", 0.3);
+    moveInfo.put("pv", new JSONArray().put("C3"));
+
+    JSONObject response = new JSONObject();
+    response.put("id", String.valueOf(id));
+    response.put("moveInfos", new JSONArray().put(moveInfo));
+    return response;
+  }
+
   private static Placement placement(int x, int y, Stone color) {
     return new Placement(x, y, color);
   }
@@ -841,6 +985,7 @@ class AnalysisEngineRequestTest {
       setField(AnalysisEngine.class, engine, "silentProgress", false);
       setField(AnalysisEngine.class, engine, "shouldRePonder", false);
       setField(AnalysisEngine.class, engine, "isLoaded", true);
+      setField(AnalysisEngine.class, engine, "resourceBundle", Lizzie.resourceBundle);
       return engine;
     }
 
@@ -860,6 +1005,17 @@ class AnalysisEngineRequestTest {
 
     private int requestCount() {
       return sentCommands.size();
+    }
+
+    private JSONObject requestAt(int index) {
+      return new JSONObject(sentCommands.get(index));
+    }
+
+    @SuppressWarnings("unchecked")
+    private void trackPending(int id, BoardHistoryNode node) throws Exception {
+      Field field = AnalysisEngine.class.getDeclaredField("analyzeMap");
+      field.setAccessible(true);
+      ((java.util.Map<Integer, BoardHistoryNode>) field.get(this)).put(id, node);
     }
 
     private int pendingRequestCount() throws Exception {


### PR DESCRIPTION
## Summary

- Fix flash analysis so continuing analysis preserves existing analyzed moves by default.
- Keep the explicit "always override existing analysis" setting available for users who want to recalculate everything.
- Make auto quick analysis after loading use the full primary analysis payload check instead of only playout/Kata flags.
- Keep missing-mainline completion paths, such as live-curve completion, strictly additive so they only fill missing nodes.

## Root Cause

Flash analysis was selecting all requested mainline or branch nodes regardless of whether those nodes already had analysis data. The override setting only affected part of the result write path, so changing the setting did not reliably control whether existing analysis was preserved or overwritten.

## Validation

- `git diff --check`
- `mvn -B -Dfmt.skip=true -Dtest=AnalysisEngineRequestTest,LizzieFrameRegressionTest test`
- `mvn -B -Dfmt.skip=true test`
- `mvn -B -Dfmt.skip=true -DskipTests package`
