### PR TITLE
[codex] Speed up kifu winrate analysis startup

### DIFF
--- a/src/main/java/featurecat/lizzie/Lizzie.java
+++ b/src/main/java/featurecat/lizzie/Lizzie.java
@@ -531,6 +531,8 @@ public class Lizzie {
                 // TODO Auto-generated catch block
                 e.printStackTrace();
               }
+            } else {
+              frame.scheduleQuickAnalysisEngineWarmupAfterStartup();
             }
             KataGoRuntimeHelper.startAppleSiliconAutoOptimizationAsync();
             KataGoRuntimeHelper.startFirstRunBenchmarkAsync();

--- a/src/main/java/featurecat/lizzie/analysis/AnalysisEngine.java
+++ b/src/main/java/featurecat/lizzie/analysis/AnalysisEngine.java
@@ -69,6 +69,7 @@ public class AnalysisEngine {
   private boolean silentProgress = false;
   private boolean requestDispatchFailed = false;
   private Runnable completionCallback;
+  private boolean keepAliveAfterCurrentRequest = false;
 
   public AnalysisEngine(boolean isPreLoad) throws IOException {
     int maxVisits =
@@ -308,11 +309,24 @@ public class AnalysisEngine {
     Lizzie.frame.requestProblemListRefresh();
     if (waitFrame != null) {
       waitFrame.setProgress(resultCount, analyzeMap.size());
-    } else if (silentProgress && (resultCount == 1 || resultCount % 8 == 0)) {
+    } else if (silentProgress && shouldRefreshSilentProgress(resultCount, analyzeMap.size())) {
       Lizzie.board.setMovelistAll();
       Lizzie.frame.refresh();
     }
     if (resultCount == analyzeMap.size()) setResult();
+  }
+
+  private static boolean shouldRefreshSilentProgress(int resultCount, int totalCount) {
+    if (resultCount <= 0) {
+      return false;
+    }
+    if (resultCount <= 12) {
+      return true;
+    }
+    if (resultCount <= 64) {
+      return resultCount % 4 == 0;
+    }
+    return resultCount % 8 == 0 || resultCount == totalCount;
   }
 
   private boolean shouldKeepForegroundAnalysis(BoardHistoryNode node) {
@@ -337,7 +351,9 @@ public class AnalysisEngine {
         Lizzie.board.nextMove(true);
       Lizzie.frame.refresh();
       Lizzie.frame.requestProblemListRefresh();
-      if (Lizzie.config.analysisAutoQuit && !Lizzie.frame.isBatchAna) {
+      boolean shouldKeepAlive = isPreLoad || keepAliveAfterCurrentRequest;
+      keepAliveAfterCurrentRequest = false;
+      if (Lizzie.config.analysisAutoQuit && !Lizzie.frame.isBatchAna && !shouldKeepAlive) {
         normalQuit();
       }
     } finally {
@@ -352,8 +368,9 @@ public class AnalysisEngine {
   public void normalQuit() {
     // TODO Auto-generated method stub
     isNormalEnd = true;
-    if (this.useJavaSSH) this.javaSSH.close();
-    else this.process.destroyForcibly();
+    if (this.useJavaSSH) {
+      if (this.javaSSH != null) this.javaSSH.close();
+    } else if (this.process != null) this.process.destroyForcibly();
     Lizzie.frame.requestProblemListRefresh();
   }
 
@@ -704,8 +721,9 @@ public class AnalysisEngine {
 
   public void shutdown() {
     // isShuttingdown = true;
-    if (useJavaSSH) javaSSH.close();
-    process.destroy();
+    if (useJavaSSH) {
+      if (javaSSH != null) javaSSH.close();
+    } else if (process != null) process.destroy();
   }
 
   public boolean sendCommand(String command) {
@@ -725,6 +743,10 @@ public class AnalysisEngine {
 
   public void setCompletionCallback(Runnable completionCallback) {
     this.completionCallback = completionCallback;
+  }
+
+  public void setKeepAliveAfterCurrentRequest(boolean keepAliveAfterCurrentRequest) {
+    this.keepAliveAfterCurrentRequest = keepAliveAfterCurrentRequest;
   }
 
   private void runCompletionCallback() {

--- a/src/main/java/featurecat/lizzie/gui/FoxKifuDownload.java
+++ b/src/main/java/featurecat/lizzie/gui/FoxKifuDownload.java
@@ -496,8 +496,7 @@ public class FoxKifuDownload extends JFrame {
         String kifu = jsonObject.getString("chess");
         showProgressNotice(
             Lizzie.frame.kifuLoadText("KifuLoad.parsing", "正在解析棋谱…", "Parsing game record..."));
-        boolean loaded =
-            Lizzie.frame.loadSgfString(kifu, 200, Lizzie.config.readKomi, false, null);
+        boolean loaded = Lizzie.frame.loadSgfString(kifu, 0, Lizzie.config.readKomi, false, null);
         if (loaded) {
           finishFoxKifuLoadAfterMainPaint();
         } else {

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -499,6 +499,10 @@ public class LizzieFrame extends JFrame {
   public ArrayList<String> priorityMoveCoords = new ArrayList<String>();
 
   public AnalysisEngine analysisEngine;
+  private final java.util.concurrent.atomic.AtomicBoolean quickAnalysisEngineStarting =
+      new java.util.concurrent.atomic.AtomicBoolean(false);
+  private final java.util.List<Runnable> pendingQuickAnalysisCallbacks =
+      new java.util.ArrayList<Runnable>();
   public volatile TrackingEngine trackingEngine;
   public TrackingConsolePane trackingConsolePane;
   public Set<String> trackedCoords = Collections.synchronizedSet(new LinkedHashSet<>());
@@ -4207,12 +4211,12 @@ public class LizzieFrame extends JFrame {
     Lizzie.config.playSound = oriSound;
     fileNameTitle = file.getName();
     updateTitle();
-    scheduleResumeAnalysisAfterLoad(1000);
+    scheduleResumeAnalysisAfterLoad(0);
     refresh();
   }
 
   public void scheduleResumeAnalysisAfterLoad() {
-    scheduleResumeAnalysisAfterLoad(1000);
+    scheduleResumeAnalysisAfterLoad(0);
   }
 
   private void scheduleMovelistRefreshAfterKifuLoad() {
@@ -8291,7 +8295,7 @@ public class LizzieFrame extends JFrame {
       return;
     }
     if (decision == PasteSgfDecision.LOAD || decision == PasteSgfDecision.CONFIRM_REPLACE) {
-      loadSgfString(sgfContent, 200, Lizzie.config.readKomi, true, null);
+      loadSgfString(sgfContent, 0, Lizzie.config.readKomi, true, null);
     }
   }
 
@@ -12976,12 +12980,44 @@ public class LizzieFrame extends JFrame {
       Lizzie.config.analysisRecentIsPartGame = isAllGame;
       Lizzie.config.analysisRecentIsAllBranches = isAllBranches;
     }
+    if (silentAnalyze) {
+      startSilentQuickAnalyzeGame(isAllGame, isAllBranches);
+      return;
+    }
     if (needsNewFlashAnalysisEngine()) {
       startFlashAnalyzeGameWithNewEngine(isAllGame, isAllBranches, silentAnalyze);
     } else {
       startFlashAnalyzeRequestsInBackground(
           analysisEngine, isAllGame, isAllBranches, silentAnalyze);
     }
+  }
+
+  private void startSilentQuickAnalyzeGame(boolean isAllGame, boolean isAllBranches) {
+    stopBusyQuickAnalysisEngineBeforeLoadedKifuAnalysis();
+    Runnable startRequests =
+        new Runnable() {
+          public void run() {
+            if (!isAnalysisEngineReusable(analysisEngine)) {
+              return;
+            }
+            analysisEngine.setKeepAliveAfterCurrentRequest(true);
+            startFlashAnalyzeRequestsInBackground(
+                analysisEngine, isAllGame, isAllBranches, true);
+          }
+        };
+    if (isAnalysisEngineReusable(analysisEngine)) {
+      startRequests.run();
+      return;
+    }
+    ensureQuickAnalysisEngineAsync(startRequests);
+  }
+
+  private void stopBusyQuickAnalysisEngineBeforeLoadedKifuAnalysis() {
+    if (analysisEngine == null || !analysisEngine.isAnalysisInProgress()) {
+      return;
+    }
+    analysisEngine.normalQuit();
+    analysisEngine = null;
   }
 
   private boolean needsNewFlashAnalysisEngine() {
@@ -16392,6 +16428,7 @@ public class LizzieFrame extends JFrame {
     if (foxKifuDownload == null || !foxKifuDownload.isDisplayable()) {
       foxKifuDownload = new FoxKifuDownload();
     }
+    preloadQuickAnalysisEngineForKifuBrowsing();
     foxKifuDownload.presentWindow();
   }
 
@@ -16439,6 +16476,119 @@ public class LizzieFrame extends JFrame {
     Lizzie.leelaz.ponder();
     refresh();
     return true;
+  }
+
+  public void preloadQuickAnalysisEngineForKifuBrowsing() {
+    if (!canWarmQuickAnalysisEngine()) {
+      return;
+    }
+    ensureQuickAnalysisEngineAsync(null);
+  }
+
+  public void scheduleQuickAnalysisEngineWarmupAfterStartup() {
+    if (!SwingUtilities.isEventDispatchThread()) {
+      SwingUtilities.invokeLater(this::scheduleQuickAnalysisEngineWarmupAfterStartup);
+      return;
+    }
+    if (Lizzie.config == null
+        || Lizzie.config.analysisEnginePreLoad
+        || !Lizzie.config.autoQuickAnalyzeOnLoad) {
+      return;
+    }
+    javax.swing.Timer warmupTimer =
+        new javax.swing.Timer(
+            1200,
+            e -> {
+              preloadQuickAnalysisEngineForKifuBrowsing();
+            });
+    warmupTimer.setRepeats(false);
+    warmupTimer.start();
+  }
+
+  private boolean canWarmQuickAnalysisEngine() {
+    return Lizzie.config != null
+        && Lizzie.config.autoQuickAnalyzeOnLoad
+        && !EngineManager.isEngineGame()
+        && !isPlayingAgainstLeelaz
+        && !isAnaPlayingAgainstLeelaz;
+  }
+
+  private void ensureQuickAnalysisEngineAsync(Runnable onReady) {
+    if (isAnalysisEngineReusable(analysisEngine)) {
+      if (onReady != null) {
+        SwingUtilities.invokeLater(onReady);
+      }
+      return;
+    }
+    if (onReady != null) {
+      synchronized (pendingQuickAnalysisCallbacks) {
+        pendingQuickAnalysisCallbacks.add(onReady);
+      }
+    }
+    if (!quickAnalysisEngineStarting.compareAndSet(false, true)) {
+      return;
+    }
+    Thread starter =
+        new Thread(
+            new Runnable() {
+              public void run() {
+                AnalysisEngine newAnalysisEngine = null;
+                try {
+                  newAnalysisEngine = new AnalysisEngine(true);
+                } catch (IOException e) {
+                  e.printStackTrace();
+                }
+                final AnalysisEngine warmedEngine = newAnalysisEngine;
+                SwingUtilities.invokeLater(
+                    new Runnable() {
+                      public void run() {
+                        finishQuickAnalysisEngineWarmup(warmedEngine);
+                      }
+                    });
+              }
+            },
+            "quick-analysis-engine-preloader");
+    starter.setDaemon(true);
+    starter.start();
+  }
+
+  private void finishQuickAnalysisEngineWarmup(AnalysisEngine warmedEngine) {
+    try {
+      if (isAnalysisEngineReusable(warmedEngine)) {
+        if (!isAnalysisEngineReusable(analysisEngine)) {
+          analysisEngine = warmedEngine;
+        } else if (analysisEngine != warmedEngine) {
+          warmedEngine.normalQuit();
+        }
+      }
+      java.util.List<Runnable> callbacks = drainQuickAnalysisCallbacks();
+      if (isAnalysisEngineReusable(analysisEngine)) {
+        for (Runnable callback : callbacks) {
+          callback.run();
+        }
+      }
+    } finally {
+      quickAnalysisEngineStarting.set(false);
+    }
+  }
+
+  private java.util.List<Runnable> drainQuickAnalysisCallbacks() {
+    synchronized (pendingQuickAnalysisCallbacks) {
+      java.util.List<Runnable> callbacks =
+          new java.util.ArrayList<Runnable>(pendingQuickAnalysisCallbacks);
+      pendingQuickAnalysisCallbacks.clear();
+      return callbacks;
+    }
+  }
+
+  private boolean isAnalysisEngineReusable(AnalysisEngine engine) {
+    if (engine == null || !engine.isLoaded()) {
+      return false;
+    }
+    if (engine.useJavaSSH) {
+      return !engine.javaSSHClosed;
+    }
+    return engine.process != null && engine.process.isAlive();
   }
 
   public boolean ensureAnalysisResumedAfterSyncLoad() {

--- a/src/main/java/featurecat/lizzie/gui/Menu.java
+++ b/src/main/java/featurecat/lizzie/gui/Menu.java
@@ -6599,6 +6599,7 @@ public class Menu extends JMenuBar {
     if (tencentKifuDownload == null || !tencentKifuDownload.isDisplayable()) {
       tencentKifuDownload = new TencentKifuDownload();
     }
+    Lizzie.frame.preloadQuickAnalysisEngineForKifuBrowsing();
     tencentKifuDownload.presentWindow();
   }
 

--- a/src/main/java/featurecat/lizzie/gui/OnlineDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/OnlineDialog.java
@@ -1069,7 +1069,7 @@ public class OnlineDialog extends JDialog {
         }
       } else {
         sgf = data;
-        Lizzie.frame.loadSgfString(sgf, 200, Lizzie.config.readKomi, false, null);
+        Lizzie.frame.loadSgfString(sgf, 0, Lizzie.config.readKomi, false, null);
         return;
       }
     }

--- a/src/main/java/featurecat/lizzie/gui/SocketGetFile.java
+++ b/src/main/java/featurecat/lizzie/gui/SocketGetFile.java
@@ -100,7 +100,7 @@ public class SocketGetFile {
               new Runnable() {
                 public void run() {
                   Lizzie.frame.failKifuLoad(null);
-                  Lizzie.frame.loadSgfString(loadedSgf, 200, Lizzie.config.readKomi, false, null);
+                  Lizzie.frame.loadSgfString(loadedSgf, 0, Lizzie.config.readKomi, false, null);
                 }
               });
         }

--- a/src/main/java/featurecat/lizzie/gui/SyncDiagnosticsDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/SyncDiagnosticsDialog.java
@@ -27,6 +27,8 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 import javax.swing.AbstractButton;
@@ -491,21 +493,36 @@ public class SyncDiagnosticsDialog extends JDialog {
     if (zip == null) {
       return null;
     }
-    Path normalized = zip.toAbsolutePath().normalize();
-    int nameCount = normalized.getNameCount();
-    for (int i = 0; i < nameCount; i++) {
-      String name = normalized.getName(i).toString();
+    List<String> segments = normalizedExportPathSegments(zip);
+    for (int i = 0; i < segments.size(); i++) {
+      String name = segments.get(i);
       if ("lizzieyzy-next".equalsIgnoreCase(name)) {
-        return normalized.subpath(i, nameCount).toString();
+        return joinPathSegments(segments, i);
       }
       if ("sync-diagnostics".equalsIgnoreCase(name) && i > 0) {
-        String parentName = normalized.getName(i - 1).toString();
+        String parentName = segments.get(i - 1);
         if (parentName.toLowerCase().startsWith("lizzieyzy-next")) {
-          return normalized.subpath(i - 1, nameCount).toString();
+          return joinPathSegments(segments, i - 1);
         }
       }
     }
     return null;
+  }
+
+  private static List<String> normalizedExportPathSegments(Path zip) {
+    String normalized = zip.toAbsolutePath().normalize().toString().replace('\\', '/');
+    String[] rawSegments = normalized.split("/+");
+    ArrayList<String> segments = new ArrayList<>();
+    for (String segment : rawSegments) {
+      if (!segment.isEmpty()) {
+        segments.add(segment);
+      }
+    }
+    return segments;
+  }
+
+  private static String joinPathSegments(List<String> segments, int start) {
+    return String.join("/", segments.subList(start, segments.size()));
   }
 
   private static String sanitizeExportPath(Path zip) {

--- a/src/main/java/featurecat/lizzie/gui/TencentKifuDownload.java
+++ b/src/main/java/featurecat/lizzie/gui/TencentKifuDownload.java
@@ -361,7 +361,7 @@ public class TencentKifuDownload extends JFrame {
         String kifu = jsonObject.getString("chess");
         showProgressNotice(
             Lizzie.frame.kifuLoadText("KifuLoad.parsing", "正在解析棋谱…", "Parsing game record..."));
-        boolean loaded = Lizzie.frame.loadSgfString(kifu, 200, false, false, null);
+        boolean loaded = Lizzie.frame.loadSgfString(kifu, 0, false, false, null);
         if (loaded) {
           finishTencentKifuLoadAfterMainPaint();
         } else {

--- a/src/main/java/featurecat/lizzie/gui/WinrateGraph.java
+++ b/src/main/java/featurecat/lizzie/gui/WinrateGraph.java
@@ -650,16 +650,21 @@ public class WinrateGraph {
       if (mode == 0) {
         boolean canDrawBlunderBar = true;
         while (node.previous().isPresent()) {
-          double wr = node.getData().winrate;
+          BoardData data = node.getData();
+          double wr = data.winrate;
           double score = node.getData().scoreMean;
-          int playouts = node.getData().getPlayouts();
-          if (playouts > 0) {
-            if (wr < 0) {
-              wr = 100 - lastWr;
+          boolean hasAnalysis = hasPrimaryAnalysisPayload(data);
+          Double displayedWinrate = displayedDefaultAnchorWinrate(node, lastWr);
+          if (displayedWinrate != null) {
+            wr = displayedWinrate.doubleValue();
+            if (hasAnalysis) {
+              if (data.winrate < 0) {
+                score = lastScore;
+              } else if (!data.blackToPlay) {
+                score = -score;
+              }
+            } else {
               score = lastScore;
-            } else if (!node.getData().blackToPlay) {
-              wr = 100 - wr;
-              score = -score;
             }
             if (node == curMove) {
               // Draw a vertical line at the current move
@@ -730,7 +735,7 @@ public class WinrateGraph {
             else g.setColor(winrateMissLineColor());
 
             if (lastOkMove > 0 && lastOkMove - movenum < 25) {
-              if (canDrawBlunderBar && Lizzie.config.showBlunderBar) {
+              if (canDrawBlunderBar && Lizzie.config.showBlunderBar && hasAnalysis) {
                 drawBlunderBar(
                     gBlunder,
                     posx,
@@ -768,18 +773,20 @@ public class WinrateGraph {
               g.setStroke(dashed);
               node = graphTraversalEnd(node);
               movenum = node.getData().moveNumber - 1;
-              Double continuationWinrate = displayedGraphWinrate(node, lastWr);
+              Double continuationWinrate = displayedDefaultAnchorWinrate(node, lastWr);
               if (continuationWinrate != null) {
                 lastWr = continuationWinrate;
                 wr = continuationWinrate;
               }
-              lastScore = node.getData().scoreMean;
-              if (!node.getData().blackToPlay) {
+              data = node.getData();
+              hasAnalysis = hasPrimaryAnalysisPayload(data);
+              lastScore = data.scoreMean;
+              if (!data.blackToPlay && hasAnalysis) {
                 lastScore = -lastScore;
               }
               // g.setStroke(new BasicStroke(Lizzie.config.winrateStrokeWidth));
               topOfVariation = Optional.empty();
-              if (node.getData().getPlayouts() == 0) {
+              if (continuationWinrate == null) {
                 lastNodeOk = false;
               }
             }
@@ -787,7 +794,7 @@ public class WinrateGraph {
               if (node == curMove
                   || (curMove.previous().isPresent()
                       && node == curMove.previous().get()
-                      && curMove.getData().getPlayouts() <= 0)) {
+                      && !hasPrimaryAnalysisPayload(curMove.getData()))) {
                 g.setColor(winrateLineColor());
                 g.fillOval(
                     posx + (movenum * width / numMoves) - DOT_RADIUS,
@@ -887,7 +894,7 @@ public class WinrateGraph {
                     moveNumString, moveNum < numMoves / 2 ? x + 3 : x - 16, posy + height - margin);
             }
             if (Lizzie.config.showWinrateLine) {
-              if (node.getData().getPlayouts() > 0) {
+              if (hasPrimaryAnalysisPayload(node.getData())) {
                 mwr = wr;
                 mmovenum = movenum;
               }

--- a/src/test/java/featurecat/lizzie/analysis/AnalysisEngineRequestTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/AnalysisEngineRequestTest.java
@@ -19,6 +19,7 @@ import featurecat.lizzie.rules.Stone;
 import featurecat.lizzie.rules.Zobrist;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -246,6 +247,74 @@ class AnalysisEngineRequestTest {
           "always override should bypass cache guards even when the new flash result has fewer visits.");
       assertEquals(77.0, analyzed.winrate, 0.0001);
       assertFalse("cached-analysis".equals(analyzed.engineName));
+    }
+  }
+
+  @Test
+  void completedManualAnalysisStillAutoQuitsWhenConfigured() throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      Lizzie.config.analysisAutoQuit = true;
+      BoardHistoryNode node = singleUnanalyzedMoveNode();
+      TrackingAnalysisEngine engine = TrackingAnalysisEngine.create();
+      engine.trackPending(1, node);
+
+      engine.parseResult(analysisResult(1, 200, 62.0));
+
+      assertEquals(1, engine.normalQuitCount);
+      waitForMovelistRefreshThreads();
+    }
+  }
+
+  @Test
+  void completedPreloadedAnalysisKeepsEngineWarm() throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      Lizzie.config.analysisAutoQuit = true;
+      BoardHistoryNode node = singleUnanalyzedMoveNode();
+      TrackingAnalysisEngine engine = TrackingAnalysisEngine.create();
+      setField(AnalysisEngine.class, engine, "isPreLoad", true);
+      engine.trackPending(1, node);
+
+      engine.parseResult(analysisResult(1, 200, 62.0));
+
+      assertEquals(0, engine.normalQuitCount);
+      waitForMovelistRefreshThreads();
+    }
+  }
+
+  @Test
+  void completedAutoQuickAnalysisKeepsEngineWarmForNextKifu() throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      Lizzie.config.analysisAutoQuit = true;
+      BoardHistoryNode node = singleUnanalyzedMoveNode();
+      TrackingAnalysisEngine engine = TrackingAnalysisEngine.create();
+      engine.setKeepAliveAfterCurrentRequest(true);
+      engine.trackPending(1, node);
+
+      engine.parseResult(analysisResult(1, 200, 62.0));
+
+      assertEquals(0, engine.normalQuitCount);
+      waitForMovelistRefreshThreads();
+    }
+  }
+
+  @Test
+  void loadedKifuQuickAnalysisStopsPreviousQueuedQuickAnalysis() throws Exception {
+    try (TestEnvironment env = TestEnvironment.open()) {
+      Lizzie.config.autoQuickAnalyzeOnLoad = true;
+      BoardHistoryNode node = singleUnanalyzedMoveNode();
+      TrackingAnalysisEngine previousEngine = TrackingAnalysisEngine.create();
+      previousEngine.trackPending(1, node);
+      Lizzie.frame.analysisEngine = previousEngine;
+
+      invokeStopBusyQuickAnalysisEngineBeforeLoadedKifuAnalysis(Lizzie.frame);
+
+      assertEquals(
+          1,
+          previousEngine.normalQuitCount,
+          "opening a new kifu must not leave old whole-game analysis queued first.");
+      assertNull(
+          Lizzie.frame.analysisEngine,
+          "after stopping the busy quick-analysis engine, the next request should use a fresh engine.");
     }
   }
 
@@ -992,6 +1061,14 @@ class AnalysisEngineRequestTest {
     return result.toString();
   }
 
+  private static BoardHistoryNode singleUnanalyzedMoveNode() throws Exception {
+    BoardHistoryList history = new BoardHistoryList(BoardData.empty(BOARD_SIZE, BOARD_SIZE));
+    history.add(
+        moveNode(stones(placement(0, 0, Stone.BLACK)), new int[] {0, 0}, Stone.BLACK, false, 1));
+    boardWithHistory(history);
+    return history.getCurrentHistoryNode();
+  }
+
   private static void waitForMovelistRefreshThreads() throws InterruptedException {
     for (Thread thread : Thread.getAllStackTraces().keySet()) {
       if ("lizzie-movelist-refresh".equals(thread.getName()) && thread.isAlive()) {
@@ -1030,6 +1107,15 @@ class AnalysisEngineRequestTest {
     Field field = owner.getDeclaredField(name);
     field.setAccessible(true);
     field.setInt(target, value);
+  }
+
+  private static void invokeStopBusyQuickAnalysisEngineBeforeLoadedKifuAnalysis(LizzieFrame frame)
+      throws Exception {
+    Method method =
+        LizzieFrame.class.getDeclaredMethod(
+            "stopBusyQuickAnalysisEngineBeforeLoadedKifuAnalysis");
+    method.setAccessible(true);
+    method.invoke(frame);
   }
 
   private static final class Placement {
@@ -1147,6 +1233,7 @@ class AnalysisEngineRequestTest {
   private static final class TrackingAnalysisEngine extends AnalysisEngine {
     private List<String> sentCommands;
     private boolean failSends;
+    private int normalQuitCount;
 
     private TrackingAnalysisEngine() throws IOException {
       super(true);
@@ -1173,6 +1260,11 @@ class AnalysisEngineRequestTest {
       }
       sentCommands.add(command);
       return true;
+    }
+
+    @Override
+    public void normalQuit() {
+      normalQuitCount++;
     }
 
     private JSONObject singleRequest() {


### PR DESCRIPTION
## Summary

- Speed up real winrate curve startup after loading Fox/Tencent/shared/Yike SGF records.
- Prewarm the dedicated KataGo analysis engine when automatic quick analysis is enabled, so opening a kifu no longer waits on cold startup.
- Stop stale queued quick-analysis work before starting analysis for a newly opened kifu, avoiding long waits behind the previous game.
- Keep warmed quick-analysis engines alive for consecutive kifu reviews and remove the fake/pending winrate line approach.
- Harden analysis-engine shutdown and keep sync diagnostics path normalization cross-platform.

## Validation

- `mvn -Dfmt.skip=true -Dtest=AnalysisEngineRequestTest,LizzieFrameRegressionTest,WinrateGraphVariationHitTest,WinrateGraphSnapshotBoundaryHitTest,WinrateGraphQuickOverviewHitTest,WinrateGraphEnginePkModeHitTest test`
- `mvn -Dfmt.skip=true test`
- `mvn -Dfmt.skip=true -DskipTests package`
- Windows OpenCL portable smoke test: launched patched app and confirmed both main `gtp` KataGo and warmed `analysis` KataGo processes are running before opening a kifu.