### PR TITLE
Fix Windows AppCDS portable packaging

### DIFF
--- a/scripts/package_windows_exe.sh
+++ b/scripts/package_windows_exe.sh
@@ -378,7 +378,8 @@ generate_app_cds_archive() {
     --app-dir "$app_dir" \
     --archive "$archive_path" \
     --manifest "$manifest_path" \
-    --optional
+    --optional \
+    >&2
 }
 
 derive_windows_app_version() {


### PR DESCRIPTION
## Summary

- Fixes the Windows release packaging failure in `create_portable_zip` after AppCDS generation.
- Keeps `generate-app-cds` helper output on stderr so `build_app_image` command substitution returns only the app image root path.
- Prevents the generated `lizzieyzy-next-cds.jsa` path from being appended into the portable marker path.

## Validation

- `bash -n scripts/package_windows_exe.sh scripts/package_release.sh scripts/package_macos_dmg.sh scripts/run_jfr_benchmark.sh`
- `python3 -m py_compile scripts/package_runtime_tools.py scripts/generate_release_notes.py`
- `git diff --check`

## Release impact

This fixes the failed Windows workflow for `next-2026-06-14.1`. After merge, the tag should be moved to the new main commit and the Windows release workflow rerun.
