### PR TITLE
Preserve board state on engine switch and polish setup layout

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/EngineManager.java
+++ b/src/main/java/featurecat/lizzie/analysis/EngineManager.java
@@ -2017,7 +2017,7 @@ public class EngineManager {
       }
     } else {
       newEng.canRestoreDymPda = false;
-      newEng.boardSize(newEng.width, newEng.height);
+      newEng.boardSizeForEngine(newEng.width, newEng.height);
       newEng.sendCommand("komi " + newEng.komi);
       // newEng.sendCommand("name");
       //  newEng.isCheckingName = true;
@@ -2217,12 +2217,12 @@ public class EngineManager {
         if (!(isEmptyBoard && changeBoard) || !isMain) {
           newEng.width = Board.boardWidth;
           newEng.height = Board.boardHeight;
-          newEng.boardSize(newEng.width, newEng.height);
+          newEng.boardSizeForEngine(newEng.width, newEng.height);
         }
         if (isEmptyBoard && changeOriBoard && isMain) {
           newEng.width = newEng.oriWidth;
           newEng.height = newEng.oriHeight;
-          newEng.boardSize(newEng.width, newEng.height);
+          newEng.boardSizeForEngine(newEng.width, newEng.height);
         }
         newEng.sendCommand("komi " + newEng.komi);
         newEng.isCheckingName = true;

--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -566,7 +566,7 @@ public class Leelaz {
               sendCommand("list_commands");
               if (!(Lizzie.frame.isPlayingAgainstLeelaz || Lizzie.frame.isAnaPlayingAgainstLeelaz))
                 sendCommand("komi " + komi);
-              boardSize(width, height);
+              boardSizeForEngine(width, height);
               if (initialCommand != null && !initialCommand.equals("")) {
                 String[] initialCommands = initialCommand.trim().split(";");
                 for (String command : initialCommands) {
@@ -594,7 +594,7 @@ public class Leelaz {
               sendCommand("name");
               sendCommand("version");
               sendCommand("list_commands");
-              boardSize(width, height);
+              boardSizeForEngine(width, height);
               if (!(Lizzie.frame.isPlayingAgainstLeelaz || Lizzie.frame.isAnaPlayingAgainstLeelaz))
                 sendCommand("komi " + komi);
               if (initialCommand != null && !initialCommand.equals("")) {
@@ -2267,11 +2267,19 @@ public class Leelaz {
   }
 
   public void boardSize(int width, int height) {
+    boardSize(width, height, true);
+  }
+
+  public void boardSizeForEngine(int width, int height) {
+    boardSize(width, height, false);
+  }
+
+  private void boardSize(int width, int height, boolean reopenMainBoard) {
     if (width != height) sendCommand("rectangular_boardsize " + width + " " + height);
     else sendCommand("boardsize " + width);
     this.width = width;
     this.height = height;
-    Lizzie.board.reopen(width, height);
+    if (reopenMainBoard) Lizzie.board.reopen(width, height);
     if (firstLoad) {
       Lizzie.board.getHistory().getGameInfo().setKomi(komi);
       Lizzie.board.getHistory().getGameInfo();

--- a/src/main/java/featurecat/lizzie/gui/KataGoAutoSetupDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/KataGoAutoSetupDialog.java
@@ -190,7 +190,7 @@ public class KataGoAutoSetupDialog extends JDialog {
 
     JPanel body = new JPanel(new BorderLayout(14, 0));
     body.setOpaque(false);
-    body.setBorder(BorderFactory.createEmptyBorder(12, 16, 12, 16));
+    body.setBorder(BorderFactory.createEmptyBorder(10, 14, 10, 14));
     body.add(createSidebarPanel(), BorderLayout.WEST);
 
     detailCards.setOpaque(false);
@@ -200,6 +200,9 @@ public class KataGoAutoSetupDialog extends JDialog {
     detailCards.add(createAccelerationSection(), CARD_ACCELERATION);
     JScrollPane detailScrollPane = new JScrollPane(detailCards);
     detailScrollPane.setBorder(null);
+    detailScrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
+    detailScrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
+    detailScrollPane.getVerticalScrollBar().setUnitIncrement(14);
     detailScrollPane.getViewport().setOpaque(false);
     detailScrollPane.setOpaque(false);
     body.add(detailScrollPane, BorderLayout.CENTER);
@@ -280,16 +283,16 @@ public class KataGoAutoSetupDialog extends JDialog {
     }
     button.setFocusPainted(false);
     button.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
-    button.setMargin(new Insets(0, 12, 0, 12));
+    button.setMargin(new Insets(0, 10, 0, 10));
     AppleStyleSupport.installButtonStyle(button);
     Dimension preferred = button.getPreferredSize();
-    button.setPreferredSize(new Dimension(Math.max(preferred.width, primary ? 112 : 96), 36));
+    button.setPreferredSize(new Dimension(Math.max(preferred.width, primary ? 106 : 90), 32));
   }
 
   private JPanel createHeaderPanel() {
-    JPanel header = new JPanel(new BorderLayout(12, 4));
+    JPanel header = new JPanel(new BorderLayout(12, 3));
     header.setBackground(SIDEBAR_BG);
-    header.setBorder(BorderFactory.createEmptyBorder(14, 18, 14, 18));
+    header.setBorder(BorderFactory.createEmptyBorder(10, 16, 10, 16));
 
     JFontLabel title = new JFontLabel(text("AutoSetup.title"));
     title.setForeground(Color.WHITE);
@@ -316,7 +319,7 @@ public class KataGoAutoSetupDialog extends JDialog {
     modeBadge.setBorder(
         BorderFactory.createCompoundBorder(
             BorderFactory.createLineBorder(new Color(103, 130, 121)),
-            BorderFactory.createEmptyBorder(6, 12, 6, 12)));
+            BorderFactory.createEmptyBorder(5, 10, 5, 10)));
     header.add(modeBadge, BorderLayout.EAST);
     return header;
   }
@@ -325,7 +328,7 @@ public class KataGoAutoSetupDialog extends JDialog {
     JPanel sidebar = new JPanel(new BorderLayout(0, 12));
     sidebar.setPreferredSize(new Dimension(180, 10));
     sidebar.setBackground(SIDEBAR_BG);
-    sidebar.setBorder(BorderFactory.createEmptyBorder(14, 12, 14, 12));
+    sidebar.setBorder(BorderFactory.createEmptyBorder(12, 12, 12, 12));
 
     JFontLabel sidebarTitle = new JFontLabel(text("AutoSetup.sidebarTitle"));
     sidebarTitle.setForeground(SIDEBAR_TEXT);
@@ -341,7 +344,7 @@ public class KataGoAutoSetupDialog extends JDialog {
         });
     sectionNav.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
     sectionNav.setSelectedIndex(0);
-    sectionNav.setFixedCellHeight(40);
+    sectionNav.setFixedCellHeight(36);
     sectionNav.setBackground(SIDEBAR_BG);
     sectionNav.setForeground(SIDEBAR_TEXT);
     sectionNav.setBorder(null);
@@ -355,7 +358,7 @@ public class KataGoAutoSetupDialog extends JDialog {
                     super.getListCellRendererComponent(
                         list, value, index, isSelected, cellHasFocus);
             label.setOpaque(true);
-            label.setBorder(BorderFactory.createEmptyBorder(8, 10, 8, 10));
+            label.setBorder(BorderFactory.createEmptyBorder(7, 10, 7, 10));
             label.setForeground(SIDEBAR_TEXT);
             label.setBackground(isSelected ? SIDEBAR_SELECTED_BG : SIDEBAR_BG);
             label.setFont(label.getFont().deriveFont(isSelected ? Font.BOLD : Font.PLAIN));
@@ -509,13 +512,13 @@ public class KataGoAutoSetupDialog extends JDialog {
 
   private JPanel createSectionCard(
       String title, String subtitle, JComponent content, JComponent actions) {
-    JPanel card = new JPanel(new BorderLayout(0, 14));
+    JPanel card = new JPanel(new BorderLayout(0, 10));
     card.setOpaque(true);
     card.setBackground(CARD_BG);
     card.setBorder(
         BorderFactory.createCompoundBorder(
             BorderFactory.createLineBorder(new Color(224, 217, 203)),
-            BorderFactory.createEmptyBorder(16, 16, 16, 16)));
+            BorderFactory.createEmptyBorder(12, 14, 12, 14)));
 
     JPanel heading = new JPanel(new BorderLayout(0, 4));
     heading.setOpaque(false);
@@ -529,13 +532,16 @@ public class KataGoAutoSetupDialog extends JDialog {
     heading.add(subtitleLabel, BorderLayout.CENTER);
     card.add(heading, BorderLayout.NORTH);
 
+    JPanel contentStack = new JPanel(new BorderLayout(0, 10));
+    contentStack.setOpaque(false);
+    contentStack.add(content, BorderLayout.NORTH);
+    if (actions != null) {
+      contentStack.add(actions, BorderLayout.CENTER);
+    }
     JPanel contentWrap = new JPanel(new BorderLayout());
     contentWrap.setOpaque(false);
-    contentWrap.add(content, BorderLayout.NORTH);
+    contentWrap.add(contentStack, BorderLayout.NORTH);
     card.add(contentWrap, BorderLayout.CENTER);
-    if (actions != null) {
-      card.add(actions, BorderLayout.SOUTH);
-    }
     return card;
   }
 
@@ -550,12 +556,12 @@ public class KataGoAutoSetupDialog extends JDialog {
     gbc.gridx = 0;
     gbc.gridy = 0;
     gbc.anchor = GridBagConstraints.NORTHWEST;
-    gbc.insets = new Insets(0, 0, 10, 10);
+    gbc.insets = new Insets(0, 0, 7, 10);
     return gbc;
   }
 
   private JPanel createActionBar(int alignment, JComponent... actions) {
-    JPanel actionBar = new JPanel(new FlowLayout(alignment, 8, 0));
+    JPanel actionBar = new JPanel(new FlowLayout(alignment, 6, 0));
     actionBar.setOpaque(false);
     for (JComponent action : actions) {
       actionBar.add(action);
@@ -564,7 +570,7 @@ public class KataGoAutoSetupDialog extends JDialog {
   }
 
   private JPanel createInlineActionRow(JComponent mainComponent, JComponent... actions) {
-    JPanel row = new JPanel(new BorderLayout(8, 0));
+    JPanel row = new JPanel(new BorderLayout(6, 0));
     row.setOpaque(false);
     row.add(mainComponent, BorderLayout.CENTER);
     row.add(createActionBar(FlowLayout.RIGHT, actions), BorderLayout.EAST);
@@ -611,7 +617,7 @@ public class KataGoAutoSetupDialog extends JDialog {
 
   private void constrainValueComponent(JComponent valueComponent) {
     Dimension preferred = valueComponent.getPreferredSize();
-    int height = Math.max(preferred.height, 32);
+    int height = Math.max(preferred.height, 30);
     if (Boolean.TRUE.equals(valueComponent.getClientProperty(WRAPPING_TEXT_KEY))
         && valueComponent instanceof JTextArea) {
       height =

--- a/src/main/java/featurecat/lizzie/rules/Board.java
+++ b/src/main/java/featurecat/lizzie/rules/Board.java
@@ -716,7 +716,7 @@ public class Board {
       boardHeight = height;
       Zobrist.init();
       clear(false);
-      Lizzie.leelaz.boardSize(boardWidth, boardHeight);
+      Lizzie.leelaz.boardSizeForEngine(boardWidth, boardHeight);
       Lizzie.leelaz.ponder();
       forceRefresh = true;
       forceRefresh2 = true;
@@ -1189,7 +1189,7 @@ public class Board {
       return false;
     }
     if (Lizzie.leelaz.width != boardWidth || Lizzie.leelaz.height != boardHeight) {
-      Lizzie.leelaz.boardSize(boardWidth, boardHeight);
+      Lizzie.leelaz.boardSizeForEngine(boardWidth, boardHeight);
     }
     resendMoveToEngine(Lizzie.leelaz, false);
     return true;
@@ -1253,7 +1253,7 @@ public class Board {
       return false;
     }
     if (Lizzie.leelaz.width != boardWidth || Lizzie.leelaz.height != boardHeight) {
-      Lizzie.leelaz.boardSize(boardWidth, boardHeight);
+      Lizzie.leelaz.boardSizeForEngine(boardWidth, boardHeight);
     }
     if (data.isMoveNode() && data.lastMove.isPresent()) {
       int[] lastMove = data.lastMove.get();

--- a/src/test/java/featurecat/lizzie/rules/BoardPrimaryEngineSyncTest.java
+++ b/src/test/java/featurecat/lizzie/rules/BoardPrimaryEngineSyncTest.java
@@ -175,9 +175,44 @@ class BoardPrimaryEngineSyncTest {
     }
   }
 
+  @Test
+  void engineBoardSizeSyncDoesNotReopenDisplayedNon19Board() throws Exception {
+    try (TestHarness harness = TestHarness.open()) {
+      Board.boardWidth = 13;
+      Board.boardHeight = 13;
+      Zobrist.init();
+      Board board = allocate(Board.class);
+      board.startStonelist = new ArrayList<>();
+      board.hasStartStone = false;
+      BoardHistoryList history = new BoardHistoryList(BoardData.empty(13, 13));
+      history.add(moveNode(5, 5, Stone.BLACK, false, 1, 13, 13));
+      board.setHistory(history);
+      Lizzie.board = board;
+
+      Leelaz engine = new Leelaz("");
+      RecordingOutputStream output = new RecordingOutputStream();
+      setOutputStream(engine, output);
+      Lizzie.leelaz = engine;
+
+      engine.boardSizeForEngine(19, 19);
+
+      assertEquals(13, Board.boardWidth);
+      assertEquals(13, Board.boardHeight);
+      assertEquals(1, Lizzie.board.getHistory().getData().moveNumber);
+      assertEquals(
+          Stone.BLACK, Lizzie.board.getHistory().getData().stones[Board.getIndex(5, 5)]);
+      assertEquals(List.of("boardsize 19"), output.commands());
+    }
+  }
+
   private static BoardData moveNode(
       int x, int y, Stone color, boolean blackToPlay, int moveNumber) {
-    Stone[] stones = emptyStones();
+    return moveNode(x, y, color, blackToPlay, moveNumber, BOARD_SIZE, BOARD_SIZE);
+  }
+
+  private static BoardData moveNode(
+      int x, int y, Stone color, boolean blackToPlay, int moveNumber, int width, int height) {
+    Stone[] stones = emptyStones(width, height);
     stones[Board.getIndex(x, y)] = color;
     int[] lastMove = new int[] {x, y};
     return BoardData.move(
@@ -187,7 +222,7 @@ class BoardPrimaryEngineSyncTest {
         blackToPlay,
         new Zobrist(),
         moveNumber,
-        moveList(x, y, moveNumber),
+        moveList(x, y, moveNumber, width, height),
         0,
         0,
         50,
@@ -195,14 +230,22 @@ class BoardPrimaryEngineSyncTest {
   }
 
   private static int[] moveList(int x, int y, int moveNumber) {
-    int[] moveNumberList = new int[BOARD_AREA];
+    return moveList(x, y, moveNumber, BOARD_SIZE, BOARD_SIZE);
+  }
+
+  private static int[] moveList(int x, int y, int moveNumber, int width, int height) {
+    int[] moveNumberList = new int[width * height];
     moveNumberList[Board.getIndex(x, y)] = moveNumber;
     return moveNumberList;
   }
 
   private static Stone[] emptyStones() {
-    Stone[] stones = new Stone[BOARD_AREA];
-    for (int index = 0; index < BOARD_AREA; index++) {
+    return emptyStones(BOARD_SIZE, BOARD_SIZE);
+  }
+
+  private static Stone[] emptyStones(int width, int height) {
+    Stone[] stones = new Stone[width * height];
+    for (int index = 0; index < stones.length; index++) {
       stones[index] = Stone.EMPTY;
     }
     return stones;


### PR DESCRIPTION
## Summary

- Fixes engine/model switching so it no longer reopens the displayed board when the board size is not 19x19.
- Splits engine-only `boardsize` synchronization from user-visible board reopen logic.
- Preserves non-19 board size and existing stones while the newly selected engine is being synchronized.
- Adds a regression test for a 13x13 game with stones where an engine receives a 19x19 `boardsize` sync.

## Root Cause

`Leelaz.boardSize(...)` both sent `boardsize` to the engine and called `Lizzie.board.reopen(...)`. Engine startup and `EngineManager.switchEngine(...)` reused that method while synchronizing the selected engine, so a newly selected/default-19 engine could reopen the main board as 19x19 and clear the current game.

## Validation

- `git diff --check`
- `mvn -B -Dfmt.skip=true -Dtest=BoardPrimaryEngineSyncTest test`
- `mvn -B -Dfmt.skip=true -Dtest=BoardPrimaryEngineSyncTest,MoreEnginesStartupModeTest,LizzieFrameRegressionTest test`
- `mvn -B -Dfmt.skip=true test` (`890` tests passed)
- `mvn -B -Dfmt.skip=true -DskipTests package`
- Local shaded jar startup smoke test
- Local KataGo Auto Setup UI smoke test for Overview, Weights, Speed Optimization, and NVIDIA acceleration tabs

