### PR TITLE
修复野狐下载棋谱贴目未读取

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/FoxKifuDownload.java
+++ b/src/main/java/featurecat/lizzie/gui/FoxKifuDownload.java
@@ -496,7 +496,8 @@ public class FoxKifuDownload extends JFrame {
         String kifu = jsonObject.getString("chess");
         showProgressNotice(
             Lizzie.frame.kifuLoadText("KifuLoad.parsing", "正在解析棋谱…", "Parsing game record..."));
-        boolean loaded = Lizzie.frame.loadSgfString(kifu, 200, false, false, null);
+        boolean loaded =
+            Lizzie.frame.loadSgfString(kifu, 200, Lizzie.config.readKomi, false, null);
         if (loaded) {
           finishFoxKifuLoadAfterMainPaint();
         } else {

--- a/src/test/java/featurecat/lizzie/rules/BoardNodeKindHistoryPipelineTest.java
+++ b/src/test/java/featurecat/lizzie/rules/BoardNodeKindHistoryPipelineTest.java
@@ -352,6 +352,22 @@ class BoardNodeKindHistoryPipelineTest {
   }
 
   @Test
+  void liveLoadFoxHandicapGameReadsZeroKomi() throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    try {
+      Lizzie.config.readKomi = true;
+      String sgf = "(;SZ[3]KM[0]HA[2]AB[aa]AB[ca];W[ba];B[bb])";
+
+      assertTrue(SGFParser.loadFromString(sgf), "loadFromString should parse Fox handicap SGF.");
+
+      BoardHistoryList history = Lizzie.board.getHistory();
+      assertEquals(0.0, history.getGameInfo().getKomi(), 0.001);
+    } finally {
+      env.close();
+    }
+  }
+
+  @Test
   void liveLoadNormalHandicapRootSetupSyncsPrimaryEngineAtRoot() throws Exception {
     assertLiveLoadHandicapSetupSyncsPrimaryEngine(false);
   }


### PR DESCRIPTION
## 问题
野狐下载棋谱加载时，代码固定以 `readKomi=false` 调用 `loadSgfString`。因此即使野狐返回的 SGF 是 `KM[0]HA[2]`，软件也不会读取 `KM[0]`，而是保留当前/默认贴目，保存后会变成 `KM[7.5]`。

已确认问题棋谱源数据不是 7.5：野狐列表接口返回 `handicap=2, komi=0`，棋谱正文也是 `KM[0]HA[2]`。

## 修改
- 野狐下载棋谱加载时改为使用已有配置 `Lizzie.config.readKomi`。
- 当用户配置允许读取贴目时，野狐下载棋谱会正常读取 SGF 中的 `KM`。
- 补充回归测试，覆盖 `KM[0]HA[2]` 加载后贴目保持为 0。

## 验证
- `mvn -Dfmt.skip=true -Dtest=featurecat.lizzie.analysis.GetFoxRequestTest,featurecat.lizzie.rules.BoardNodeKindHistoryPipelineTest#liveLoadFoxHandicapGameReadsZeroKomi test`
- Windows `D:\katago\srccode` 切到该分支后执行 `mvn '-Dfmt.skip=true' '-DskipTests' package` 成功，产物 `target\\lizzie-yzy2.5.3.jar` 已测试通过。