### PR TITLE
Reuse existing variation moves from board clicks

### DIFF
--- a/src/main/java/featurecat/lizzie/rules/Board.java
+++ b/src/main/java/featurecat/lizzie/rules/Board.java
@@ -2124,10 +2124,18 @@ public class Board {
           && !isEngineFollowTrialActive()) {
         Lizzie.leelaz.playMove(color, convertCoordinatesToName(x, y), true, color.isWhite());
       }
-      history.addOrGoto(newState, newBranch);
+      boolean usedExistingVariation =
+          !newBranch && !forSync && history.nextByMoveIdentity(newState).isPresent();
+      if (!usedExistingVariation) {
+        history.addOrGoto(newState, newBranch);
+      } else {
+        clearAfterMove();
+      }
       if (shouldLogLocalMovePlace) {
         logLocalMovePlace(
-            "place history addOrGoto done x="
+            (usedExistingVariation
+                    ? "place history existing-variation done x="
+                    : "place history addOrGoto done x=")
                 + x
                 + " y="
                 + y

--- a/src/main/java/featurecat/lizzie/rules/BoardHistoryList.java
+++ b/src/main/java/featurecat/lizzie/rules/BoardHistoryList.java
@@ -107,6 +107,17 @@ public class BoardHistoryList {
     head = head.addOrGoto(data, newBranch, changeMove, tsumego);
   }
 
+  Optional<BoardData> nextByMoveIdentity(BoardData data) {
+    Optional<BoardHistoryNode> n = head.findDirectChildByMoveIdentity(data);
+    if (n.isPresent()) {
+      if (head.hasRemovedStone()) head.clearAndSyncBoard(true);
+      if (Lizzie.leelaz != null) Lizzie.leelaz.clearBestMoves();
+      head = n.get();
+      head.placeExtraStones();
+    }
+    return n.map(BoardHistoryNode::getData);
+  }
+
   /**
    * moves the pointer to the left, returns the data stored there
    *

--- a/src/main/java/featurecat/lizzie/rules/BoardHistoryNode.java
+++ b/src/main/java/featurecat/lizzie/rules/BoardHistoryNode.java
@@ -243,6 +243,18 @@ public class BoardHistoryNode {
     return node;
   }
 
+  Optional<BoardHistoryNode> findDirectChildByMoveIdentity(BoardData candidate) {
+    if (candidate == null || !candidate.isHistoryActionNode()) {
+      return Optional.empty();
+    }
+    for (BoardHistoryNode variation : variations) {
+      if (matchesMoveIdentity(variation.getData(), candidate)) {
+        return Optional.of(variation);
+      }
+    }
+    return Optional.empty();
+  }
+
   /**
    * @return data stored on this node
    */
@@ -850,6 +862,19 @@ public class BoardHistoryNode {
   private static boolean matchesVariationIdentity(
       BoardHistoryNode existingChild, BoardData candidate) {
     return matchesVariationIdentity(existingChild, candidate, false, null);
+  }
+
+  private static boolean matchesMoveIdentity(BoardData existing, BoardData candidate) {
+    return existing.isHistoryActionNode()
+        && candidate.isHistoryActionNode()
+        && existing.getNodeKind() == candidate.getNodeKind()
+        && existing.dummy == candidate.dummy
+        && sameLastMove(existing.lastMove, candidate.lastMove)
+        && existing.blackToPlay == candidate.blackToPlay
+        && existing.lastMoveColor == candidate.lastMoveColor
+        && existing.blackCaptures == candidate.blackCaptures
+        && existing.whiteCaptures == candidate.whiteCaptures
+        && Arrays.equals(existing.stones, candidate.stones);
   }
 
   private static boolean matchesVariationIdentity(

--- a/src/test/java/featurecat/lizzie/rules/BoardHistoryMoveIdentityTest.java
+++ b/src/test/java/featurecat/lizzie/rules/BoardHistoryMoveIdentityTest.java
@@ -1,0 +1,153 @@
+package featurecat.lizzie.rules;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class BoardHistoryMoveIdentityTest {
+  private static final int BOARD_SIZE = 3;
+  private static final int BOARD_AREA = BOARD_SIZE * BOARD_SIZE;
+
+  @Test
+  void nextByMoveIdentityReusesExistingVariationWithDifferentComment() {
+    try (BoardSizeScope ignored = BoardSizeScope.open()) {
+      BoardHistoryList history = new BoardHistoryList(BoardData.empty(BOARD_SIZE, BOARD_SIZE));
+      BoardHistoryNode root = history.getCurrentHistoryNode();
+      root.add(new BoardHistoryNode(moveData(1, 0, Stone.BLACK, false, 0, 0)));
+
+      BoardData existingData = moveData(0, 0, Stone.BLACK, false, 0, 0);
+      existingData.comment = "existing SGF variation comment";
+      BoardHistoryNode existingVariation = new BoardHistoryNode(existingData);
+      existingVariation.reparentAsLastVariationOf(root);
+
+      BoardData clickedMove = moveData(0, 0, Stone.BLACK, false, 0, 0);
+
+      assertTrue(history.nextByMoveIdentity(clickedMove).isPresent());
+      assertSame(existingVariation, history.getCurrentHistoryNode());
+      assertEquals(2, root.numberOfChildren(), "clicking an existing variation must not duplicate it.");
+      assertEquals(
+          "existing SGF variation comment",
+          history.getData().comment,
+          "entering the existing branch should preserve its original node data.");
+    }
+  }
+
+  @Test
+  void nextByMoveIdentityDoesNotMatchDifferentMoveIdentity() {
+    try (BoardSizeScope ignored = BoardSizeScope.open()) {
+      BoardHistoryList history = new BoardHistoryList(BoardData.empty(BOARD_SIZE, BOARD_SIZE));
+      BoardHistoryNode root = history.getCurrentHistoryNode();
+      new BoardHistoryNode(moveData(0, 0, Stone.BLACK, false, 1, 0))
+          .reparentAsLastVariationOf(root);
+
+      assertFalse(
+          history.nextByMoveIdentity(moveData(0, 0, Stone.BLACK, false, 0, 0)).isPresent(),
+          "same coordinate should not match when capture totals differ.");
+      assertFalse(
+          history.nextByMoveIdentity(moveData(0, 0, Stone.WHITE, true, 1, 0)).isPresent(),
+          "same coordinate should not match when the played color differs.");
+      assertSame(root, history.getCurrentHistoryNode());
+      assertEquals(1, root.numberOfChildren());
+    }
+  }
+
+  @Test
+  void directChildMoveIdentitySupportsPassNodes() {
+    try (BoardSizeScope ignored = BoardSizeScope.open()) {
+      BoardHistoryList history = new BoardHistoryList(BoardData.empty(BOARD_SIZE, BOARD_SIZE));
+      BoardHistoryNode root = history.getCurrentHistoryNode();
+      BoardData existingPass = passData(Stone.BLACK, false, 0, 0);
+      existingPass.comment = "existing pass variation";
+      BoardHistoryNode passVariation = new BoardHistoryNode(existingPass);
+      passVariation.reparentAsLastVariationOf(root);
+
+      assertTrue(history.nextByMoveIdentity(passData(Stone.BLACK, false, 0, 0)).isPresent());
+      assertSame(passVariation, history.getCurrentHistoryNode());
+      assertEquals("existing pass variation", history.getData().comment);
+    }
+  }
+
+  private static BoardData moveData(
+      int x, int y, Stone color, boolean blackToPlay, int blackCaptures, int whiteCaptures) {
+    Stone[] stones = emptyStones();
+    stones[Board.getIndex(x, y)] = color;
+    return BoardData.move(
+        stones,
+        new int[] {x, y},
+        color,
+        blackToPlay,
+        zobrist(stones),
+        1,
+        new int[BOARD_AREA],
+        blackCaptures,
+        whiteCaptures,
+        50,
+        0);
+  }
+
+  private static BoardData passData(
+      Stone color, boolean blackToPlay, int blackCaptures, int whiteCaptures) {
+    Stone[] stones = emptyStones();
+    return BoardData.pass(
+        stones,
+        color,
+        blackToPlay,
+        zobrist(stones),
+        1,
+        new int[BOARD_AREA],
+        blackCaptures,
+        whiteCaptures,
+        50,
+        0);
+  }
+
+  private static Stone[] emptyStones() {
+    Stone[] stones = new Stone[BOARD_AREA];
+    for (int index = 0; index < BOARD_AREA; index++) {
+      stones[index] = Stone.EMPTY;
+    }
+    return stones;
+  }
+
+  private static Zobrist zobrist(Stone[] stones) {
+    Zobrist zobrist = new Zobrist();
+    for (int x = 0; x < BOARD_SIZE; x++) {
+      for (int y = 0; y < BOARD_SIZE; y++) {
+        Stone stone = stones[Board.getIndex(x, y)];
+        if (!stone.isEmpty()) {
+          zobrist.toggleStone(x, y, stone);
+        }
+      }
+    }
+    return zobrist;
+  }
+
+  private static final class BoardSizeScope implements AutoCloseable {
+    private final int previousBoardWidth;
+    private final int previousBoardHeight;
+
+    private BoardSizeScope(int previousBoardWidth, int previousBoardHeight) {
+      this.previousBoardWidth = previousBoardWidth;
+      this.previousBoardHeight = previousBoardHeight;
+    }
+
+    private static BoardSizeScope open() {
+      int previousBoardWidth = Board.boardWidth;
+      int previousBoardHeight = Board.boardHeight;
+      Board.boardWidth = BOARD_SIZE;
+      Board.boardHeight = BOARD_SIZE;
+      Zobrist.init();
+      return new BoardSizeScope(previousBoardWidth, previousBoardHeight);
+    }
+
+    @Override
+    public void close() {
+      Board.boardWidth = previousBoardWidth;
+      Board.boardHeight = previousBoardHeight;
+      Zobrist.init();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Fixes board clicks on an existing variation move so they enter the existing branch instead of creating a duplicate sibling branch.
- Adds a move-identity match for direct child variations that ignores comments and analysis payloads while preserving strict SGF/sync matching rules.
- Covers move, pass, comment-preserving, and mismatch cases with a focused unit test.

## Validation

- `git diff --check`
- `mvn -B -Dfmt.skip=true -Dtest=BoardHistoryMoveIdentityTest test`
- `mvn -B -Dfmt.skip=true -Dtest=BoardHistoryMoveIdentityTest,BoardHistoryListSyncSnapshotTest,BoardMovelistExportTest test`
- `mvn -B -Dfmt.skip=true test`
- `mvn -B -Dfmt.skip=true -DskipTests package`

## Notes

This PR intentionally does not relax the existing strict identity comparison used for SGF import or sync rebuilds, so metadata-only sibling variations remain distinct.
