### PR TITLE
Fix Fox handicap komi normalization

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/GetFoxRequest.java
+++ b/src/main/java/featurecat/lizzie/analysis/GetFoxRequest.java
@@ -460,6 +460,19 @@ public class GetFoxRequest {
       rootProperties.add(
           new SgfProperty("HA", Arrays.asList(String.valueOf(handicapStones.size()))));
       rootProperties.add(new SgfProperty("AB", coordinates));
+      setSingleValueRootProperty(rootProperties, "KM", "0");
+    }
+
+    private void setSingleValueRootProperty(
+        List<SgfProperty> rootProperties, String name, String value) {
+      for (int i = 0; i < rootProperties.size(); i++) {
+        SgfProperty property = rootProperties.get(i);
+        if (name.equals(property.name)) {
+          rootProperties.set(i, new SgfProperty(name, Arrays.asList(value)));
+          return;
+        }
+      }
+      rootProperties.add(new SgfProperty(name, Arrays.asList(value)));
     }
 
     private String buildSgf(List<SgfProperty> rootProperties, List<SgfMove> moves) {

--- a/src/test/java/featurecat/lizzie/analysis/GetFoxRequestTest.java
+++ b/src/test/java/featurecat/lizzie/analysis/GetFoxRequestTest.java
@@ -49,6 +49,8 @@ class GetFoxRequestTest {
     String normalizedPayload = (String) normalizeMethod.invoke(request, payload);
     String normalizedSgf = new JSONObject(normalizedPayload).getString("chess");
 
+    assertTrue(normalizedSgf.contains("KM[0]"), normalizedSgf);
+    assertFalse(normalizedSgf.contains("KM[375]"), normalizedSgf);
     assertTrue(normalizedSgf.contains("HA[4]"), normalizedSgf);
     assertTrue(normalizedSgf.contains("AB[pd][pq][dd][dp]"), normalizedSgf);
     assertFalse(normalizedSgf.contains("HA[0]"), normalizedSgf);


### PR DESCRIPTION
## Summary
- force KM[0] when Fox leading black moves are normalized into handicap stones
- keep HA/AB promotion while preventing original Fox KM values such as KM[375] from being persisted
- add regression coverage for Fox handicap normalization

## Verification
- mvn -Dtest=GetFoxRequestTest test
- Windows: mvn -DskipTests package