### PR TITLE
Fix hover variation no-refresh preview

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
+++ b/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
@@ -1508,6 +1508,8 @@ public class BoardRenderer {
 
   /** Draw the 'ghost stones' which show a variationOpt Leelaz is thinking about */
   private void drawBranch() {
+    boolean wasShowingBranch = isShowingBranch;
+    String previousMouseOverCoords = mouseOverCoords;
     branchOpt = Optional.empty();
     isShowingBranch = false;
     // calculate best moves and branch
@@ -1625,9 +1627,9 @@ public class BoardRenderer {
 
     // List<String>
     if (!Lizzie.config.noRefreshOnMouseMove
-        || (!isShowingBranch || !mouseOverCoords.equals(suggestedMove.get().coordinate))) {
-      variation = suggestedMove.get().variation;
-      pvVistis = suggestedMove.get().pvVisits;
+        || (!wasShowingBranch || !previousMouseOverCoords.equals(suggestedMove.get().coordinate))) {
+      variation = branchPreviewList(suggestedMove.get().variation);
+      pvVistis = branchPreviewList(suggestedMove.get().pvVisits);
     }
     if (variation == null) {
       return;
@@ -1770,6 +1772,11 @@ public class BoardRenderer {
 
   private boolean hasRenderedBranchImages() {
     return branchStonesImage != emptyImage && branchStonesShadowImage != emptyImage;
+  }
+
+  private List<String> branchPreviewList(List<String> source) {
+    if (source == null) return null;
+    return Lizzie.config.noRefreshOnMouseMove ? new ArrayList<String>(source) : source;
   }
 
   private void invalidateBranchImageCache() {

--- a/src/main/java/featurecat/lizzie/gui/FloatBoardRenderer.java
+++ b/src/main/java/featurecat/lizzie/gui/FloatBoardRenderer.java
@@ -784,8 +784,8 @@ public class FloatBoardRenderer {
     // List<String>
     if (!Lizzie.config.noRefreshOnMouseMove
         || (!isShowingBranch || !mouseOverCoords.equals(suggestedMove.get().coordinate))) {
-      variation = suggestedMove.get().variation;
-      pvVistis = suggestedMove.get().pvVisits;
+      variation = branchPreviewList(suggestedMove.get().variation);
+      pvVistis = branchPreviewList(suggestedMove.get().pvVisits);
     }
     if (variation == null) {
       return;
@@ -904,6 +904,11 @@ public class FloatBoardRenderer {
 
   private boolean hasRenderedBranchImages() {
     return branchStonesImage != emptyImage && branchStonesShadowImage != emptyImage;
+  }
+
+  private List<String> branchPreviewList(List<String> source) {
+    if (source == null) return null;
+    return Lizzie.config.noRefreshOnMouseMove ? new ArrayList<String>(source) : source;
   }
 
   private void invalidateBranchImageCache() {

--- a/src/test/java/featurecat/lizzie/gui/MoveOnlyUiGateTest.java
+++ b/src/test/java/featurecat/lizzie/gui/MoveOnlyUiGateTest.java
@@ -2,6 +2,7 @@ package featurecat.lizzie.gui;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -336,6 +337,97 @@ class MoveOnlyUiGateTest {
   }
 
   @Test
+  void boardRendererNoRefreshFreezesHoveredVariationSnapshot() throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    try {
+      Lizzie.config.showBranch = true;
+      Lizzie.config.showSuggestionVariations = true;
+      Lizzie.config.showBlackCandidates = true;
+      Lizzie.config.showWhiteCandidates = true;
+      Lizzie.config.noRefreshOnMouseMove = true;
+      Lizzie.config.usePureStone = true;
+      TrackingLizzieFrame frame = configuredFrame();
+      frame.mouseOverCoordinate = new int[] {0, 1};
+      frame.isMouseOver = true;
+      frame.priorityMoveCoords = new ArrayList<>();
+      Lizzie.frame = frame;
+      BoardData current = currentData();
+      MoveData suggested = current.bestMoves.get(0);
+      List<String> firstPv =
+          new ArrayList<>(List.of(suggested.coordinate, Board.convertCoordinatesToName(1, 1)));
+      suggested.variation = firstPv;
+      Lizzie.board = boardWith(historyForCurrentNode(current));
+      BoardRenderer renderer = configuredBranchRenderer();
+
+      invokeDrawBranch(renderer);
+
+      Optional<List<String>> firstPreview = boardRendererVariationOpt(renderer);
+      assertTrue(firstPreview.isPresent());
+      assertIterableEquals(firstPv, firstPreview.get());
+      assertNotSame(
+          suggested.variation,
+          firstPreview.get(),
+          "no-refresh hover should keep an immutable preview snapshot, not the live engine list.");
+
+      firstPv.set(1, Board.convertCoordinatesToName(2, 2));
+      firstPv.add(Board.convertCoordinatesToName(1, 2));
+      invokeDrawBranch(renderer);
+
+      Optional<List<String>> secondPreview = boardRendererVariationOpt(renderer);
+      assertTrue(secondPreview.isPresent());
+      assertIterableEquals(
+          List.of(suggested.coordinate, Board.convertCoordinatesToName(1, 1)),
+          secondPreview.get(),
+          "same hovered move should not refresh when no-refresh-on-mouse-move is enabled.");
+    } finally {
+      env.close();
+    }
+  }
+
+  @Test
+  void boardRendererRefreshesHoveredVariationWhenNoRefreshDisabled() throws Exception {
+    TestEnvironment env = TestEnvironment.open();
+    try {
+      Lizzie.config.showBranch = true;
+      Lizzie.config.showSuggestionVariations = true;
+      Lizzie.config.showBlackCandidates = true;
+      Lizzie.config.showWhiteCandidates = true;
+      Lizzie.config.noRefreshOnMouseMove = false;
+      Lizzie.config.usePureStone = true;
+      TrackingLizzieFrame frame = configuredFrame();
+      frame.mouseOverCoordinate = new int[] {0, 1};
+      frame.isMouseOver = true;
+      frame.priorityMoveCoords = new ArrayList<>();
+      Lizzie.frame = frame;
+      BoardData current = currentData();
+      MoveData suggested = current.bestMoves.get(0);
+      suggested.variation =
+          new ArrayList<>(List.of(suggested.coordinate, Board.convertCoordinatesToName(1, 1)));
+      Lizzie.board = boardWith(historyForCurrentNode(current));
+      BoardRenderer renderer = configuredBranchRenderer();
+
+      invokeDrawBranch(renderer);
+
+      suggested.variation =
+          new ArrayList<>(
+              List.of(
+                  suggested.coordinate,
+                  Board.convertCoordinatesToName(2, 2),
+                  Board.convertCoordinatesToName(1, 2)));
+      invokeDrawBranch(renderer);
+
+      Optional<List<String>> preview = boardRendererVariationOpt(renderer);
+      assertTrue(preview.isPresent());
+      assertIterableEquals(
+          suggested.variation,
+          preview.get(),
+          "hover variation should keep refreshing when no-refresh-on-mouse-move is disabled.");
+    } finally {
+      env.close();
+    }
+  }
+
+  @Test
   void independentMainBoardBlunderHoverIgnoresSnapshotMarker() throws Exception {
     TestEnvironment env = TestEnvironment.open();
     try {
@@ -531,6 +623,12 @@ class MoveOnlyUiGateTest {
     Field field = owner.getDeclaredField(name);
     field.setAccessible(true);
     return field.get(target);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Optional<List<String>> boardRendererVariationOpt(BoardRenderer renderer)
+      throws Exception {
+    return (Optional<List<String>>) getField(BoardRenderer.class, renderer, "variationOpt");
   }
 
   private static BoardHistoryList historyWithNext(BoardData current, BoardData next) {


### PR DESCRIPTION
## Summary

- Fixes hover variation preview refresh when `no-refresh-on-mouse-move` is enabled.
- Preserves the previously hovered move state before resetting branch render state.
- Snapshots hover preview PV lists so live engine updates do not mutate an already frozen preview.
- Applies the same snapshot behavior to the floating board preview renderer.

## Root Cause

`BoardRenderer.drawBranch()` reset `isShowingBranch` before checking whether the same suggested move was still being hovered, so the no-refresh branch always looked like a fresh hover. The preview also kept a live reference to the engine PV list, allowing later engine updates to change the displayed variation even when refresh was disabled.

## Validation

- `git diff --check`
- `mvn -B -Dfmt.skip=true test`
- `mvn -B -Dfmt.skip=true -DskipTests package`
- Manual local UI test by maintainer: hover variation no-refresh now behaves correctly.
