### PR TITLE
Improve Windows portable core update packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,11 @@
 > 欢迎交流使用问题、反馈 bug、分享使用体验，或者讨论接下来最想加的功能。
 
 > [!IMPORTANT]
-> 如果你只想先下对版本，先记住这 10 句：
+> 如果你只想先下对版本，先记住这几句：
 > - Windows 大多数用户：到 [Releases](https://github.com/wimi321/lizzieyzy-next/releases) 下载 `*windows64.opencl.portable.zip`
 > - RTX 20/30/40 NVIDIA 显卡并且想更快：下载 `*windows64.nvidia.portable.zip`
 > - RTX 5070/5080/5090：优先下载 `*windows64.nvidia50.cuda.portable.zip`，需要 TensorRT 时再到软件内“一键设置”按需安装
+> - 已经有 Windows 免安装版：日常升级优先下载 `*windows64.core-update.zip`，关闭软件后解压到旧目录覆盖，只更新主程序
 > - TensorRT 不只给 RTX 50：RTX 20/30/40/50 NVIDIA 显卡都可以在软件内按需安装；GTX 10 系及更老显卡优先 CUDA/OpenCL
 > - `KataGo 一键设置` 会检测 NVIDIA GPU 和 Compute Capability，自动提示是否推荐 TensorRT；检测失败也可以手动继续
 > - TensorRT 一键安装成功后会自动清理下载包缓存；运行缓存尽量写入软件自己的 `user-data/runtime`，减少 C 盘额外占用
@@ -98,6 +99,7 @@
 | Windows，NVIDIA 显卡，想安装 | `*windows64.nvidia.installer.exe` |
 | Windows，RTX 5070/5080/5090，CUDA 版，免安装 | `*windows64.nvidia50.cuda.portable.zip` |
 | Windows，RTX 5070/5080/5090，CUDA 版，想安装 | `*windows64.nvidia50.cuda.installer.exe` |
+| 已经有 Windows 免安装版，日常升级 | `*windows64.core-update.zip`，解压到旧目录覆盖 |
 | Windows，RTX 20/30/40/50，想测试 TensorRT 加速 | 先下载对应 NVIDIA 包（RTX 50 用 `*windows64.nvidia50.cuda.portable.zip`），打开后在 `KataGo 一键设置` 里安装 |
 | Windows，高级用户，想离线测试 TensorRT 预装包 | `*windows64.nvidia.tensorrt.portable.7z.001` 起的全部分卷，先看同名 `README.txt` |
 | Windows，自己配引擎，免安装 | `*windows64.without.engine.portable.zip` |
@@ -108,9 +110,12 @@
 
 Windows `portable.zip` 是真正的免安装模式：配置、日志、保存棋谱、下载权重和软件内安装的 TensorRT 加速文件都会保存在解压出来的同一个文件夹里，主要位置是 `user-data/`。如果想彻底清理这个免安装版，删除整个解压文件夹即可；如果想保留设置，升级前把旧文件夹里的 `user-data/` 复制到新文件夹。
 
+已有 Windows 免安装版时，日常小版本升级不用重新下载完整大包。下载 `*windows64.core-update.zip`，关闭软件，把 zip 里的内容解压到旧的免安装目录覆盖即可。这个小包只替换 `app/lizzie-yzy2.5.3-shaded.jar`，不会重复下载或覆盖 `weights/`、`engines/`、`runtime/`、`jcef-bundle/`、`readboard/`、`user-data/`。如果某次 release 明确写了 KataGo、权重或运行环境升级，再按说明下载完整包或对应资源包。
+
 如果你懒得分辨：
 
 - Windows：先下 `*windows64.opencl.portable.zip`
+- 已经有 Windows 免安装版：先下 `*windows64.core-update.zip` 覆盖旧目录，除非更新说明要求下载完整包
 - Windows + RTX 20/30/40 NVIDIA 显卡：先下 `*windows64.nvidia.portable.zip`
 - Windows + RTX 5070/5080/5090：先下 `*windows64.nvidia50.cuda.portable.zip`
 - Windows + RTX 20/30/40/50 想试 TensorRT：普通用户先下对应 NVIDIA/CUDA 包，再在软件内“一键设置”按需安装；软件会检测 GPU 和 Compute Capability 后给出推荐，下载支持断点续传

--- a/docs/PACKAGES.md
+++ b/docs/PACKAGES.md
@@ -10,9 +10,10 @@
 
 这份文档讲的是当前维护版 `LizzieYzy Next` 的公开发布格式，不是旧 `lizzieyzy` 的历史发布布局。
 
-- 当前维护版公开主推 15 个用户向主资产
+- 当前维护版公开主推 15 个首次下载主资产，另有 1 个 Windows 免安装小更新包
 - Windows 默认优先推荐 `portable.zip`
 - 大多数普通用户先下 `windows64.opencl.portable.zip`
+- 已有 Windows 免安装版的老用户，日常升级优先下载 `windows64.core-update.zip` 覆盖旧目录
 - OpenCL 表现不好时改用 `windows64.with-katago.portable.zip`
 - RTX 20/30/40 系列 NVIDIA 显卡并且更在意速度时改用 `windows64.nvidia.portable.zip`
 - RTX 5070/5080/5090 优先试 `windows64.nvidia50.cuda.portable.zip`，TensorRT 加速改为软件内按需安装
@@ -39,6 +40,7 @@
 | Windows 64 位 NVIDIA 极速安装器 | `<date>-windows64.nvidia.installer.exe` | 有 NVIDIA 显卡，想保留安装流程 |
 | Windows 64 位 RTX 50 CUDA 免安装包 | `<date>-windows64.nvidia50.cuda.portable.zip` | RTX 5070/5080/5090 用户首选 |
 | Windows 64 位 RTX 50 CUDA 安装器 | `<date>-windows64.nvidia50.cuda.installer.exe` | RTX 5070/5080/5090 用户，想保留安装流程 |
+| Windows 免安装小更新包 | `<date>-windows64.core-update.zip` | 已经有旧版免安装目录，只想日常升级主程序的用户 |
 | Windows 64 位 TensorRT 高级可选分卷包 | `<date>-windows64.nvidia.tensorrt.portable.7z.001` 等全部分卷 | 熟悉 7-Zip、想离线测试 TensorRT 的 RTX 20/30/40/50 用户 |
 | Windows 64 位无引擎便携包 | `<date>-windows64.without.engine.portable.zip` | 想自己配置分析引擎 |
 | Windows 64 位无引擎安装器 | `<date>-windows64.without.engine.installer.exe` | 想保留安装流程，但自己配置分析引擎 |
@@ -51,10 +53,11 @@
 说明：
 
 - `<date>` 代表发布日期，例如 `2026-03-21`。
-- 当前维护版公开 release 主列表只保留这 15 个用户向主资产。
+- 当前维护版公开 release 主列表只保留 15 个首次下载主资产；`windows64.core-update.zip` 是已有免安装用户的日常小更新资产，不是首次下载包。
 - TensorRT 分卷包是高级可选资产，不计入普通用户主推荐路径；只下载 `.7z.001` 没用，必须下载全部 `.7z.00N`。
 - Windows 64 位现在优先推荐免安装包，安装器作为可选路径保留。
 - Windows 免安装包会在解压目录内启用便携模式，配置、日志、保存棋谱、下载权重和软件内安装的 TensorRT 文件都随这个文件夹保存，主要位于 `user-data/`。
+- 已有 Windows 免安装版时，关闭软件后把 `<date>-windows64.core-update.zip` 解压到旧目录覆盖即可；它只替换 `app/lizzie-yzy2.5.3-shaded.jar`，不会覆盖权重、引擎、运行环境、JCEF、readboard、TensorRT 或 `user-data/`。
 - 旧 tag 里如果还看到兼容 zip 或历史包，那属于历史发布格式。
 
 ## 每个包里内置了什么
@@ -69,6 +72,7 @@
 | `windows64.nvidia.installer.exe` | 是 | 是 | 安装后从开始菜单或桌面打开 |
 | `windows64.nvidia50.cuda.portable.zip` | 是 | 是 | 解压后运行 `LizzieYzy Next NVIDIA 50 CUDA.exe` |
 | `windows64.nvidia50.cuda.installer.exe` | 是 | 是 | 安装后从开始菜单或桌面打开 |
+| `windows64.core-update.zip` | 否 | 依赖旧免安装目录 | 解压到旧免安装目录覆盖，用于日常升级主程序 |
 | `windows64.without.engine.portable.zip` | 是 | 否 | 解压后运行 `LizzieYzy Next.exe` |
 | `windows64.without.engine.installer.exe` | 是 | 否 | 安装后从开始菜单或桌面打开 |
 | `mac-apple-silicon.with-katago.dmg` | App 自带 | 是 | 拖到 Applications |
@@ -166,7 +170,7 @@ OUT_DIR=dist/perf SCENARIO=startup DURATION_SECONDS=45 \
 - Windows 64 位主推荐资产是 `portable.zip`
 - Windows 64 位同时提供 `opencl`、`with-katago`、`nvidia`、`nvidia50.cuda` 四条内置引擎线的安装器和便携包
 - Windows 64 位无引擎包同时提供安装器和 `.portable.zip`
-- 当前公开 release 主列表固定为 15 个普通用户向主资产；TensorRT 分卷包如出现在 Release 中，定位为高级可选资产，不替代软件内断点续传安装
+- 当前公开 release 主列表固定为 15 个首次下载主资产；`windows64.core-update.zip` 是已有 Windows 免安装用户的小更新资产；TensorRT 分卷包如出现在 Release 中，定位为高级可选资产，不替代软件内断点续传安装
 - 旧的兼容 zip 只作为历史 tag 说明保留，不再放进主推荐区
 
 ## 相关文档

--- a/scripts/generate_release_notes.py
+++ b/scripts/generate_release_notes.py
@@ -35,6 +35,7 @@ TENSORRT_SPLIT_README_SUFFIX = 'windows64.nvidia.tensorrt.portable.README.txt'
 TENSORRT_SPLIT_PART_PATTERN = r'windows64\.nvidia\.tensorrt\.portable\.7z\.\d+$'
 TENSORRT_SPLIT_MANIFEST_SUFFIX = 'windows64.nvidia.tensorrt.portable.manifest.json'
 TENSORRT_SPLIT_SHA256_SUFFIX = 'windows64.nvidia.tensorrt.portable.sha256.txt'
+WINDOWS_CORE_UPDATE_SUFFIX = 'windows64.core-update.zip'
 TENSORRT_SPLIT_ASSET_KEYS = (
     'windows_tensorrt_split_readme',
     'windows_tensorrt_split_parts',
@@ -268,13 +269,15 @@ def validate_release_sections(sections: list[dict[str, object]]) -> None:
 
             if key == 'download':
                 rows = block.get('rows')
-                if not isinstance(rows, list) or len(rows) not in (
+                allowed_row_counts = (
                     expected_download_rows,
                     expected_download_rows + 1,
-                ):
+                    expected_download_rows + 2,
+                )
+                if not isinstance(rows, list) or len(rows) not in allowed_row_counts:
                     raise SystemExit(
                         f'{language} download table must contain {expected_download_rows} rows'
-                        f' or {expected_download_rows + 1} rows with optional TensorRT split guidance'
+                        f' plus optional core-update and TensorRT split guidance'
                     )
                 continue
 
@@ -283,11 +286,85 @@ def validate_release_sections(sections: list[dict[str, object]]) -> None:
                 raise SystemExit(f'{language} release notes section "{key}" needs bullet items')
 
 
+def formatted_asset_available(value: str | None) -> bool:
+    if not value:
+        return False
+    return '暂未包含在本次发布中' not in value and 'Not included in this release' not in value
+
+
+def add_windows_core_update_download_row(
+    sections: list[dict[str, object]],
+    assets_cn: dict[str, str],
+    assets: dict[str, str],
+) -> None:
+    labels_by_language = {
+        '中文': '已有 Windows 免安装版，日常升级小包',
+        '繁體中文': '已有 Windows 免安裝版，日常升級小包',
+        'English': 'Existing Windows portable install, small routine update',
+        '日本語': '既存の Windows portable 版向け小型更新',
+        '한국어': '기존 Windows portable 사용자를 위한 소형 업데이트',
+        'ภาษาไทย': 'อัปเดตเล็กสำหรับผู้ใช้ Windows portable เดิม',
+    }
+    before_note_by_language = {
+        '中文': '已经有 Windows 免安装版的老用户，日常升级优先下载 `windows64.core-update.zip`，关闭软件后解压到旧目录覆盖；引擎、权重、TensorRT、设置和棋谱都会保留。',
+        '繁體中文': '已經有 Windows 免安裝版的舊使用者，日常升級優先下載 `windows64.core-update.zip`，關閉軟體後解壓到舊目錄覆蓋；引擎、權重、TensorRT、設定和棋譜都會保留。',
+        'English': 'Existing Windows portable users should prefer `windows64.core-update.zip` for routine updates: close the app, extract it over the old folder, and keep engines, weights, TensorRT, settings, and game records in place.',
+        '日本語': '既存の Windows portable ユーザーは、通常更新では `windows64.core-update.zip` を優先してください。アプリを閉じて既存フォルダへ展開すれば、エンジン、重み、TensorRT、設定、棋譜は保持されます。',
+        '한국어': '기존 Windows portable 사용자는 일반 업데이트에서 `windows64.core-update.zip` 을 우선 사용하세요. 앱을 닫고 기존 폴더에 덮어 풀면 엔진, 가중치, TensorRT, 설정, 기보가 유지됩니다.',
+        'ภาษาไทย': 'ผู้ใช้ Windows portable เดิมควรใช้ `windows64.core-update.zip` สำหรับอัปเดตทั่วไป: ปิดแอปแล้วแตกไฟล์ทับโฟลเดอร์เดิม โดย engine, weight, TensorRT, settings และ game records จะยังอยู่',
+    }
+    update_note_by_language = {
+        '中文': 'Windows 免安装版新增更清晰的小更新路径：`core-update` 只替换主程序，不重复打包引擎、权重、JCEF、readboard、Java runtime 或用户数据。',
+        '繁體中文': 'Windows 免安裝版新增更清楚的小更新路徑：`core-update` 只替換主程式，不重複打包引擎、權重、JCEF、readboard、Java runtime 或使用者資料。',
+        'English': 'Windows portable builds now have a clearer small-update path: `core-update` replaces only the app core and does not rebundle engines, weights, JCEF, readboard, Java runtime, or user data.',
+        '日本語': 'Windows portable 版に分かりやすい小型更新パスを追加しました。`core-update` はアプリ本体だけを置き換え、エンジン、重み、JCEF、readboard、Java runtime、ユーザーデータを再同梱しません。',
+        '한국어': 'Windows portable 빌드에 더 명확한 소형 업데이트 경로를 추가했습니다. `core-update` 는 앱 핵심만 교체하고 엔진, 가중치, JCEF, readboard, Java runtime, 사용자 데이터를 다시 묶지 않습니다.',
+        'ภาษาไทย': 'Windows portable มีทางอัปเดตเล็กที่ชัดเจนขึ้น: `core-update` เปลี่ยนเฉพาะ app core และไม่แพ็ก engine, weight, JCEF, readboard, Java runtime หรือ user data ซ้ำ',
+    }
+    for section in sections:
+        language = str(section['language'])
+        localized_assets = assets_cn if language in ('中文', '繁體中文') else assets
+        core_asset = localized_assets.get('windows_core_update')
+        if not formatted_asset_available(core_asset):
+            continue
+        download = section['download']
+        assert isinstance(download, dict)
+        rows = download['rows']
+        assert isinstance(rows, list)
+        if not any('core-update' in str(row[1]) for row in rows if isinstance(row, tuple)):
+            insert_at = 1
+            for index, row in enumerate(rows):
+                if isinstance(row, tuple) and 'windows64.opencl.portable' in str(row[1]):
+                    insert_at = index + 1
+                    break
+            rows.insert(
+                insert_at,
+                (labels_by_language.get(language, labels_by_language['English']), core_asset),
+            )
+
+        before = section['before']
+        assert isinstance(before, dict)
+        before_items = before['items']
+        assert isinstance(before_items, list)
+        note = before_note_by_language.get(language, before_note_by_language['English'])
+        if note not in before_items:
+            before_items.append(note)
+
+        updates = section['updates']
+        assert isinstance(updates, dict)
+        update_items = updates['items']
+        assert isinstance(update_items, list)
+        update_note = update_note_by_language.get(language, update_note_by_language['English'])
+        if update_note not in update_items:
+            update_items.append(update_note)
+
+
 def add_nvidia50_download_rows(
     sections: list[dict[str, object]],
     assets_cn: dict[str, str],
     assets: dict[str, str],
 ) -> None:
+    add_windows_core_update_download_row(sections, assets_cn, assets)
     labels_by_language = {
         '中文': (
             'Windows 64 位，RTX 50 CUDA 版，5070/5080/5090 优先，免安装',
@@ -6634,6 +6711,11 @@ def main() -> int:
         key: pick_asset(asset_names, suffix, args.date_tag)
         for key, suffix, _cn, _en in ASSET_SPECS
     }
+    asset_map['windows_core_update'] = pick_asset(
+        asset_names,
+        WINDOWS_CORE_UPDATE_SUFFIX,
+        args.date_tag,
+    )
     asset_map['windows_tensorrt_split_readme'] = pick_asset(
         asset_names,
         TENSORRT_SPLIT_README_SUFFIX,

--- a/scripts/package_windows_exe.sh
+++ b/scripts/package_windows_exe.sh
@@ -780,6 +780,11 @@ Generated on: $DATE_TAG
 Release display version: $APP_DISPLAY_VERSION
 
 How to pick the right file:
+- ${DATE_TAG}-${ARCH_TAG}.core-update.zip
+  Lightweight update for existing Windows portable users. Use it only after you already have a full portable folder.
+  Close the app, extract this zip into the folder that contains LizzieYzy Next*.exe and app/, and allow overwriting app/${MAIN_JAR}.
+  It updates only the application core; engines, weights, Java runtime, JCEF, readboard, TensorRT, settings, saves, and user-data stay in place.
+  New users should still download one of the full portable packages below first.
 EOF
 
   if [[ "$has_with_katago" == "true" ]]; then
@@ -1098,8 +1103,9 @@ create_core_update_asset() {
   local native_core_zip
 
   rm -rf "$core_dir" "$core_zip"
-  mkdir -p "$core_dir"
+  mkdir -p "$core_dir/app"
   cp "$JAR_PATH" "$core_dir/lizzieyzy-next-core.jar"
+  cp "$JAR_PATH" "$core_dir/app/$MAIN_JAR"
   cat >"$core_dir/README.txt" <<EOF
 LizzieYzy Next lightweight core update
 =====================================
@@ -1107,9 +1113,81 @@ LizzieYzy Next lightweight core update
 Release: $APP_DISPLAY_VERSION
 Date: $DATE_TAG
 
-This package updates the LizzieYzy Next application core only.
-KataGo engines, weights, JCEF, readboard, Java runtime, settings, saves, and user-data are preserved unless a future update manifest explicitly lists a changed resource component.
+用途：
+- 已经在使用 Windows 免安装版的老用户，日常升级优先下载这个小更新包。
+- 关闭 LizzieYzy Next 后，把这个 zip 解压到旧的免安装目录里覆盖。
+- 目标目录应该是包含 "LizzieYzy Next*.exe" 和 "app" 文件夹的目录。
+- 解压时允许覆盖 app/$MAIN_JAR。
+- 根目录里的 lizzieyzy-next-core.jar 是软件内自动更新器使用的副本，手动覆盖时可以忽略。
+
+这个包只更新 LizzieYzy Next 主程序核心。
+KataGo 引擎、权重、JCEF、readboard、Java runtime、设置、棋谱、TensorRT 和 user-data 都会保留。
+只有未来更新 manifest 明确列出资源组件时，才需要下载对应的大资源更新。
+
+Manual update:
+- Existing Windows portable users can use this small package for regular updates.
+- Close LizzieYzy Next, then extract this zip into the existing portable app folder.
+- The target folder should contain "LizzieYzy Next*.exe" and an "app" folder.
+- Allow overwriting app/$MAIN_JAR.
+- The root lizzieyzy-next-core.jar is for the in-app updater and can be ignored during manual extraction.
+
+This package updates the application core only.
+KataGo engines, weights, JCEF, readboard, Java runtime, settings, saves, TensorRT, and user-data are preserved unless a future update manifest explicitly lists a changed resource component.
 EOF
+
+  resolve_python_bin
+  "$PYTHON_BIN" - \
+    "$core_dir/lizzieyzy-next-core-update-manifest.json" \
+    "$APP_DISPLAY_VERSION" \
+    "$DATE_TAG" \
+    "$MAIN_JAR" \
+    "$JAR_PATH" <<'PY'
+import hashlib
+import json
+import pathlib
+import sys
+
+output, release_tag, date_tag, main_jar, jar_path = sys.argv[1:]
+jar = pathlib.Path(jar_path)
+digest = hashlib.sha256()
+with jar.open("rb") as handle:
+    for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+        digest.update(chunk)
+
+payload = {
+    "schemaVersion": 1,
+    "kind": "windows-core-update",
+    "releaseTag": release_tag,
+    "dateTag": date_tag,
+    "manualOverlayTarget": "folder containing LizzieYzy Next*.exe and app/",
+    "preserves": [
+        "user-data/",
+        "app/weights/",
+        "app/engines/",
+        "app/jcef-bundle/",
+        "app/readboard/",
+        "runtime/",
+    ],
+    "files": [
+        {
+            "path": "lizzieyzy-next-core.jar",
+            "purpose": "in-app-updater-source",
+            "sizeBytes": jar.stat().st_size,
+            "sha256": digest.hexdigest(),
+        },
+        {
+            "path": f"app/{main_jar}",
+            "purpose": "manual-overlay-target",
+            "sizeBytes": jar.stat().st_size,
+            "sha256": digest.hexdigest(),
+        },
+    ],
+}
+pathlib.Path(output).write_text(
+    json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+    encoding="utf-8",
+)
+PY
 
   native_core_dir="$(to_native_path "$core_dir")"
   native_core_zip="$(to_native_path "$core_zip")"

--- a/scripts/validate_release_assets.sh
+++ b/scripts/validate_release_assets.sh
@@ -140,6 +140,7 @@ import json
 import pathlib
 import re
 import sys
+import zipfile
 
 release_dir = pathlib.Path(sys.argv[1])
 date_tag = sys.argv[2]
@@ -160,6 +161,37 @@ assert core_path.is_file()
 assert core["sizeBytes"] == core_path.stat().st_size
 assert re.fullmatch(r"[0-9a-fA-F]{64}", core["sha256"])
 assert core["sha256"].lower() == hashlib.sha256(core_path.read_bytes()).hexdigest()
+with zipfile.ZipFile(core_path) as archive:
+    entries = {
+        name.replace("\\", "/")
+        for name in archive.namelist()
+        if name and not name.endswith("/")
+    }
+assert "lizzieyzy-next-core.jar" in entries
+assert "app/lizzie-yzy2.5.3-shaded.jar" in entries
+assert "README.txt" in entries
+assert "lizzieyzy-next-core-update-manifest.json" in entries
+for entry in entries:
+    normalized = entry.strip("/")
+    first = normalized.split("/", 1)[0]
+    assert first not in {
+        "weights",
+        "engines",
+        "runtime",
+        "jcef-bundle",
+        "readboard",
+        "user-data",
+    }, f"core update must not bundle large/resource path: {entry}"
+    if normalized.startswith("app/"):
+        second = normalized.split("/", 2)[1] if "/" in normalized[4:] else ""
+        assert second not in {
+            "weights",
+            "engines",
+            "runtime",
+            "jcef-bundle",
+            "readboard",
+            "user-data",
+        }, f"core update must not bundle app resource path: {entry}"
 PY
     ;;
   mac-arm64|mac-amd64)

--- a/src/main/java/featurecat/lizzie/update/WindowsUpdateDialog.java
+++ b/src/main/java/featurecat/lizzie/update/WindowsUpdateDialog.java
@@ -100,22 +100,26 @@ public final class WindowsUpdateDialog extends JDialog {
   private String updateSummary() {
     StringBuilder text = new StringBuilder();
     text.append("这次会先下载并校验更新文件，然后关闭当前程序，由独立更新器替换文件并重新打开。\n\n");
-    text.append("核心更新: ").append(formatBytes(plan.coreSizeBytes())).append('\n');
-    text.append("大资源更新: ").append(formatBytes(plan.resourceSizeBytes())).append('\n');
+    text.append("本次主程序小更新: ").append(formatBytes(plan.coreSizeBytes())).append('\n');
+    if (plan.resourceSizeBytes() > 0L) {
+      text.append("本次需要更新的大资源: ").append(formatBytes(plan.resourceSizeBytes())).append('\n');
+    } else {
+      text.append("大资源本次无需下载: KataGo、权重、运行环境、同步工具和浏览器组件都会保留。\n");
+    }
     text.append("总下载: ").append(formatBytes(plan.selectedSizeBytes())).append("\n\n");
     text.append("将更新的组件:\n");
     for (WindowsUpdatePlan.Item item : plan.selectedItems()) {
       text.append("- ").append(displayName(item.component)).append("  ");
       text.append(formatBytes(item.component.sizeBytes)).append('\n');
     }
-    text.append("\n未变化的大资源不会重复下载。用户数据、棋谱、设置和下载的模型会保留。");
+    text.append("\n未变化的大资源不会重复下载。用户数据、棋谱、设置、下载权重和 TensorRT 会保留。");
     return text.toString();
   }
 
   private String displayName(UpdateManifest.Component component) {
     switch (component.id) {
       case "core":
-        return "主程序核心";
+        return "主程序小更新";
       case "katago-cpu":
         return "KataGo CPU 引擎";
       case "katago-opencl":

--- a/src/test/java/featurecat/lizzie/update/WindowsUpdateApplierTest.java
+++ b/src/test/java/featurecat/lizzie/update/WindowsUpdateApplierTest.java
@@ -22,7 +22,10 @@ class WindowsUpdateApplierTest {
   void appliesCoreUpdateAndPreservesUserData() throws Exception {
     Fixture fixture = fixture();
     Path coreZip = tempDir.resolve("core.zip");
-    writeZip(coreZip, entry("lizzieyzy-next-core.jar", "new-core"));
+    writeZip(
+        coreZip,
+        entry("lizzieyzy-next-core.jar", "new-core"),
+        entry("app/lizzie-yzy2.5.3-shaded.jar", "manual-overlay-core"));
     Path request =
         request(
             fixture,


### PR DESCRIPTION
## Summary

- Makes `windows64.core-update.zip` a clear small update package for existing Windows portable users.
- Keeps the in-app updater path compatible by preserving the root `lizzieyzy-next-core.jar`.
- Adds a manual overlay path at `app/lizzie-yzy2.5.3-shaded.jar` so users can close the app, extract over an old portable folder, and update only the app core.
- Documents that engines, weights, Java runtime, JCEF, readboard, TensorRT, settings, saves, and `user-data` are preserved.
- Updates release-note generation so future multilingual release notes consistently include the small-update package guidance.

## Validation

- `python3 -m py_compile scripts/generate_release_notes.py`
- `bash -n scripts/package_windows_exe.sh && bash -n scripts/validate_release_assets.sh`
- `python3 scripts/check_markdown_links.py`
- `git diff --check`
- `mvn -B -Dfmt.skip=true -Dtest=WindowsUpdateApplierTest,WindowsUpdatePlanTest,UpdateManifestTest test`
- `mvn -B -Dfmt.skip=true test` (871 tests, 0 failures)
- `mvn -B -Dfmt.skip=true -DskipTests package`
- Simulated Windows release asset validation with `scripts/validate_release_assets.sh windows`, including `core-update.zip` content audit

## Notes

The full Windows packaging script still requires a Windows environment because it uses `powershell.exe` for portable ZIP creation. This PR adds shell syntax checks plus a simulated Windows release asset validation on macOS to cover the new `core-update.zip` structure.
