### PR TITLE
Fix Windows core update launcher config refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
 > - Windows 大多数用户：到 [Releases](https://github.com/wimi321/lizzieyzy-next/releases) 下载 `*windows64.opencl.portable.zip`
 > - RTX 20/30/40 NVIDIA 显卡并且想更快：下载 `*windows64.nvidia.portable.zip`
 > - RTX 5070/5080/5090：优先下载 `*windows64.nvidia50.cuda.portable.zip`，需要 TensorRT 时再到软件内“一键设置”按需安装
-> - 已经有 Windows 免安装版：日常升级优先下载 `*windows64.core-update.zip`，关闭软件后解压到旧目录覆盖，只更新主程序
+> - 已经有 Windows 免安装版：日常升级优先下载 `*windows64.core-update.zip`，关闭软件后解压到旧目录覆盖，只更新主程序和启动器配置
 > - TensorRT 不只给 RTX 50：RTX 20/30/40/50 NVIDIA 显卡都可以在软件内按需安装；GTX 10 系及更老显卡优先 CUDA/OpenCL
 > - `KataGo 一键设置` 会检测 NVIDIA GPU 和 Compute Capability，自动提示是否推荐 TensorRT；检测失败也可以手动继续
 > - TensorRT 一键安装成功后会自动清理下载包缓存；运行缓存尽量写入软件自己的 `user-data/runtime`，减少 C 盘额外占用
@@ -113,7 +113,7 @@
 
 Windows `portable.zip` 是真正的免安装模式：配置、日志、保存棋谱、下载权重和软件内安装的 TensorRT 加速文件都会保存在解压出来的同一个文件夹里，主要位置是 `user-data/`。如果想彻底清理这个免安装版，删除整个解压文件夹即可；如果想保留设置，升级前把旧文件夹里的 `user-data/` 复制到新文件夹。
 
-已有 Windows 免安装版时，日常小版本升级不用重新下载完整大包。下载 `*windows64.core-update.zip`，关闭软件，把 zip 里的内容解压到旧的免安装目录覆盖即可。这个小包只替换 `app/lizzie-yzy2.5.3-shaded.jar`，不会重复下载或覆盖 `weights/`、`engines/`、`runtime/`、`jcef-bundle/`、`readboard/`、`user-data/`。如果某次 release 明确写了 KataGo、权重或运行环境升级，再按说明下载完整包或对应资源包。
+已有 Windows 免安装版时，日常小版本升级不用重新下载完整大包。下载 `*windows64.core-update.zip`，关闭软件，把 zip 里的内容解压到旧的免安装目录覆盖即可。这个小包只替换 `app/lizzie-yzy2.5.3-shaded.jar` 和 `app/LizzieYzy Next*.cfg`，用来同步标题栏版本号和必要 JVM 参数；不会重复下载或覆盖 `weights/`、`engines/`、`runtime/`、`jcef-bundle/`、`readboard/`、`user-data/`。如果某次 release 明确写了 KataGo、权重或运行环境升级，再按说明下载完整包或对应资源包。
 
 如果你懒得分辨：
 

--- a/docs/PACKAGES.md
+++ b/docs/PACKAGES.md
@@ -13,7 +13,7 @@
 - 当前维护版公开主推 15 个首次下载主资产，另有 1 个 Windows 免安装小更新包
 - Windows 默认优先推荐 `portable.zip`
 - 大多数普通用户先下 `windows64.opencl.portable.zip`
-- 已有 Windows 免安装版的老用户，日常升级优先下载 `windows64.core-update.zip` 覆盖旧目录
+- 已有 Windows 免安装版的老用户，日常升级优先下载 `windows64.core-update.zip` 覆盖旧目录，只更新主程序和启动器配置
 - OpenCL 表现不好时改用 `windows64.with-katago.portable.zip`
 - RTX 20/30/40 系列 NVIDIA 显卡并且更在意速度时改用 `windows64.nvidia.portable.zip`
 - RTX 5070/5080/5090 优先试 `windows64.nvidia50.cuda.portable.zip`，TensorRT 加速改为软件内按需安装
@@ -57,7 +57,7 @@
 - TensorRT 分卷包是高级可选资产，不计入普通用户主推荐路径；只下载 `.7z.001` 没用，必须下载全部 `.7z.00N`。
 - Windows 64 位现在优先推荐免安装包，安装器作为可选路径保留。
 - Windows 免安装包会在解压目录内启用便携模式，配置、日志、保存棋谱、下载权重和软件内安装的 TensorRT 文件都随这个文件夹保存，主要位于 `user-data/`。
-- 已有 Windows 免安装版时，关闭软件后把 `<date>-windows64.core-update.zip` 解压到旧目录覆盖即可；它只替换 `app/lizzie-yzy2.5.3-shaded.jar`，不会覆盖权重、引擎、运行环境、JCEF、readboard、TensorRT 或 `user-data/`。
+- 已有 Windows 免安装版时，关闭软件后把 `<date>-windows64.core-update.zip` 解压到旧目录覆盖即可；它只替换 `app/lizzie-yzy2.5.3-shaded.jar` 和 `app/LizzieYzy Next*.cfg`，用于同步标题栏版本号和必要 JVM 参数，不会覆盖权重、引擎、运行环境、JCEF、readboard、TensorRT 或 `user-data/`。
 - 旧 tag 里如果还看到兼容 zip 或历史包，那属于历史发布格式。
 
 ## 每个包里内置了什么
@@ -72,7 +72,7 @@
 | `windows64.nvidia.installer.exe` | 是 | 是 | 安装后从开始菜单或桌面打开 |
 | `windows64.nvidia50.cuda.portable.zip` | 是 | 是 | 解压后运行 `LizzieYzy Next NVIDIA 50 CUDA.exe` |
 | `windows64.nvidia50.cuda.installer.exe` | 是 | 是 | 安装后从开始菜单或桌面打开 |
-| `windows64.core-update.zip` | 否 | 依赖旧免安装目录 | 解压到旧免安装目录覆盖，用于日常升级主程序 |
+| `windows64.core-update.zip` | 否 | 依赖旧免安装目录 | 解压到旧免安装目录覆盖，用于日常升级主程序和启动器配置 |
 | `windows64.without.engine.portable.zip` | 是 | 否 | 解压后运行 `LizzieYzy Next.exe` |
 | `windows64.without.engine.installer.exe` | 是 | 否 | 安装后从开始菜单或桌面打开 |
 | `mac-apple-silicon.with-katago.dmg` | App 自带 | 是 | 拖到 Applications |

--- a/scripts/generate_release_notes.py
+++ b/scripts/generate_release_notes.py
@@ -314,12 +314,12 @@ def add_windows_core_update_download_row(
         'ภาษาไทย': 'ผู้ใช้ Windows portable เดิมควรใช้ `windows64.core-update.zip` สำหรับอัปเดตทั่วไป: ปิดแอปแล้วแตกไฟล์ทับโฟลเดอร์เดิม โดย engine, weight, TensorRT, settings และ game records จะยังอยู่',
     }
     update_note_by_language = {
-        '中文': 'Windows 免安装版新增更清晰的小更新路径：`core-update` 只替换主程序，不重复打包引擎、权重、JCEF、readboard、Java runtime 或用户数据。',
-        '繁體中文': 'Windows 免安裝版新增更清楚的小更新路徑：`core-update` 只替換主程式，不重複打包引擎、權重、JCEF、readboard、Java runtime 或使用者資料。',
-        'English': 'Windows portable builds now have a clearer small-update path: `core-update` replaces only the app core and does not rebundle engines, weights, JCEF, readboard, Java runtime, or user data.',
-        '日本語': 'Windows portable 版に分かりやすい小型更新パスを追加しました。`core-update` はアプリ本体だけを置き換え、エンジン、重み、JCEF、readboard、Java runtime、ユーザーデータを再同梱しません。',
-        '한국어': 'Windows portable 빌드에 더 명확한 소형 업데이트 경로를 추가했습니다. `core-update` 는 앱 핵심만 교체하고 엔진, 가중치, JCEF, readboard, Java runtime, 사용자 데이터를 다시 묶지 않습니다.',
-        'ภาษาไทย': 'Windows portable มีทางอัปเดตเล็กที่ชัดเจนขึ้น: `core-update` เปลี่ยนเฉพาะ app core และไม่แพ็ก engine, weight, JCEF, readboard, Java runtime หรือ user data ซ้ำ',
+        '中文': 'Windows 免安装版新增更清晰的小更新路径：`core-update` 只替换主程序和启动器配置，不重复打包引擎、权重、JCEF、readboard、Java runtime 或用户数据。',
+        '繁體中文': 'Windows 免安裝版新增更清楚的小更新路徑：`core-update` 只替換主程式和啟動器設定，不重複打包引擎、權重、JCEF、readboard、Java runtime 或使用者資料。',
+        'English': 'Windows portable builds now have a clearer small-update path: `core-update` replaces only the app core and launcher configuration, without rebundling engines, weights, JCEF, readboard, Java runtime, or user data.',
+        '日本語': 'Windows portable 版に分かりやすい小型更新パスを追加しました。`core-update` はアプリ本体とランチャー設定だけを置き換え、エンジン、重み、JCEF、readboard、Java runtime、ユーザーデータを再同梱しません。',
+        '한국어': 'Windows portable 빌드에 더 명확한 소형 업데이트 경로를 추가했습니다. `core-update` 는 앱 핵심과 launcher configuration 만 교체하고 엔진, 가중치, JCEF, readboard, Java runtime, 사용자 데이터를 다시 묶지 않습니다.',
+        'ภาษาไทย': 'Windows portable มีทางอัปเดตเล็กที่ชัดเจนขึ้น: `core-update` เปลี่ยนเฉพาะ app core และ launcher configuration และไม่แพ็ก engine, weight, JCEF, readboard, Java runtime หรือ user data ซ้ำ',
     }
     for section in sections:
         language = str(section['language'])
@@ -362,27 +362,27 @@ def add_windows_core_update_download_row(
 def remove_windows_core_update_auto_notes(sections: list[dict[str, object]]) -> None:
     notes_by_language = {
         '中文': (
-            'Windows 免安装版新增更清晰的小更新路径：`core-update` 只替换主程序，不重复打包引擎、权重、JCEF、readboard、Java runtime 或用户数据。',
+            'Windows 免安装版新增更清晰的小更新路径：`core-update` 只替换主程序和启动器配置，不重复打包引擎、权重、JCEF、readboard、Java runtime 或用户数据。',
             '已经有 Windows 免安装版的老用户，日常升级优先下载 `windows64.core-update.zip`，关闭软件后解压到旧目录覆盖；引擎、权重、TensorRT、设置和棋谱都会保留。',
         ),
         '繁體中文': (
-            'Windows 免安裝版新增更清楚的小更新路徑：`core-update` 只替換主程式，不重複打包引擎、權重、JCEF、readboard、Java runtime 或使用者資料。',
+            'Windows 免安裝版新增更清楚的小更新路徑：`core-update` 只替換主程式和啟動器設定，不重複打包引擎、權重、JCEF、readboard、Java runtime 或使用者資料。',
             '已經有 Windows 免安裝版的舊使用者，日常升級優先下載 `windows64.core-update.zip`，關閉軟體後解壓到舊目錄覆蓋；引擎、權重、TensorRT、設定和棋譜都會保留。',
         ),
         'English': (
-            'Windows portable builds now have a clearer small-update path: `core-update` replaces only the app core and does not rebundle engines, weights, JCEF, readboard, Java runtime, or user data.',
+            'Windows portable builds now have a clearer small-update path: `core-update` replaces only the app core and launcher configuration, without rebundling engines, weights, JCEF, readboard, Java runtime, or user data.',
             'Existing Windows portable users should prefer `windows64.core-update.zip` for routine updates: close the app, extract it over the old folder, and keep engines, weights, TensorRT, settings, and game records in place.',
         ),
         '日本語': (
-            'Windows portable 版に分かりやすい小型更新パスを追加しました。`core-update` はアプリ本体だけを置き換え、エンジン、重み、JCEF、readboard、Java runtime、ユーザーデータを再同梱しません。',
+            'Windows portable 版に分かりやすい小型更新パスを追加しました。`core-update` はアプリ本体とランチャー設定だけを置き換え、エンジン、重み、JCEF、readboard、Java runtime、ユーザーデータを再同梱しません。',
             '既存の Windows portable ユーザーは、通常更新では `windows64.core-update.zip` を優先してください。アプリを閉じて既存フォルダへ展開すれば、エンジン、重み、TensorRT、設定、棋譜は保持されます。',
         ),
         '한국어': (
-            'Windows portable 빌드에 더 명확한 소형 업데이트 경로를 추가했습니다. `core-update` 는 앱 핵심만 교체하고 엔진, 가중치, JCEF, readboard, Java runtime, 사용자 데이터를 다시 묶지 않습니다.',
+            'Windows portable 빌드에 더 명확한 소형 업데이트 경로를 추가했습니다. `core-update` 는 앱 핵심과 launcher configuration 만 교체하고 엔진, 가중치, JCEF, readboard, Java runtime, 사용자 데이터를 다시 묶지 않습니다.',
             '기존 Windows portable 사용자는 일반 업데이트에서 `windows64.core-update.zip` 을 우선 사용하세요. 앱을 닫고 기존 폴더에 덮어 풀면 엔진, 가중치, TensorRT, 설정, 기보가 유지됩니다.',
         ),
         'ภาษาไทย': (
-            'Windows portable มีทางอัปเดตเล็กที่ชัดเจนขึ้น: `core-update` เปลี่ยนเฉพาะ app core และไม่แพ็ก engine, weight, JCEF, readboard, Java runtime หรือ user data ซ้ำ',
+            'Windows portable มีทางอัปเดตเล็กที่ชัดเจนขึ้น: `core-update` เปลี่ยนเฉพาะ app core และ launcher configuration และไม่แพ็ก engine, weight, JCEF, readboard, Java runtime หรือ user data ซ้ำ',
             'ผู้ใช้ Windows portable เดิมควรใช้ `windows64.core-update.zip` สำหรับอัปเดตทั่วไป: ปิดแอปแล้วแตกไฟล์ทับโฟลเดอร์เดิม โดย engine, weight, TensorRT, settings และ game records จะยังอยู่',
         ),
     }
@@ -6750,32 +6750,32 @@ def build_next_2026_06_18_1_notes(
 ) -> str:
     notes = build_next_2026_06_16_1_notes(asset_map, bundle, repo, release_tag)
     additions = {
-        '- Windows 免安装版新增更清晰的小更新路径：`core-update` 只替换主程序，不重复打包引擎、权重、JCEF、readboard、Java runtime 或用户数据。\n':
+        '- Windows 免安装版新增更清晰的小更新路径：`core-update` 只替换主程序和启动器配置，不重复打包引擎、权重、JCEF、readboard、Java runtime 或用户数据。\n':
             '- 在已有变化图的下一手位置直接落子时，会进入原来的变化分支，不再重复新建一个相同分支。\n'
             '- 粘贴 SGF 时增加保护和兼容回归测试，避免误覆盖当前棋盘，也让加载后的引擎同步更稳。\n'
             '- 新增中式棋盘风格，棋盘外侧坐标会按中式显示；同时合入上游 SGF、着手列表和 UI 维护修复。\n'
             '- 棋力评估主卡改为显示用户能理解的棋力区间，评分规则改成短标签，避免 `1.0段` 这类内部值和省略号误导用户。\n',
-        '- Windows 免安裝版新增更清楚的小更新路徑：`core-update` 只替換主程式，不重複打包引擎、權重、JCEF、readboard、Java runtime 或使用者資料。\n':
+        '- Windows 免安裝版新增更清楚的小更新路徑：`core-update` 只替換主程式和啟動器設定，不重複打包引擎、權重、JCEF、readboard、Java runtime 或使用者資料。\n':
             '- 在已有變化圖的下一手位置直接落子時，會進入原來的變化分支，不再重複新建一個相同分支。\n'
             '- 貼上 SGF 時增加保護和相容回歸測試，避免誤覆蓋目前棋盤，也讓載入後的引擎同步更穩。\n'
             '- 新增中式棋盤風格，棋盤外側座標會按中式顯示；同時合入上游 SGF、著手列表和 UI 維護修復。\n'
             '- 棋力評估主卡改為顯示使用者能理解的棋力區間，評分規則改成短標籤，避免 `1.0段` 這類內部值和省略號誤導使用者。\n',
-        '- Windows portable builds now have a clearer small-update path: `core-update` replaces only the app core and does not rebundle engines, weights, JCEF, readboard, Java runtime, or user data.\n':
+        '- Windows portable builds now have a clearer small-update path: `core-update` replaces only the app core and launcher configuration, without rebundling engines, weights, JCEF, readboard, Java runtime, or user data.\n':
             '- Clicking a move that already exists as the next move of a variation now enters that existing branch instead of creating a duplicate branch.\n'
             '- SGF paste now has stronger protection and compatibility regression coverage, reducing accidental board replacement and improving engine sync after load.\n'
             '- Added Chinese classic board style with matching outer coordinates, and folded in upstream SGF, move-list, and UI maintenance fixes.\n'
             '- Player Strength cards now show user-facing strength bands, and the score-scale labels are shorter so internal values such as `1.0 dan` and clipped ellipses no longer confuse users.\n',
-        '- Windows portable 版に分かりやすい小型更新パスを追加しました。`core-update` はアプリ本体だけを置き換え、エンジン、重み、JCEF、readboard、Java runtime、ユーザーデータを再同梱しません。\n':
+        '- Windows portable 版に分かりやすい小型更新パスを追加しました。`core-update` はアプリ本体とランチャー設定だけを置き換え、エンジン、重み、JCEF、readboard、Java runtime、ユーザーデータを再同梱しません。\n':
             '- 既存の変化図にある次の一手を盤面でクリックした場合、同じ分岐を重複作成せず、その既存分岐へ入るようにしました。\n'
             '- SGF 貼り付けに保護と互換性回帰テストを追加し、現在の盤面を誤って置き換えるリスクを減らし、読み込み後のエンジン同期も安定させました。\n'
             '- 中国式の盤面スタイルを追加し、盤外座標も中国式表示に対応しました。あわせて上流の SGF、着手リスト、UI メンテナンス修正を取り込みました。\n'
             '- 棋力評価カードはユーザー向けの棋力区間を表示し、スコア尺度ラベルを短くしました。`1.0段` のような内部値や省略表示で迷わないようにしています。\n',
-        '- Windows portable 빌드에 더 명확한 small-update 경로를 추가했습니다. `core-update` 는 앱 core 만 교체하며 engine, weight, JCEF, readboard, Java runtime, user data 를 다시 포함하지 않습니다.\n':
+        '- Windows portable 빌드에 더 명확한 small-update 경로를 추가했습니다. `core-update` 는 앱 core 와 launcher configuration 만 교체하며 engine, weight, JCEF, readboard, Java runtime, user data 를 다시 포함하지 않습니다.\n':
             '- 이미 존재하는 변화도의 다음 수 위치를 직접 클릭하면 같은 분기를 새로 만들지 않고 기존 변화 분기로 들어갑니다.\n'
             '- SGF 붙여넣기에 보호 로직과 compatibility regression test 를 추가해 현재 보드가 실수로 교체될 위험을 줄이고, 로드 후 engine sync 도 더 안정적으로 만들었습니다.\n'
             '- Chinese classic board style 을 추가하고 바깥 좌표도 중국식으로 표시합니다. 또한 upstream SGF, move-list, UI maintenance fix 를 함께 반영했습니다.\n'
             '- Player Strength 카드는 사용자에게 이해되는 기력 구간을 표시하고 score-scale label 을 짧게 바꿔 `1.0 dan` 같은 내부 값이나 잘린 말줄임표로 혼동하지 않게 했습니다.\n',
-        '- เพิ่มเส้นทางอัปเดตขนาดเล็กที่ชัดเจนขึ้นสำหรับ Windows portable: `core-update` จะเปลี่ยนเฉพาะ app core และไม่ bundle engine, weight, JCEF, readboard, Java runtime หรือ user data ซ้ำ\n':
+        '- เพิ่มเส้นทางอัปเดตขนาดเล็กที่ชัดเจนขึ้นสำหรับ Windows portable: `core-update` จะเปลี่ยนเฉพาะ app core และ launcher configuration และไม่ bundle engine, weight, JCEF, readboard, Java runtime หรือ user data ซ้ำ\n':
             '- เมื่อคลิกจุดเดินที่มีอยู่แล้วเป็นตาถัดไปของ variation โปรแกรมจะเข้า branch เดิมแทนการสร้าง branch ซ้ำ\n'
             '- เพิ่มการป้องกันและ regression test สำหรับการ paste SGF เพื่อลดความเสี่ยงการแทนที่กระดานปัจจุบันโดยไม่ตั้งใจ และทำให้ engine sync หลังโหลดเสถียรขึ้น\n'
             '- เพิ่ม Chinese classic board style พร้อม coordinate รอบกระดานแบบจีน และรวม upstream fix ด้าน SGF, move list และ UI maintenance\n'

--- a/scripts/package_windows_exe.sh
+++ b/scripts/package_windows_exe.sh
@@ -1101,11 +1101,22 @@ create_core_update_asset() {
   local core_zip="$RELEASE_DIR/${DATE_TAG}-${ARCH_TAG}.core-update.zip"
   local native_core_dir
   local native_core_zip
+  local copied_cfg_count=0
 
   rm -rf "$core_dir" "$core_zip"
   mkdir -p "$core_dir/app"
   cp "$JAR_PATH" "$core_dir/lizzieyzy-next-core.jar"
   cp "$JAR_PATH" "$core_dir/app/$MAIN_JAR"
+  shopt -s nullglob
+  for launcher_cfg in "$DIST_DIR"/app-image-*/*/app/*.cfg; do
+    cp "$launcher_cfg" "$core_dir/app/$(basename "$launcher_cfg")"
+    copied_cfg_count=$((copied_cfg_count + 1))
+  done
+  shopt -u nullglob
+  if (( copied_cfg_count == 0 )); then
+    echo "Core update package did not find any Windows launcher .cfg files." >&2
+    return 1
+  fi
   cat >"$core_dir/README.txt" <<EOF
 LizzieYzy Next lightweight core update
 =====================================
@@ -1117,10 +1128,11 @@ Date: $DATE_TAG
 - 已经在使用 Windows 免安装版的老用户，日常升级优先下载这个小更新包。
 - 关闭 LizzieYzy Next 后，把这个 zip 解压到旧的免安装目录里覆盖。
 - 目标目录应该是包含 "LizzieYzy Next*.exe" 和 "app" 文件夹的目录。
-- 解压时允许覆盖 app/$MAIN_JAR。
+- 解压时允许覆盖 app/$MAIN_JAR 和 app/LizzieYzy Next*.cfg。
 - 根目录里的 lizzieyzy-next-core.jar 是软件内自动更新器使用的副本，手动覆盖时可以忽略。
 
-这个包只更新 LizzieYzy Next 主程序核心。
+这个包只更新 LizzieYzy Next 主程序核心和启动器配置。
+启动器配置用于同步标题栏版本号和必要 JVM 参数；不会改变你的引擎、权重或用户数据。
 KataGo 引擎、权重、JCEF、readboard、Java runtime、设置、棋谱、TensorRT 和 user-data 都会保留。
 只有未来更新 manifest 明确列出资源组件时，才需要下载对应的大资源更新。
 
@@ -1128,10 +1140,11 @@ Manual update:
 - Existing Windows portable users can use this small package for regular updates.
 - Close LizzieYzy Next, then extract this zip into the existing portable app folder.
 - The target folder should contain "LizzieYzy Next*.exe" and an "app" folder.
-- Allow overwriting app/$MAIN_JAR.
+- Allow overwriting app/$MAIN_JAR and app/LizzieYzy Next*.cfg.
 - The root lizzieyzy-next-core.jar is for the in-app updater and can be ignored during manual extraction.
 
-This package updates the application core only.
+This package updates the application core and launcher configuration only.
+The launcher configuration keeps the title-bar version and required JVM options in sync.
 KataGo engines, weights, JCEF, readboard, Java runtime, settings, saves, TensorRT, and user-data are preserved unless a future update manifest explicitly lists a changed resource component.
 EOF
 
@@ -1141,18 +1154,49 @@ EOF
     "$APP_DISPLAY_VERSION" \
     "$DATE_TAG" \
     "$MAIN_JAR" \
-    "$JAR_PATH" <<'PY'
+    "$JAR_PATH" \
+    "$core_dir" <<'PY'
 import hashlib
 import json
 import pathlib
 import sys
 
-output, release_tag, date_tag, main_jar, jar_path = sys.argv[1:]
+output, release_tag, date_tag, main_jar, jar_path, core_dir = sys.argv[1:]
 jar = pathlib.Path(jar_path)
-digest = hashlib.sha256()
-with jar.open("rb") as handle:
-    for chunk in iter(lambda: handle.read(1024 * 1024), b""):
-        digest.update(chunk)
+core_root = pathlib.Path(core_dir)
+
+def sha256(path):
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+jar_sha256 = sha256(jar)
+files = [
+    {
+        "path": "lizzieyzy-next-core.jar",
+        "purpose": "in-app-updater-source",
+        "sizeBytes": jar.stat().st_size,
+        "sha256": jar_sha256,
+    },
+    {
+        "path": f"app/{main_jar}",
+        "purpose": "manual-overlay-target",
+        "sizeBytes": jar.stat().st_size,
+        "sha256": jar_sha256,
+    },
+]
+
+for launcher_cfg in sorted((core_root / "app").glob("*.cfg")):
+    files.append(
+        {
+            "path": f"app/{launcher_cfg.name}",
+            "purpose": "launcher-config",
+            "sizeBytes": launcher_cfg.stat().st_size,
+            "sha256": sha256(launcher_cfg),
+        }
+    )
 
 payload = {
     "schemaVersion": 1,
@@ -1168,20 +1212,7 @@ payload = {
         "app/readboard/",
         "runtime/",
     ],
-    "files": [
-        {
-            "path": "lizzieyzy-next-core.jar",
-            "purpose": "in-app-updater-source",
-            "sizeBytes": jar.stat().st_size,
-            "sha256": digest.hexdigest(),
-        },
-        {
-            "path": f"app/{main_jar}",
-            "purpose": "manual-overlay-target",
-            "sizeBytes": jar.stat().st_size,
-            "sha256": digest.hexdigest(),
-        },
-    ],
+    "files": files,
 }
 pathlib.Path(output).write_text(
     json.dumps(payload, ensure_ascii=False, indent=2) + "\n",

--- a/scripts/validate_release_assets.sh
+++ b/scripts/validate_release_assets.sh
@@ -169,6 +169,7 @@ with zipfile.ZipFile(core_path) as archive:
     }
 assert "lizzieyzy-next-core.jar" in entries
 assert "app/lizzie-yzy2.5.3-shaded.jar" in entries
+assert any(entry.startswith("app/LizzieYzy Next") and entry.endswith(".cfg") for entry in entries), "core update must include launcher cfg files so title-bar version and JVM options are refreshed"
 assert "README.txt" in entries
 assert "lizzieyzy-next-core-update-manifest.json" in entries
 for entry in entries:

--- a/src/main/java/featurecat/lizzie/update/WindowsUpdateApplier.java
+++ b/src/main/java/featurecat/lizzie/update/WindowsUpdateApplier.java
@@ -12,7 +12,9 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
+import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import org.json.JSONArray;
@@ -93,7 +95,30 @@ public final class WindowsUpdateApplier {
       throw new IOException("Core update jar not found: " + newJar);
     }
     replaceFile(newJar, currentJar, backupRoot, appDir, backups);
+    replaceBundledLauncherConfigsIfPresent(extracted, appDir, backupRoot, backups);
+  }
 
+  private static void replaceBundledLauncherConfigsIfPresent(
+      Path extracted, Path appDir, Path backupRoot, List<BackupEntry> backups) throws IOException {
+    Path extractedAppDir = extracted.resolve("app").normalize();
+    if (!Files.isDirectory(extractedAppDir)) {
+      return;
+    }
+    try (Stream<Path> stream = Files.list(extractedAppDir)) {
+      List<Path> configs =
+          stream
+              .filter(Files::isRegularFile)
+              .filter(
+                  path ->
+                      path.getFileName()
+                          .toString()
+                          .toLowerCase(Locale.ROOT)
+                          .endsWith(".cfg"))
+              .toList();
+      for (Path config : configs) {
+        replaceFile(config, appDir.resolve(config.getFileName()), backupRoot, appDir, backups);
+      }
+    }
   }
 
   private static void writeInstalledManifestIfPresent(

--- a/src/test/java/featurecat/lizzie/update/WindowsUpdateApplierTest.java
+++ b/src/test/java/featurecat/lizzie/update/WindowsUpdateApplierTest.java
@@ -25,7 +25,8 @@ class WindowsUpdateApplierTest {
     writeZip(
         coreZip,
         entry("lizzieyzy-next-core.jar", "new-core"),
-        entry("app/lizzie-yzy2.5.3-shaded.jar", "manual-overlay-core"));
+        entry("app/lizzie-yzy2.5.3-shaded.jar", "manual-overlay-core"),
+        entry("app/LizzieYzy Next OpenCL.cfg", "-Dlizzie.next.version=next-2026-06-21.1"));
     Path request =
         request(
             fixture,
@@ -35,6 +36,9 @@ class WindowsUpdateApplierTest {
     WindowsUpdateApplier.apply(request);
 
     assertEquals("new-core", Files.readString(fixture.currentJar));
+    assertEquals(
+        "-Dlizzie.next.version=next-2026-06-21.1",
+        Files.readString(fixture.appDir.resolve("LizzieYzy Next OpenCL.cfg")));
     assertEquals("user-save", Files.readString(fixture.appRoot.resolve("user-data").resolve("save.txt")));
     assertTrue(Files.isRegularFile(fixture.appDir.resolve(InstalledUpdateState.INSTALLED_MANIFEST_NAME)));
   }
@@ -94,6 +98,7 @@ class WindowsUpdateApplierTest {
     Path userData = Files.createDirectories(appRoot.resolve("user-data"));
     Path currentJar = appDir.resolve("lizzie-yzy2.5.3-shaded.jar");
     Files.writeString(currentJar, "old-core");
+    Files.writeString(appDir.resolve("LizzieYzy Next OpenCL.cfg"), "-Dlizzie.next.version=old");
     Files.writeString(userData.resolve("save.txt"), "user-save");
     Path staging = Files.createDirectories(tempDir.resolve("staging"));
     return new Fixture(appRoot, appDir, currentJar, staging);


### PR DESCRIPTION
## Summary

- Fixes Windows `windows64.core-update.zip` so routine portable updates also refresh bundled launcher `.cfg` files.
- Updates the in-app Windows updater to apply `app/*.cfg` files during `replace-core`, keeping the title-bar version and JVM options in sync after small updates.
- Updates package docs, release-note templates, and release asset validation so future Windows core-update assets cannot silently omit launcher config files again.

## Root Cause

The Swing title uses `Lizzie.getAppDisplayName()`, which reads `Lizzie.nextVersion` from `-Dlizzie.next.version`. Windows `jpackage` stores that JVM option in `app/LizzieYzy Next*.cfg`. The previous core-update package replaced only the shaded jar, so users who applied a small update could still launch with the old `.cfg` and see the old version in the title bar.

## Validation

- `git diff --check`
- `bash -n scripts/package_windows_exe.sh scripts/validate_release_assets.sh`
- `python3 -m py_compile scripts/generate_release_notes.py`
- `mvn -B -Dfmt.skip=true -Dtest=WindowsUpdateApplierTest,WindowsUpdatePlanTest,UpdateManifestTest test`
- `mvn -B -Dfmt.skip=true test`：888 tests, 0 failures
- `mvn -B -Dfmt.skip=true -DskipTests package`

## Notes

This does not add large assets to the small update package. It only adds launcher config files alongside the existing app core jar, while preserving engines, weights, runtime, JCEF, readboard, TensorRT, and user data.
