### PR TITLE
修正棋力评估好手率展示判定

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/PlayerStrengthEstimator.java
+++ b/src/main/java/featurecat/lizzie/analysis/PlayerStrengthEstimator.java
@@ -55,6 +55,16 @@ public final class PlayerStrengthEstimator {
   private static final double GOOD_SCORE_LOSS = 1.2;
   private static final double INACCURACY_SCORE_LOSS = 4.0;
   private static final double MISTAKE_SCORE_LOSS = 10.0;
+  private static final double DEFAULT_WIN_LOSS_THRESHOLD_1 = -1.0;
+  private static final double DEFAULT_WIN_LOSS_THRESHOLD_2 = -3.0;
+  private static final double DEFAULT_WIN_LOSS_THRESHOLD_3 = -6.0;
+  private static final double DEFAULT_WIN_LOSS_THRESHOLD_4 = -12.0;
+  private static final double DEFAULT_WIN_LOSS_THRESHOLD_5 = -24.0;
+  private static final double DEFAULT_SCORE_LOSS_THRESHOLD_1 = -0.5;
+  private static final double DEFAULT_SCORE_LOSS_THRESHOLD_2 = -1.5;
+  private static final double DEFAULT_SCORE_LOSS_THRESHOLD_3 = -3.0;
+  private static final double DEFAULT_SCORE_LOSS_THRESHOLD_4 = -6.0;
+  private static final double DEFAULT_SCORE_LOSS_THRESHOLD_5 = -12.0;
   private static final String[] STRENGTH_BANDS = {
     "Beginner",
     "11-15k",
@@ -224,6 +234,7 @@ public final class PlayerStrengthEstimator {
         firstChoice,
         playedCandidate.rank >= 0 ? playedCandidate.rank : ADDITIONAL_MOVE_ORDER,
         categorize(scoreEquivalentLoss),
+        categorizeMoveRank(lossEstimate),
         scoreEquivalentLoss,
         complexity,
         adjustedWeight);
@@ -433,6 +444,73 @@ public final class PlayerStrengthEstimator {
       return MoveCategory.MISTAKE;
     }
     return MoveCategory.BLUNDER;
+  }
+
+  private static MoveCategory categorizeMoveRank(LossEstimate lossEstimate) {
+    double winrateLoss = positive(lossEstimate.winrateLoss);
+    Optional<Double> scoreLoss = lossEstimate.scoreLoss.map(PlayerStrengthEstimator::positive);
+    if (reachesMoveRankThreshold(winrateLoss, scoreLoss, 5)) {
+      return MoveCategory.BLUNDER;
+    }
+    if (reachesMoveRankThreshold(winrateLoss, scoreLoss, 4)) {
+      return MoveCategory.MISTAKE;
+    }
+    if (reachesMoveRankThreshold(winrateLoss, scoreLoss, 3)
+        || reachesMoveRankThreshold(winrateLoss, scoreLoss, 2)) {
+      return MoveCategory.INACCURACY;
+    }
+    if (reachesMoveRankThreshold(winrateLoss, scoreLoss, 1)) {
+      return MoveCategory.GREAT;
+    }
+    return MoveCategory.EXCELLENT;
+  }
+
+  private static boolean reachesMoveRankThreshold(
+      double winrateLoss, Optional<Double> scoreLoss, int level) {
+    Config config = Lizzie.config;
+    boolean useWinLoss = config == null || config.useWinLossInMoveRank;
+    boolean useScoreLoss = config == null || config.useScoreLossInMoveRank;
+    boolean reachesWinLoss =
+        useWinLoss && winrateLoss >= Math.abs(moveRankWinLossThreshold(config, level));
+    boolean reachesScoreLoss =
+        useScoreLoss
+            && scoreLoss.isPresent()
+            && scoreLoss.get() >= Math.abs(moveRankScoreLossThreshold(config, level));
+    return reachesWinLoss || reachesScoreLoss;
+  }
+
+  private static double moveRankWinLossThreshold(Config config, int level) {
+    switch (level) {
+      case 1:
+        return config == null ? DEFAULT_WIN_LOSS_THRESHOLD_1 : config.winLossThreshold1;
+      case 2:
+        return config == null ? DEFAULT_WIN_LOSS_THRESHOLD_2 : config.winLossThreshold2;
+      case 3:
+        return config == null ? DEFAULT_WIN_LOSS_THRESHOLD_3 : config.winLossThreshold3;
+      case 4:
+        return config == null ? DEFAULT_WIN_LOSS_THRESHOLD_4 : config.winLossThreshold4;
+      case 5:
+        return config == null ? DEFAULT_WIN_LOSS_THRESHOLD_5 : config.winLossThreshold5;
+      default:
+        throw new IllegalArgumentException("Unsupported move-rank threshold level: " + level);
+    }
+  }
+
+  private static double moveRankScoreLossThreshold(Config config, int level) {
+    switch (level) {
+      case 1:
+        return config == null ? DEFAULT_SCORE_LOSS_THRESHOLD_1 : config.scoreLossThreshold1;
+      case 2:
+        return config == null ? DEFAULT_SCORE_LOSS_THRESHOLD_2 : config.scoreLossThreshold2;
+      case 3:
+        return config == null ? DEFAULT_SCORE_LOSS_THRESHOLD_3 : config.scoreLossThreshold3;
+      case 4:
+        return config == null ? DEFAULT_SCORE_LOSS_THRESHOLD_4 : config.scoreLossThreshold4;
+      case 5:
+        return config == null ? DEFAULT_SCORE_LOSS_THRESHOLD_5 : config.scoreLossThreshold5;
+      default:
+        throw new IllegalArgumentException("Unsupported move-rank threshold level: " + level);
+    }
   }
 
   private static boolean isBlank(String value) {
@@ -1081,6 +1159,7 @@ public final class PlayerStrengthEstimator {
     public final double matchRate;
     public final double firstChoiceRate;
     public final double goodMoveRate;
+    public final double moveRankGoodMoveRate;
     public final double badMoveRate;
     public final double mistakeRate;
     public final double blunderRate;
@@ -1104,6 +1183,7 @@ public final class PlayerStrengthEstimator {
         double matchRate,
         double firstChoiceRate,
         double goodMoveRate,
+        double moveRankGoodMoveRate,
         double badMoveRate,
         double mistakeRate,
         double blunderRate,
@@ -1125,6 +1205,7 @@ public final class PlayerStrengthEstimator {
       this.matchRate = matchRate;
       this.firstChoiceRate = firstChoiceRate;
       this.goodMoveRate = goodMoveRate;
+      this.moveRankGoodMoveRate = moveRankGoodMoveRate;
       this.badMoveRate = badMoveRate;
       this.mistakeRate = mistakeRate;
       this.blunderRate = blunderRate;
@@ -1223,6 +1304,7 @@ public final class PlayerStrengthEstimator {
     public final boolean firstChoice;
     public final int aiRank;
     public final MoveCategory category;
+    public final MoveCategory moveRankCategory;
     public final double scoreEquivalentLoss;
     public final double complexity;
     public final double adjustedWeight;
@@ -1235,6 +1317,7 @@ public final class PlayerStrengthEstimator {
         boolean firstChoice,
         int aiRank,
         MoveCategory category,
+        MoveCategory moveRankCategory,
         double scoreEquivalentLoss,
         double complexity,
         double adjustedWeight) {
@@ -1245,6 +1328,7 @@ public final class PlayerStrengthEstimator {
       this.firstChoice = firstChoice;
       this.aiRank = aiRank;
       this.category = category;
+      this.moveRankCategory = moveRankCategory;
       this.scoreEquivalentLoss = scoreEquivalentLoss;
       this.complexity = complexity;
       this.adjustedWeight = adjustedWeight;
@@ -1290,6 +1374,7 @@ public final class PlayerStrengthEstimator {
             0.0,
             0.0,
             0.0,
+            0.0,
             "-",
             Confidence.LOW,
             new ArrayList<>());
@@ -1311,6 +1396,7 @@ public final class PlayerStrengthEstimator {
       int top5Moves = 0;
       int excellentMoves = 0;
       int goodMoves = 0;
+      int moveRankGoodMoves = 0;
       int badMoves = 0;
       int inaccuracies = 0;
       int mistakes = 0;
@@ -1345,6 +1431,9 @@ public final class PlayerStrengthEstimator {
           goodMoves++;
         } else {
           badMoves++;
+        }
+        if (sample.moveRankCategory.isGoodMove()) {
+          moveRankGoodMoves++;
         }
         if (sample.category == MoveCategory.INACCURACY) {
           inaccuracies++;
@@ -1382,6 +1471,7 @@ public final class PlayerStrengthEstimator {
       double top5Rate = (double) top5Moves / sampleCount;
       double excellentRate = (double) excellentMoves / sampleCount;
       double goodMoveRate = (double) goodMoves / sampleCount;
+      double moveRankGoodMoveRate = (double) moveRankGoodMoves / sampleCount;
       double badMoveRate = (double) badMoves / sampleCount;
       double inaccuracyRate = (double) inaccuracies / sampleCount;
       double mistakeRate = (double) mistakes / sampleCount;
@@ -1442,6 +1532,7 @@ public final class PlayerStrengthEstimator {
           matchRate,
           firstChoiceRate,
           goodMoveRate,
+          moveRankGoodMoveRate,
           badMoveRate,
           mistakeRate,
           blunderRate,

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -13468,7 +13468,7 @@ public class LizzieFrame extends JFrame {
     addPlayerStrengthMetric(
         metrics,
         Lizzie.resourceBundle.getString("PlayerStrengthEstimate.goodMoveRate"),
-        playerStrengthPrecisePercentText(report.goodMoveRate));
+        playerStrengthPrecisePercentText(report.moveRankGoodMoveRate));
     addPlayerStrengthMetric(
         metrics,
         Lizzie.resourceBundle.getString("PlayerStrengthEstimate.weightedScoreLoss"),
@@ -14451,8 +14451,8 @@ public class LizzieFrame extends JFrame {
           g2,
           rowY + 64,
           Lizzie.resourceBundle.getString("PlayerStrengthEstimate.goodMoveRate"),
-          playerStrengthPercentText(report.goodMoveRate),
-          report.goodMoveRate,
+          playerStrengthPercentText(report.moveRankGoodMoveRate),
+          report.moveRankGoodMoveRate,
           PlayerStrengthDashboardRoot.ACCENT,
           contentRight);
       drawMetricRow(
@@ -14617,7 +14617,7 @@ public class LizzieFrame extends JFrame {
           metricX + columnGap,
           62,
           Lizzie.resourceBundle.getString("PlayerStrengthEstimate.goodMoveRate"),
-          playerStrengthPercentText(report.goodMoveRate),
+          playerStrengthPercentText(report.moveRankGoodMoveRate),
           statWidth);
       drawTinyStat(
           g2,
@@ -14867,7 +14867,7 @@ public class LizzieFrame extends JFrame {
       int blockWidth = playerStrengthMoveBlockWidth(width, maxMove);
       for (PlayerStrengthEstimator.Sample sample : samples) {
         boolean firstChoice = sample.firstChoice;
-        boolean goodMove = sample.category != null && sample.category.isGoodMove();
+        boolean goodMove = sample.moveRankCategory != null && sample.moveRankCategory.isGoodMove();
         if (!firstChoice && !goodMove) {
           continue;
         }
@@ -14923,7 +14923,7 @@ public class LizzieFrame extends JFrame {
       if (sample.firstChoice) {
         drawTimelineBlock(g2, point.x, firstY, blockWidth, laneHeight, primary, hovered);
       }
-      if (sample.category != null && sample.category.isGoodMove()) {
+      if (sample.moveRankCategory != null && sample.moveRankCategory.isGoodMove()) {
         drawTimelineBlock(g2, point.x, goodY, blockWidth, laneHeight, good, hovered);
       }
       if (hovered) {
@@ -14971,7 +14971,7 @@ public class LizzieFrame extends JFrame {
           textX,
           goodBaseline,
           Lizzie.resourceBundle.getString("PlayerStrengthEstimate.match.goodMove"),
-          playerStrengthPercentText(sideReport.goodMoveRate));
+          playerStrengthPercentText(sideReport.moveRankGoodMoveRate));
     }
 
     private void drawStat(Graphics2D g2, int x, int y, String label, String value) {
@@ -15023,7 +15023,7 @@ public class LizzieFrame extends JFrame {
       String category =
           sample.firstChoice
               ? Lizzie.resourceBundle.getString("PlayerStrengthEstimate.match.firstChoice")
-              : sample.category != null && sample.category.isGoodMove()
+              : sample.moveRankCategory != null && sample.moveRankCategory.isGoodMove()
                   ? Lizzie.resourceBundle.getString("PlayerStrengthEstimate.match.goodMove")
                   : Lizzie.resourceBundle.getString("PlayerStrengthEstimate.match.otherMove");
       String aiChoice =
@@ -15084,7 +15084,7 @@ public class LizzieFrame extends JFrame {
       String detail =
           (sample.firstChoice
                   ? Lizzie.resourceBundle.getString("PlayerStrengthEstimate.match.firstChoice")
-                  : sample.category != null && sample.category.isGoodMove()
+                  : sample.moveRankCategory != null && sample.moveRankCategory.isGoodMove()
                       ? Lizzie.resourceBundle.getString("PlayerStrengthEstimate.match.goodMove")
                       : Lizzie.resourceBundle.getString("PlayerStrengthEstimate.match.otherMove"))
               + "  "
@@ -15362,7 +15362,7 @@ public class LizzieFrame extends JFrame {
           g2.setColor(black ? BLACK_FIRST : WHITE_FIRST);
           g2.fillRect(x, firstY, blockWidth, laneHeight);
         }
-        if (sample.category.isGoodMove()) {
+        if (sample.moveRankCategory.isGoodMove()) {
           g2.setColor(black ? BLACK_GOOD : WHITE_GOOD);
           g2.fillRect(x, goodY, blockWidth, laneHeight);
         }
@@ -15384,7 +15384,7 @@ public class LizzieFrame extends JFrame {
           statsX,
           goodY + laneHeight,
           Lizzie.resourceBundle.getString("PlayerStrengthEstimate.match.goodMove"),
-          percentText(sideReport.goodMoveRate));
+          percentText(sideReport.moveRankGoodMoveRate));
       drawStat(
           g2,
           statsX,

--- a/src/test/java/featurecat/lizzie/analysis/PlayerStrengthEstimatorTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/PlayerStrengthEstimatorTest.java
@@ -314,6 +314,7 @@ class PlayerStrengthEstimatorTest {
     assertEquals(56, report.overall.sampleCount);
     assertEquals(0.46, report.overall.firstChoiceRate, 0.01);
     assertEquals(0.79, report.overall.goodMoveRate, 0.01);
+    assertEquals(0.98, report.overall.moveRankGoodMoveRate, 0.01);
     assertEquals(0.02, report.overall.mistakeRate, 0.01);
     assertEquals("9d", report.overall.strengthBand);
   }
@@ -421,6 +422,24 @@ class PlayerStrengthEstimatorTest {
     assertEquals(0, report.black.scoreSampleCount);
     assertEquals(10.0, report.black.averageWinrateLoss, 0.0001);
     assertEquals("-", report.black.averageScoreLossText());
+  }
+
+  @Test
+  void keepsModelGoodMoveRateStableButExcludesHighWinrateLossFromDisplayedGoodMoves() {
+    BoardHistoryList history =
+        new BoardHistoryList(
+            analyzedRoot(
+                true, 70.0, 10.0, candidate("pass", 70.0, 10.0), candidate("A9", 50.0, 9.9)));
+    history.add(analyzedMove(0, 0, Stone.BLACK, false, 1, 30.0, -9.9));
+
+    PlayerStrengthEstimator.Report report = PlayerStrengthEstimator.estimate(history.getStart());
+
+    assertEquals(1, report.black.sampleCount);
+    assertEquals(20.0, report.black.averageWinrateLoss, 0.0001);
+    assertEquals(0.1, report.black.averageScoreLoss, 0.0001);
+    assertEquals(1.0, report.black.goodMoveRate, 0.0001);
+    assertEquals(0.0, report.black.moveRankGoodMoveRate, 0.0001);
+    assertEquals(0.0, report.black.mistakeRate, 0.0001);
   }
 
   @Test

--- a/src/test/java/featurecat/lizzie/gui/LizzieFrameRegressionTest.java
+++ b/src/test/java/featurecat/lizzie/gui/LizzieFrameRegressionTest.java
@@ -533,12 +533,23 @@ class LizzieFrameRegressionTest {
             boolean.class,
             int.class,
             PlayerStrengthEstimator.MoveCategory.class,
+            PlayerStrengthEstimator.MoveCategory.class,
             double.class,
             double.class,
             double.class);
     constructor.setAccessible(true);
     return constructor.newInstance(
-        color, moveNumber, winrateLoss, scoreLoss, firstChoice, aiRank, category, 1.0, 35.0, 1.0);
+        color,
+        moveNumber,
+        winrateLoss,
+        scoreLoss,
+        firstChoice,
+        aiRank,
+        category,
+        category,
+        1.0,
+        35.0,
+        1.0);
   }
 
   private static PlayerStrengthEstimator.SideReport playerStrengthSideReport(
@@ -551,6 +562,7 @@ class LizzieFrameRegressionTest {
             int.class,
             int.class,
             PlayerStrengthEstimator.StrengthModel.class,
+            double.class,
             double.class,
             double.class,
             double.class,
@@ -584,6 +596,7 @@ class LizzieFrameRegressionTest {
         1.2,
         goodMoveRate,
         firstChoiceRate,
+        goodMoveRate,
         goodMoveRate,
         0.0,
         0.0,


### PR DESCRIPTION
## 说明

修正棋力评估面板中“好手率/好手命中”展示的判定方式，避免目损很小但胜率损失很大的手仍被展示为好手。

## 改动

- 保留模型内部的旧 `goodMoveRate` / `mistakeRate` 定义，不改变 XGBoost 入参和段位评估特征语义。
- 新增 `moveRankCategory` 和 `moveRankGoodMoveRate`，按棋盘落子颜色标记阈值同时考虑胜率损失和目损。
- 棋力评估 UI 中的好手率、好手命中条和 tooltip 的“好手”展示改用 `moveRankGoodMoveRate` / `moveRankCategory`。
- 补充回归测试：高胜率损失但低目损时，模型旧好手率保持不变，展示好手率不再计入。

## 验证

```bash
mvn -Dtest=PlayerStrengthEstimatorTest test
```

关联 issue：#66
